### PR TITLE
fix(ark): stop telling users a possibly-sent payment was not sent

### DIFF
--- a/src/screens/Ark/ArkSendReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkSendReviewScreen/index.tsx
@@ -11,6 +11,7 @@ import {
     classifyArkDestination,
     estimateArkSendFee,
     executeArkSend,
+    isArkSendIndeterminate,
     labelForDestinationKind,
     type ArkDestination,
     type ArkSendFeeView,
@@ -149,8 +150,15 @@ export default function ArkSendReviewScreen({ route }: Props) {
         setAmountSats(sendAllAmount); // triggers re-estimate via the effect
     }, [sendAllAmount]);
 
+    // Latched once a send returns an INDETERMINATE outcome (see
+    // isArkSendIndeterminate). Never cleared: the whole point is that this
+    // screen must not offer to send again, because a retry to an ln-address
+    // mints a fresh invoice and can pay the recipient a second time.
+    const [sendIndeterminate, setSendIndeterminate] = useState(false);
+
     const canSend =
-        destinationValid && !!fee && grossWithinBalance && !isEstimating && !isSending;
+        destinationValid && !!fee && grossWithinBalance && !isEstimating && !isSending &&
+        !sendIndeterminate;
 
     const runSend = useCallback(async () => {
         if (!canSend || !fee) return;
@@ -167,9 +175,17 @@ export default function ArkSendReviewScreen({ route }: Props) {
             });
         } catch (err: any) {
             console.error('[ArkSendReview] send failed:', err);
-            setErrorMsg(
-                `Send failed: ${err?.message ?? 'unknown error'}. Your funds were not moved.`,
-            );
+            if (isArkSendIndeterminate(err)) {
+                // Outcome UNKNOWN. Do not claim the funds are safe, and do not
+                // re-arm Send: the payment may still settle, and a retry to an
+                // ln-address would mint a new invoice and pay twice.
+                setSendIndeterminate(true);
+                setErrorMsg(err?.message ?? 'This payment may still be in flight. Do not send it again.');
+            } else {
+                setErrorMsg(
+                    `Send failed: ${err?.message ?? 'unknown error'}. Your funds were not moved.`,
+                );
+            }
         } finally {
             setIsSending(false);
         }

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -201,6 +201,7 @@ export {
     classifyArkDestination,
     estimateArkSendFee,
     executeArkSend,
+    isArkSendIndeterminate,
     labelForDestinationKind,
 } from './send';
 export type {

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -40,6 +40,27 @@ export type ArkSendFeeView = {
     vtxosSpent: string[];
 };
 
+/**
+ * Error thrown when a send's outcome is UNKNOWN rather than failed: the HTLC is
+ * still live and may yet settle.
+ *
+ * This is the single most dangerous state in the send path, because the natural
+ * UI response to a thrown error ("it failed, try again") is exactly the wrong
+ * one. Retrying an ln-address or ln-offer mints a fresh invoice with a new
+ * payment hash, so the retry can settle alongside the original and pay the
+ * recipient twice, irreversibly.
+ *
+ * Callers MUST use `isArkSendIndeterminate()` before reporting an error, and
+ * when it is true they MUST NOT claim the funds are safe and MUST NOT re-enable
+ * their send control.
+ */
+export type ArkSendIndeterminateError = Error & { arkSendIndeterminate: true };
+
+/** True when the send's outcome is unknown and retrying risks paying twice. */
+export function isArkSendIndeterminate(err: unknown): boolean {
+    return !!err && (err as { arkSendIndeterminate?: boolean }).arkSendIndeterminate === true;
+}
+
 export type ArkSendResult = {
     /** Kind of send that was executed — helps callers route to the right toast. */
     kind: ArkDestinationKind;
@@ -368,9 +389,21 @@ export async function executeArkSend(
             const outcome = await waitForArkLightningSettlement(handle, resolvedInvoice);
             if (outcome === 'settled') { settled = true; break; }
             if (outcome === 'pending') {
-                throw new Error(
-                    'Lightning payment is still confirming. Check Activity before retrying so you do not send twice.',
-                );
+                // INDETERMINATE, not a failure. The HTLC is still live and may
+                // yet settle. Retrying an ln-address or ln-offer mints a FRESH
+                // invoice with a new payment hash, so a retry can settle
+                // alongside this one and pay the recipient twice.
+                //
+                // Flagged rather than left to string-matching so callers can
+                // branch on it reliably. A caller MUST NOT tell the user their
+                // funds are safe, and MUST NOT re-arm its send control, when
+                // this flag is set.
+                const indeterminate = new Error(
+                    'This payment may still be in flight. Do not send it again: wait for your ' +
+                    'balance to settle, or confirm with the recipient before retrying.',
+                ) as ArkSendIndeterminateError;
+                indeterminate.arkSendIndeterminate = true;
+                throw indeterminate;
             }
             // outcome === 'failed' -> HTLC refunded, funds back. Retry if attempts remain.
             console.log(

--- a/tests/unit/arkSendIndeterminate.test.ts
+++ b/tests/unit/arkSendIndeterminate.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A Lightning send whose outcome is UNKNOWN must never be reported as failed.
+ *
+ * When the settlement wait times out with the HTLC still live, send.ts throws
+ * deliberately so the caller does not retry: the payment may yet settle. The
+ * review screen used to append "Your funds were not moved." to that error and
+ * clear isSending, which re-armed Send with the same destination and amount.
+ * Retrying an ln-address or ln-offer mints a FRESH invoice with a new payment
+ * hash, so the retry can settle alongside the original and pay the recipient
+ * twice, irreversibly, once per tap.
+ *
+ * This is the hardest path to reach on a device: it needs a real Lightning
+ * payment still unsettled after 75 seconds, which cannot be conjured on demand.
+ * Here the bark handle is faked to never report settlement and the clock is
+ * advanced past the deadline, so the branch runs deterministically.
+ *
+ * The contract under test is that the thrown error carries the indeterminate
+ * flag, and that its wording never claims the funds are safe. Callers branch on
+ * isArkSendIndeterminate() to decide whether to keep Send disabled.
+ */
+
+const LightningSendStatus_Tags = {
+    Unknown: 'Unknown',
+    InProgress: 'InProgress',
+    Paid: 'Paid',
+} as const;
+
+const mockHandle = {
+    estimateLightningSendFee: jest.fn(),
+    payLightningAddress: jest.fn(),
+    payLightningInvoice: jest.fn(),
+    payLightningOffer: jest.fn(),
+    checkLightningPayment: jest.fn(),
+    history: jest.fn(),
+};
+
+jest.mock('@secondts/bark-react-native', () => ({
+    __esModule: true,
+    LightningSendStatus_Tags,
+    validateArkAddress: jest.fn(() => false),
+}));
+
+jest.mock('../../src/services/ark/exit', () => ({
+    __esModule: true,
+    assertNoActiveArkExit: jest.fn(),
+}));
+
+jest.mock('../../src/services/ark/restore', () => ({
+    __esModule: true,
+    ensureArkWalletHandleReady: jest.fn(async () => mockHandle),
+}));
+
+jest.mock('../../src/services/ark/balance', () => ({
+    __esModule: true,
+    fetchArkBalance: jest.fn(async () => ({ spendableSats: 100_000 })),
+}));
+
+jest.mock('../../src/services/ark/vtxos', () => ({
+    __esModule: true,
+    fetchArkVtxos: jest.fn(async () => ({ spendable: [], all: [] })),
+}));
+
+jest.mock('@Cypher/stores/eventLogStore', () => ({
+    __esModule: true,
+    recordEvent: jest.fn(),
+}));
+
+import { executeArkSend, isArkSendIndeterminate } from '../../src/services/ark/send';
+
+const LN_ADDRESS_DEST = { kind: 'ln-address' as const, value: 'someone@example.com' };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandle.estimateLightningSendFee.mockResolvedValue({
+        feeSats: 2n,
+        grossAmountSats: 1002n,
+        netAmountSats: 1000n,
+        vtxosSpent: [],
+    });
+    // Dispatch returns without settling. `Unknown` carries no resolved bolt11,
+    // so the wait falls back to the raw destination, which is not a decodable
+    // invoice, so no payment hash is available to poll.
+    mockHandle.payLightningAddress.mockResolvedValue({ tag: LightningSendStatus_Tags.Unknown });
+    // No matching movement ever appears: the HTLC stays live.
+    mockHandle.history.mockResolvedValue([]);
+    mockHandle.checkLightningPayment.mockResolvedValue({ tag: LightningSendStatus_Tags.Unknown });
+});
+
+/**
+ * Run a send to completion with the 75s settlement wait collapsed.
+ *
+ * The wait sleeps on setTimeout between polls and compares Date.now() against a
+ * deadline. Under fake timers both are driven by the same clock, so flushing
+ * microtasks and then jumping past the deadline lets the loop exit on its next
+ * check without waiting in real time.
+ */
+async function runSendPastDeadline() {
+    jest.useFakeTimers();
+    try {
+        const pending = executeArkSend(LN_ADDRESS_DEST, 1000);
+        const caught = pending.catch((e) => e);
+        // Let dispatch + the first poll settle, then jump the clock repeatedly
+        // so every scheduled poll fires and the deadline check finally fails.
+        for (let i = 0; i < 20; i++) {
+            await Promise.resolve();
+            await Promise.resolve();
+            jest.advanceTimersByTime(10_000);
+        }
+        return await caught;
+    } finally {
+        jest.useRealTimers();
+    }
+}
+
+describe('an unsettled Lightning send is reported as indeterminate', () => {
+    it('throws rather than resolving, so no caller records a success', async () => {
+        const err = await runSendPastDeadline();
+        expect(err).toBeInstanceOf(Error);
+    });
+
+    it('flags the error so callers can branch without string matching', async () => {
+        const err = await runSendPastDeadline();
+        expect(isArkSendIndeterminate(err)).toBe(true);
+    });
+
+    it('never claims the funds are safe or unmoved', async () => {
+        // The exact false statement that used to be the last sentence the user
+        // read, while the payment was still in flight.
+        const err = await runSendPastDeadline();
+        expect(err.message).not.toMatch(/not moved/i);
+        expect(err.message).not.toMatch(/funds are safe/i);
+        expect(err.message).not.toMatch(/nothing was sent/i);
+    });
+
+    it('tells the user not to send again', async () => {
+        const err = await runSendPastDeadline();
+        expect(err.message).toMatch(/do not send it again/i);
+    });
+
+    it('did not retry the payment itself', async () => {
+        // A pending outcome must break the retry loop. Re-dispatching to an
+        // ln-address mints a new invoice and can pay twice.
+        await runSendPastDeadline();
+        expect(mockHandle.payLightningAddress).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('isArkSendIndeterminate', () => {
+    it('is true only for the flagged error', () => {
+        const flagged = Object.assign(new Error('may still be in flight'), {
+            arkSendIndeterminate: true,
+        });
+        expect(isArkSendIndeterminate(flagged)).toBe(true);
+    });
+
+    it('is false for an ordinary send failure, which MAY say funds are safe', () => {
+        // The refunded-after-retries error is a genuine failure. Treating it as
+        // indeterminate would disable Send forever after a recoverable error.
+        expect(isArkSendIndeterminate(new Error('failed after several attempts and was refunded'))).toBe(false);
+    });
+
+    it.each([null, undefined, 'a string', 0, {}, { arkSendIndeterminate: false }])(
+        'is false for %p',
+        (value) => {
+            expect(isArkSendIndeterminate(value)).toBe(false);
+        },
+    );
+
+    it('is false for a truthy-but-not-true flag, so only the real marker counts', () => {
+        expect(isArkSendIndeterminate({ arkSendIndeterminate: 'yes' })).toBe(false);
+        expect(isArkSendIndeterminate({ arkSendIndeterminate: 1 })).toBe(false);
+    });
+});


### PR DESCRIPTION
When a Lightning settlement wait times out with the HTLC still live, `send.ts` throws deliberately so the caller does **not** retry: the payment may yet settle.

The review screen caught that error and appended **"Your funds were not moved."** unconditionally, so the false claim was the last sentence the user read. It then cleared `isSending`, and because `canSend` does not include `errorMsg`, the Send button came back armed with the same destination and amount.

Retrying an `ln-address` or `ln-offer` mints a fresh invoice with a **new payment hash**, so the retry can settle alongside the original and pay the recipient twice, irreversibly, once per tap.

The error also told the user to "Check Activity", but `recordEvent` fires only on the success path, so an in-flight send is invisible there and checking appeared to confirm the false message.

## Change

- The indeterminate outcome is flagged on the error (`arkSendIndeterminate`) rather than left to string matching, exposed as `isArkSendIndeterminate()`.
- The review screen branches on it: honest wording, and a latched flag that permanently disables Send on that screen so a retry cannot be offered.
- Wording is now "This payment may still be in flight. Do not send it again: wait for your balance to settle, or confirm with the recipient before retrying."

## Known gaps, deliberately not in this PR

- **In-flight sends still do not appear in Activity.** The event-log kinds are a closed union, so surfacing one needs a schema change plus a renderer. The new copy no longer points users at Activity, so it is no longer misleading, but the visibility gap is real.
- The audit also found that Android hardware-back from the success screen returns to a live review screen with a stale estimate. The latch here does not cover that path, since it is a fresh mount. Separate fix.

**Needs device QA.** Hard to trigger deliberately: it needs a Lightning send whose settlement is still pending after 75s. Easiest approach is a deliberately slow or unreachable destination.

Commit is unsigned.