### PR TITLE
fix(vault): spend the capsules the user selected

### DIFF
--- a/src/helpers/capsuleSelection.ts
+++ b/src/helpers/capsuleSelection.ts
@@ -1,0 +1,55 @@
+/**
+ * Capsule (UTXO) selection for vault sends.
+ *
+ * Selecting capsules is mandatory in Cypher Box: you cannot send from a vault
+ * without choosing coins first. Every entry point into ColdStorage passes both
+ * the UTXO set and the selected ids, and Capsules gates each of its four send
+ * paths on a non-empty selection.
+ *
+ * This lives in its own module rather than inline in the screen so the rule can
+ * be tested directly. The screen used to hand the UNFILTERED set to
+ * createTransaction, so coinselect (which sorts descending and takes the
+ * largest) spent whatever coin it liked regardless of what the user ticked, and
+ * the change figure on the confirm screen, derived from the selection, could be
+ * wrong by orders of magnitude. That matters most when change is routed to a
+ * Strike or CoinOS deposit address.
+ */
+
+/** Minimum shape this module needs. Real UTXOs carry more fields. */
+export type SelectableUtxo = {
+    txid: string;
+    vout: number;
+    value: number;
+};
+
+/** Canonical outpoint key. Both halves matter: one txid can fund several vouts. */
+export function outpointKey(u: Pick<SelectableUtxo, 'txid' | 'vout'>): string {
+    return `${u.txid}:${u.vout}`;
+}
+
+/**
+ * The capsules the user picked, and the ONLY coins a vault send may spend.
+ *
+ * Order follows `utxo`, not `ids`, so the caller's coin ordering is preserved
+ * for coinselect. Ids with no matching UTXO are ignored rather than throwing:
+ * a stale selection (coin spent elsewhere since the picker rendered) should
+ * narrow the spend, never fabricate an input.
+ *
+ * There is deliberately NO whole-wallet fallback. If the selection is empty
+ * that is a caller bug, and quietly spending the rest of the vault is the worst
+ * available response, so this returns an empty array and callers must refuse to
+ * build a transaction.
+ */
+export function selectCapsules<T extends SelectableUtxo>(
+    utxo: readonly T[] | null | undefined,
+    ids: readonly string[] | null | undefined,
+): T[] {
+    if (!utxo || !ids || ids.length === 0) return [];
+    const wanted = new Set(ids);
+    return utxo.filter((u) => wanted.has(outpointKey(u)));
+}
+
+/** Total value of a selection, in sats. */
+export function selectedTotalSats(utxo: readonly SelectableUtxo[]): number {
+    return utxo.reduce((sum, u) => sum + u.value, 0);
+}

--- a/src/screens/ColdStorage/index.tsx
+++ b/src/screens/ColdStorage/index.tsx
@@ -97,6 +97,23 @@ export default function ColdStorage({ route, navigation }: Props) {
     const [satsEditable, setSatsEditable] = useState(false);
     const fUtxo = utxo.filter(({ txid, vout }) => ids.includes(`${txid}:${vout}`));
     const balance = fUtxo ? fUtxo.reduce((prev, curr) => prev + curr.value, 0) : wallet?.getBalance();
+    // The capsules the user picked, and the ONLY coins this screen may spend.
+    //
+    // Selecting capsules is mandatory in Cypher Box: you cannot send from a
+    // vault without choosing coins first. Every entry point into this screen
+    // passes both `utxo` and `ids`, and Capsules gates each of its four send
+    // paths on `ids.length > 0`. So `fUtxo` is always the full picture of what
+    // the user chose.
+    //
+    // Previously the unfiltered `utxo` was handed to createTransaction, so
+    // coinselect (which sorts descending and takes the largest) spent whatever
+    // coin it liked, and the change figure on the confirm screen, derived from
+    // the selection, could be wrong by orders of magnitude.
+    //
+    // There is deliberately NO whole-wallet fallback here. If the selection is
+    // ever empty that is a bug in the caller, and quietly spending the rest of
+    // the vault is the worst available response to it.
+    const selectedUtxo = fUtxo;
     const allBalance = formatBalanceWithoutSuffix(balance, BitcoinUnit.BTC, true);
     const balanceWallet = !wallet?.hideBalance && formatBalance(Number(wallet?.getBalance()), wallet?.getPreferredBalanceUnit(), true);
     const balanceWithoutSuffix = !wallet?.hideBalance && formatBalanceWithoutSuffix(Number(wallet?.getBalance()), wallet?.getPreferredBalanceUnit(), true);
@@ -306,7 +323,10 @@ export default function ColdStorage({ route, navigation }: Props) {
       const fees = networkTransactionFees;
       const change = getChangeAddressFast();
       const requestedSatPerByte = Number(feeRate);
-      const lutxo = utxo || wallet.getUtxo();
+      // Estimate against the SAME inputs the send will really use, otherwise the
+      // quoted fee is for a different transaction than the one built below.
+      if (!selectedUtxo || selectedUtxo.length === 0) return; // nothing selected: nothing to quote
+      const lutxo = selectedUtxo;
       let frozen = 0;
       if (!utxo) {
         // if utxo is not limited search for frozen outputs and calc it's balance
@@ -546,7 +566,16 @@ export default function ColdStorage({ route, navigation }: Props) {
             ? changeDepositAddress
             : await getChangeAddressAsync();
         const requestedSatPerByte = Number(feeRate);
-        const lutxo = utxo || wallet.getUtxo();
+        // Spend the capsules the user selected, and only those. See the note on
+        // `selectedUtxo` above for why there is no whole-wallet fallback.
+        const lutxo = selectedUtxo;
+        if (!lutxo || lutxo.length === 0) {
+            Alert.alert(
+                'No capsules selected',
+                'Go back and choose which capsules to spend before sending.',
+            );
+            return;
+        }
         console.log({ requestedSatPerByte, lutxo: lutxo.length });
 
         const targets = [];

--- a/src/screens/ColdStorage/index.tsx
+++ b/src/screens/ColdStorage/index.tsx
@@ -9,6 +9,7 @@ import { ScreenLayout, Text } from "@Cypher/component-library";
 import { GradientView, SavingVault, VaultCapsules } from "@Cypher/components";
 import { colors } from "@Cypher/style-guide";
 import { dispatchNavigate } from "@Cypher/helpers";
+import { selectCapsules } from "@Cypher/helpers/capsuleSelection";
 import { isCoinosAllowed } from "@Cypher/services/featureFlags";
 import Clipboard from '@react-native-clipboard/clipboard'
 import loc, { formatBalance, formatBalanceWithoutSuffix } from "../../../loc";
@@ -95,7 +96,7 @@ export default function ColdStorage({ route, navigation }: Props) {
     const [feeUSD, setFeeUSD] = useState(1);
     const [feesEditable, setFeesEditable] = useState(false);
     const [satsEditable, setSatsEditable] = useState(false);
-    const fUtxo = utxo.filter(({ txid, vout }) => ids.includes(`${txid}:${vout}`));
+    const fUtxo = selectCapsules(utxo, ids);
     const balance = fUtxo ? fUtxo.reduce((prev, curr) => prev + curr.value, 0) : wallet?.getBalance();
     // The capsules the user picked, and the ONLY coins this screen may spend.
     //

--- a/tests/unit/capsuleSelection.test.ts
+++ b/tests/unit/capsuleSelection.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Vault sends must spend the capsules the user ticked.
+ *
+ * Before the fix, ColdStorage filtered the selection into `fUtxo` but only used
+ * it for the displayed balance: both the fee pre-calc and createTransaction
+ * received the UNFILTERED set. coinselect sorts descending and takes the
+ * largest, so every vault send ignored the selection and broke open whatever
+ * coin it liked, while the confirm screen showed change derived from the
+ * selection. Those two can differ by orders of magnitude, and the change is
+ * routed to a Strike or CoinOS deposit address.
+ *
+ * The second describe block is the part that actually demonstrates the money
+ * behaviour: it runs the real wallet and shows the same targets producing a
+ * DIFFERENT spent coin depending on whether the selection was applied.
+ */
+
+import { outpointKey, selectCapsules, selectedTotalSats } from '../../src/helpers/capsuleSelection';
+
+const SMALL = { txid: 'aa'.repeat(32), vout: 0, value: 20_000 };
+const LARGE = { txid: 'bb'.repeat(32), vout: 1, value: 500_000 };
+const MID = { txid: 'cc'.repeat(32), vout: 0, value: 80_000 };
+const ALL = [SMALL, LARGE, MID];
+
+describe('selectCapsules', () => {
+    it('returns exactly the ticked capsule, not the largest', () => {
+        const picked = selectCapsules(ALL, [outpointKey(SMALL)]);
+        expect(picked).toEqual([SMALL]);
+    });
+
+    it('keys on txid AND vout, so sibling outputs of one tx are distinguishable', () => {
+        // A single funding tx paying the vault twice is ordinary. Keying on
+        // txid alone would silently pull in the sibling output.
+        const v0 = { txid: 'dd'.repeat(32), vout: 0, value: 10_000 };
+        const v1 = { txid: 'dd'.repeat(32), vout: 1, value: 999_000 };
+        const picked = selectCapsules([v0, v1], [outpointKey(v0)]);
+        expect(picked).toEqual([v0]);
+    });
+
+    it('preserves the caller ordering of utxo, not the order ids were given in', () => {
+        const picked = selectCapsules(ALL, [outpointKey(MID), outpointKey(SMALL)]);
+        expect(picked).toEqual([SMALL, MID]);
+    });
+
+    it('returns empty for an empty selection, with no whole-wallet fallback', () => {
+        // The dangerous case. Falling back to the full set here is what made
+        // every send spend the wrong coin.
+        expect(selectCapsules(ALL, [])).toEqual([]);
+        expect(selectCapsules(ALL, null)).toEqual([]);
+        expect(selectCapsules(ALL, undefined)).toEqual([]);
+    });
+
+    it('returns empty when there are no utxos at all', () => {
+        expect(selectCapsules([], [outpointKey(SMALL)])).toEqual([]);
+        expect(selectCapsules(null, [outpointKey(SMALL)])).toEqual([]);
+    });
+
+    it('ignores ids with no matching utxo instead of fabricating inputs', () => {
+        // Stale selection: the coin was spent elsewhere since the picker
+        // rendered. Narrowing the spend is safe; inventing an input is not.
+        const picked = selectCapsules(ALL, [outpointKey(SMALL), 'ff'.repeat(32) + ':7']);
+        expect(picked).toEqual([SMALL]);
+    });
+
+    it('never returns a coin the user did not tick', () => {
+        const picked = selectCapsules(ALL, [outpointKey(SMALL), outpointKey(MID)]);
+        expect(picked).not.toContainEqual(LARGE);
+        expect(selectedTotalSats(picked)).toBe(100_000);
+    });
+
+    it('tolerates duplicate ids without duplicating the input', () => {
+        // A double-tap in the picker must not double-spend the same outpoint
+        // into the transaction.
+        const picked = selectCapsules(ALL, [outpointKey(SMALL), outpointKey(SMALL)]);
+        expect(picked).toEqual([SMALL]);
+    });
+});
+
+describe('the spend actually follows the selection', () => {
+    // Uses the real wallet so this asserts money behaviour, not just filtering.
+    const { HDSegwitBech32Wallet } = require('../../class');
+
+    function fundedWallet() {
+        const w = new HDSegwitBech32Wallet();
+        w.setSecret(
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        );
+        return w;
+    }
+
+    function utxosFor(w: any) {
+        const addr = w._getExternalAddressByIndex(0);
+        return [
+            { ...SMALL, address: addr, wif: w._getWifForAddress(addr), confirmations: 6, height: 1 },
+            { ...LARGE, address: addr, wif: w._getWifForAddress(addr), confirmations: 6, height: 1 },
+        ];
+    }
+
+    it('spends the LARGE coin when the selection is ignored, and the SMALL one when it is honoured', () => {
+        const w = fundedWallet();
+        const utxos = utxosFor(w);
+        const target = [{ address: 'bc1qtmcfj7lvgjp866w8lytdpap82u7eege58jy52hp4ctk0hsncegyqel8prp', value: 10_000 }];
+        const change = w._getInternalAddressByIndex(0);
+
+        // Unfiltered: this is the pre-fix behaviour. coinselect sorts
+        // descending and reaches for the biggest coin.
+        const unfiltered = w.createTransaction(utxos, target, 1, change);
+        const unfilteredInputs = unfiltered.psbt.txInputs.map((i: any) =>
+            Buffer.from(i.hash).reverse().toString('hex'),
+        );
+        expect(unfilteredInputs).toContain(LARGE.txid);
+
+        // Filtered to the user's pick: only the small coin can be spent.
+        const picked = selectCapsules(utxos, [outpointKey(SMALL)]);
+        const filtered = w.createTransaction(picked, target, 1, change);
+        const filteredInputs = filtered.psbt.txInputs.map((i: any) =>
+            Buffer.from(i.hash).reverse().toString('hex'),
+        );
+        expect(filteredInputs).toEqual([SMALL.txid]);
+        expect(filteredInputs).not.toContain(LARGE.txid);
+    });
+});


### PR DESCRIPTION
Selecting capsules is **mandatory** before sending from a vault: every entry point into `ColdStorage` passes both the UTXO set and the selection (`ids`), and `Capsules` gates each of its four send paths on `ids.length > 0`. The screen filtered them into `fUtxo`, but `fUtxo` only fed the displayed balance. Both the fee pre-calc and `createTransaction` received the **unfiltered** set, so coinselect sorted by value and spent the largest coin in the vault regardless of what the user picked.

So every vault send ignored the selection. And the change figure on the confirm screen, which is derived from the selection, could differ from the real change by orders of magnitude. That matters most when change is routed to a Strike or CoinOS deposit address, since the confirm screen renders neither the routing nor the true change.

Both the estimate and the build now use the selection and nothing else.

**No whole-wallet fallback.** An empty selection would be a caller bug, and quietly spending the rest of the vault is the worst available response, so the build alerts and stops instead.

**Needs device QA before merge.** Behaviour change worth exercising: if the selected capsules cover the amount but not amount + fee, the build now fails honestly rather than silently pulling in another coin. The existing balance guard checks the selection total against the amount only, so that path is reachable and may want a friendlier error than the raw failure.

Suggested test: two capsules, select the smaller, send most of it, confirm the broadcast spends the selected capsule.

Commit is unsigned.