### PR TITLE
fix(ark): never run a cooperative round while a unilateral exit is live

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
       "node_modules/(?!((jest-)?react-native(-.*)?|@react-native(-community)?)/)"
     ],
     "moduleNameMapper": {
-      "\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/tests/__mocks__/imageMock.js"
+      "\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/tests/__mocks__/imageMock.js",
+      "^@Cypher/(.*)$": "<rootDir>/src/$1"
     },
     "setupFiles": [
       "./node_modules/react-native-gesture-handler/jestSetup.js",

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1912,13 +1912,30 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // persisted at-start snapshot, so the amount survives
                 // reloads and closed-handle windows.
                 //
-                // `null` (no live read yet) is the ONLY case the snapshot
-                // should cover. The old form fell back to it whenever the
-                // live figure was 0 too, so once every capsule was claimed
-                // the panel re-displayed the original at-start total and kept
-                // showing it for the rest of the exit (observed live: 3671
-                // sats pinned on screen with 0 actually pending).
-                const shownSats = pendingExitSats ?? arkExitStartedSats;
+                // Three sources, best first. Getting this ladder wrong is
+                // what made the panel lie in two different ways.
+                //
+                // 1. `pendingExitSats`, the live per-VTXO poll above.
+                // 2. the store's `pendingExitSats`, refreshed by useArkSync's
+                //    exit drive and persisted (the store has no partialize, so
+                //    it survives a cold launch). This rung is why the panel
+                //    stops quoting a stale total: the local poll calls
+                //    fetchArkExitVtxos, which THROWS while the wallet handle
+                //    is closed, and the effect swallows it, so on a cold
+                //    launch with the vault still locked the local value stays
+                //    null for as long as the user takes to authenticate.
+                // 3. `arkExitStartedSats`, the at-start snapshot, only when
+                //    nothing better has ever been recorded.
+                //
+                // Rung 3 must never outrank rung 2, because the snapshot is
+                // fixed at exit start and does NOT decrement as capsules are
+                // claimed. Observed live: 1801 of 3671 sats already recovered
+                // and confirmed on chain, vault locked after a relaunch, and
+                // the panel still reading "3671 sats pending exit".
+                const shownSats =
+                  pendingExitSats ??
+                  arkBalanceDetail?.pendingExitSats ??
+                  arkExitStartedSats;
                 return shownSats == null || shownSats <= 0
                   ? 'Broadcasting exit transactions…'
                   : `${shownSats.toLocaleString()} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.`;

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -48,6 +48,7 @@ import {
   getICloudBackupPath,
   getICloudBackupPathForFingerprint,
   getLastLocalBackupNote,
+  isActiveExit,
   isGoogleDriveConnected,
   isICloudBackupAvailable,
   probeAspReachable,
@@ -957,12 +958,18 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
         // phases), which left this panel blank mid-exit. Derive the figure
         // from the per-VTXO exit records and keep the SDK total as a
         // lower bound for whatever later phase it does count.
+        //
+        // Liveness goes through isActiveExit, NOT a regex on String(v.state):
+        // bark 0.6.1 made `state` a tagged-enum object, so the old
+        // /^(Processing|Awaiting)/ test matched "[object Object]" never,
+        // activeSats was always 0, and this fell back to the exact SDK quirk
+        // the code above exists to work around.
         const [vtxos, pendingTotal] = await Promise.all([
           fetchArkExitVtxos(),
           fetchPendingExitsTotalSats(),
         ]);
         const activeSats = vtxos
-          .filter((v) => /^(Processing|Awaiting)/.test(String(v.state)) || v.isClaimable)
+          .filter((v) => isActiveExit(v))
           .reduce((acc, v) => acc + Number(v.amountSats), 0);
         if (!cancelled) setPendingExitSats(Math.max(activeSats, pendingTotal));
       } catch {
@@ -1904,10 +1911,14 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // Live per-VTXO read when the handle is open; otherwise the
                 // persisted at-start snapshot, so the amount survives
                 // reloads and closed-handle windows.
-                const shownSats =
-                  pendingExitSats && pendingExitSats > 0
-                    ? pendingExitSats
-                    : (arkExitStartedSats ?? pendingExitSats);
+                //
+                // `null` (no live read yet) is the ONLY case the snapshot
+                // should cover. The old form fell back to it whenever the
+                // live figure was 0 too, so once every capsule was claimed
+                // the panel re-displayed the original at-start total and kept
+                // showing it for the rest of the exit (observed live: 3671
+                // sats pinned on screen with 0 actually pending).
+                const shownSats = pendingExitSats ?? arkExitStartedSats;
                 return shownSats == null || shownSats <= 0
                   ? 'Broadcasting exit transactions…'
                   : `${shownSats.toLocaleString()} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.`;

--- a/src/services/ark/backgroundRefresh.ts
+++ b/src/services/ark/backgroundRefresh.ts
@@ -10,6 +10,7 @@ import {
     writeBackgroundArkSeed,
 } from './backgroundKeychain';
 import { getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
+import { hasActiveArkExitRecords } from './exit';
 import { maintenanceArkDelegated } from './refresh';
 import { syncArkWallet } from './sync';
 import { AVG_BLOCK_MINUTES, fetchChainTipHeight } from './chainTip';
@@ -160,6 +161,25 @@ export async function runArkBackgroundMaintenance(
 
     useAuthStore.getState().setArkBgRefreshLastAttempt(Date.now());
     console.log('[Ark bg-refresh] maintenance start, trigger=', trigger);
+
+    // Never run a cooperative round while a unilateral exit is in flight: it
+    // would spend a coin that is already committed on-chain. maintenanceArkDelegated
+    // enforces this too, but bail here so a deliberate skip is recorded as such
+    // rather than surfacing as an 'error' and feeding the consecutive-failure
+    // escalation. Checked after the seed read because the handle may not exist
+    // until openArkWallet runs below; hasActiveArkExitRecords returns false on
+    // a missing handle, and the in-call guard catches that case.
+    if (await hasActiveArkExitRecords()) {
+        console.log('[Ark bg-refresh] skipped: unilateral exit in progress');
+        void recordTelemetry({
+            at: startedAt,
+            trigger,
+            outcome: 'exit_in_progress',
+            elapsedMs: Date.now() - startedAt,
+        });
+        return;
+    }
+
     try {
         // Reuse a live handle if the process is already resident; otherwise open
         // from the background-readable seed (no biometric prompt).

--- a/src/services/ark/backgroundTelemetry.ts
+++ b/src/services/ark/backgroundTelemetry.ts
@@ -25,6 +25,10 @@ export type ArkBgRefreshOutcome =
     | 'dust_stranded'
     | 'no_seed'
     | 'disabled'
+    // Deliberately skipped because a unilateral exit is in flight: a
+    // cooperative round would commit the same coin twice. Not a failure, and
+    // must not count toward the consecutive-failure escalation.
+    | 'exit_in_progress'
     | 'error';
 
 export type ArkBgRefreshTelemetryEntry = {

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -38,6 +38,7 @@ import type { ExitClaimTransaction, ExitVtxo } from '@secondts/bark-react-native
 
 import useAuthStore from '@Cypher/stores/authStore';
 
+import { isActiveExit } from './barkState';
 import { ensureArkOnchainHandle, getArkWalletHandle } from './walletHandle';
 
 /**
@@ -163,6 +164,15 @@ export async function fetchArkExitVtxos(): Promise<ExitVtxo[]> {
  * the ~24h AwaitingDelta CSV wait), or claimable. Matching only Processing
  * would report "no exit" for most of the exit's life.
  *
+ * Liveness MUST go through isActiveExit. This function used to regex
+ * `String(v.state)` for /^(Processing|Awaiting)/, which bark 0.6.1 broke when
+ * it turned `state` into a tagged-enum object: `String({tag:'AwaitingDelta'})`
+ * is "[object Object]", the regex never matched, and the whole check collapsed
+ * to `v.isClaimable`. Verified live on 2026-08-18 against an exit with 2794
+ * sats in flight (three AwaitingDelta, one ClaimInProgress, all
+ * isClaimable=false): this returned FALSE, so the guard it feeds was open for
+ * essentially the entire exit.
+ *
  * Returns false when the handle is unavailable or the read throws: callers use
  * this to BLOCK an action, and a failed read is not evidence of an exit. The
  * sync-flag check in `assertNoActiveArkExit` remains the first line of defence.
@@ -172,9 +182,7 @@ export async function hasActiveArkExitRecords(): Promise<boolean> {
         const handle = getArkWalletHandle();
         if (!handle) return false;
         const exits = await handle.getExitVtxos();
-        return (exits ?? []).some(
-            (v) => /^(Processing|Awaiting)/.test(String(v.state)) || v.isClaimable,
-        );
+        return (exits ?? []).some((v) => isActiveExit(v));
     } catch {
         return false;
     }

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -152,6 +152,52 @@ export async function fetchArkExitVtxos(): Promise<ExitVtxo[]> {
 }
 
 /**
+ * Does bark's own DB hold any NON-TERMINAL exit record?
+ *
+ * The authoritative "is an exit live" signal, and deliberately independent of
+ * zustand: the background-refresh wake runs headless and can execute before the
+ * store has rehydrated, at which point `arkExitInProgress` reads its default
+ * `false` and the sync guard silently passes. This one asks bark.
+ *
+ * Non-terminal means Processing (broadcasting), any Awaiting* phase (including
+ * the ~24h AwaitingDelta CSV wait), or claimable. Matching only Processing
+ * would report "no exit" for most of the exit's life.
+ *
+ * Returns false when the handle is unavailable or the read throws: callers use
+ * this to BLOCK an action, and a failed read is not evidence of an exit. The
+ * sync-flag check in `assertNoActiveArkExit` remains the first line of defence.
+ */
+export async function hasActiveArkExitRecords(): Promise<boolean> {
+    try {
+        const handle = getArkWalletHandle();
+        if (!handle) return false;
+        const exits = await handle.getExitVtxos();
+        return (exits ?? []).some(
+            (v) => /^(Processing|Awaiting)/.test(String(v.state)) || v.isClaimable,
+        );
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Async companion to `assertNoActiveArkExit` for paths that can run before the
+ * store is hydrated (background wake) or that are about to hand VTXOs to the
+ * ASP for a cooperative round.
+ *
+ * Checks the cheap sync signals first, then bark's DB.
+ */
+export async function assertNoActiveArkExitAsync(action = 'This action'): Promise<void> {
+    const s = useAuthStore.getState();
+    const exitingVtxo = (s.arkVtxos ?? []).some((v) => (v as { exiting?: boolean }).exiting);
+    if (s.arkExitInProgress || exitingVtxo || (await hasActiveArkExitRecords())) {
+        throw new Error(
+            `${action} is unavailable while an Emergency Exit is in progress.`,
+        );
+    }
+}
+
+/**
  * Subset of `getExitVtxos` filtered to only those whose CSV timelock has
  * matured AND whose on-chain confirmations are sufficient for `drainExits`
  * to succeed. Empty until the first exit ripens (~24h post-start on

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -1,4 +1,5 @@
 import { getArkWalletHandle, getCachedArkMnemonic } from './walletHandle';
+import { assertNoActiveArkExitAsync } from './exit';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
 import { writeArkAutoBackup } from './backup';
@@ -83,6 +84,16 @@ export async function refreshArkVtxos(
     totalSats?: number,
 ): Promise<ArkRefreshResult> {
     const handle = requireHandle();
+
+    // A refresh is a COOPERATIVE round: it spends the VTXO and hands the ASP a
+    // new one. Running it against a coin that is mid-unilateral-exit commits
+    // the same coin twice, once cooperatively and once on-chain, and one of the
+    // two loses. bark does not protect against this (confirmed with Second
+    // 2026-08-13: "we allow VTXOs to be marked for exit and for the user to
+    // still spend them"), and the lock/unlock API they suggest is not exposed
+    // in bark-react-native 0.16.1, so the client is the only thing standing
+    // here.
+    await assertNoActiveArkExitAsync('Refreshing capsules');
 
     // Serialize rounds: one refresh at a time, per wallet. The in-process
     // flag catches same-process races; the pendingRoundStates probe catches
@@ -240,6 +251,10 @@ export async function refreshArkVtxosDelegated(
 ): Promise<ArkDelegatedRefreshResult> {
     const handle = requireHandle();
 
+    // Same exit guard as the self-signed path: a delegated round is still a
+    // cooperative spend of the VTXO. See refreshArkVtxos.
+    await assertNoActiveArkExitAsync('Refreshing capsules');
+
     // Cross-caller submission guard. `refreshSubmissionInFlight` is shared
     // with the self-signed path and now also with delegated maintenance, so
     // an arkoor auto-refresh, a Capsules tap-refresh, and a background wake
@@ -375,6 +390,15 @@ export async function refreshArkVtxosDelegatedAndSync(
  */
 export async function maintenanceArkDelegated(): Promise<void> {
     const handle = requireHandle();
+
+    // The highest-risk caller of the exit guard. `maintenanceDelegated()`
+    // chooses its own VTXOs inside bark, so there is no input list to filter:
+    // the only lever is whether to call it at all. It also runs headless from a
+    // silent-push wake, outside useArkSync's exit early-return, which is why
+    // the guard is the async one that asks bark's DB rather than trusting a
+    // possibly-unhydrated store.
+    await assertNoActiveArkExitAsync('Background refresh');
+
     // Same cross-caller guard as refreshArkVtxosDelegated: the background wake
     // must not submit a maintenance round while another submission is mid-
     // flight or a round is already ongoing (previously this path had no check

--- a/tests/unit/arkExitGuard.test.ts
+++ b/tests/unit/arkExitGuard.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Exit guard: never run a cooperative round while a unilateral exit is live.
+ *
+ * bark does NOT defend against this. Confirmed with Second 2026-08-13: "we
+ * allow VTXOs to be marked for exit and for the user to still spend them."
+ * The lock/unlock API they suggest is not exposed in bark-react-native 0.16.1,
+ * so this client-side guard is the only thing standing between a delegated
+ * round and a coin that is already committed on-chain.
+ *
+ * These paths are deliberately NOT reachable from the UI, which is why they get
+ * a unit test rather than device QA. On device (2026-08-16) every refresh
+ * control is disabled once an exit is active, so the guard underneath can never
+ * be exercised by tapping. The background wake has no UI at all: it runs
+ * headless from a silent push, picks its own VTXOs inside bark, and executes
+ * before the store has hydrated.
+ */
+
+const mockGetExitVtxos = jest.fn();
+const mockStoreState = {
+    arkExitInProgress: false,
+    arkVtxos: [] as Array<{ id: string; exiting?: boolean }>,
+};
+
+jest.mock('@Cypher/stores/authStore', () => ({
+    __esModule: true,
+    default: { getState: () => mockStoreState },
+}));
+
+jest.mock('../../src/services/ark/walletHandle', () => ({
+    __esModule: true,
+    getArkWalletHandle: () => ({ getExitVtxos: mockGetExitVtxos }),
+    ensureArkOnchainHandle: jest.fn(),
+}));
+
+jest.mock('@secondts/bark-react-native', () => ({
+    __esModule: true,
+    extractTxFromPsbt: jest.fn(),
+}));
+
+import {
+    assertNoActiveArkExitAsync,
+    hasActiveArkExitRecords,
+} from '../../src/services/ark/exit';
+
+beforeEach(() => {
+    mockGetExitVtxos.mockReset();
+    mockStoreState.arkExitInProgress = false;
+    mockStoreState.arkVtxos = [];
+});
+
+describe('hasActiveArkExitRecords', () => {
+    it('is false when bark reports no exit records at all', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+
+    it('is true while an exit is Processing (broadcasting)', async () => {
+        // The live state observed on device: every capsule sat at Processing
+        // for the whole broadcast phase.
+        mockGetExitVtxos.mockResolvedValue([{ state: 'Processing', isClaimable: false }]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it.each([
+        'AwaitingConfirmation',
+        'AwaitingInputConfirmation',
+        'AwaitingCpfpBroadcast',
+        'AwaitingDelta',
+    ])('is true during the %s phase', async (state) => {
+        // Matching only Processing would report "no exit" for most of an exit's
+        // life: AwaitingDelta alone is the ~24h CSV wait.
+        mockGetExitVtxos.mockResolvedValue([{ state, isClaimable: false }]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is true when a vtxo is claimable but not yet claimed', async () => {
+        mockGetExitVtxos.mockResolvedValue([{ state: 'Done', isClaimable: true }]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is false once every record is terminal', async () => {
+        mockGetExitVtxos.mockResolvedValue([
+            { state: 'Done', isClaimable: false },
+            { state: 'Exited', isClaimable: false },
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+
+    it('is true when only ONE of several records is still active', async () => {
+        mockGetExitVtxos.mockResolvedValue([
+            { state: 'Done', isClaimable: false },
+            { state: 'Exited', isClaimable: false },
+            { state: 'Processing', isClaimable: false },
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is false when the read throws, because a failed read is not evidence of an exit', async () => {
+        // Callers use this to BLOCK an action. Returning true on a failed read
+        // would wedge refresh whenever bark's DB hiccuped.
+        mockGetExitVtxos.mockRejectedValue(new Error('db locked'));
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+
+    it('is false when getExitVtxos resolves null rather than an array', async () => {
+        mockGetExitVtxos.mockResolvedValue(null);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+});
+
+describe('assertNoActiveArkExitAsync', () => {
+    it('resolves when nothing indicates an exit', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        await expect(assertNoActiveArkExitAsync('Refreshing capsules')).resolves.toBeUndefined();
+    });
+
+    it('throws on the zustand flag alone', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        mockStoreState.arkExitInProgress = true;
+        await expect(assertNoActiveArkExitAsync('Refreshing capsules')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
+    });
+
+    it('throws on a vtxo flagged exiting even when the store flag is clear', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        mockStoreState.arkVtxos = [{ id: 'a' }, { id: 'b', exiting: true }];
+        await expect(assertNoActiveArkExitAsync('Refreshing capsules')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
+    });
+
+    it("throws on bark's DB even when the store looks clean", async () => {
+        // The whole reason this async variant exists. The background wake runs
+        // before the store hydrates, so `arkExitInProgress` reads its default
+        // false and the sync guard silently passes. bark is the authority.
+        mockStoreState.arkExitInProgress = false;
+        mockStoreState.arkVtxos = [];
+        mockGetExitVtxos.mockResolvedValue([{ state: 'Processing', isClaimable: false }]);
+        await expect(assertNoActiveArkExitAsync('Background refresh')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
+    });
+
+    it('names the action in the message so the UI can surface it verbatim', async () => {
+        mockStoreState.arkExitInProgress = true;
+        mockGetExitVtxos.mockResolvedValue([]);
+        await expect(assertNoActiveArkExitAsync('Background refresh')).rejects.toThrow(
+            /^Background refresh is unavailable/,
+        );
+    });
+});

--- a/tests/unit/arkExitGuard.test.ts
+++ b/tests/unit/arkExitGuard.test.ts
@@ -79,18 +79,33 @@ describe('hasActiveArkExitRecords', () => {
     });
 
     it('is false once every record is terminal', async () => {
+        // The terminal set is exactly Claimed / VtxoAlreadySpent / Canceled,
+        // per the SDK's generated ExitState_Tags. This case used to assert on
+        // 'Done' and 'Exited', which are not ExitState variants at all, so it
+        // proved nothing about real terminal detection.
         mockGetExitVtxos.mockResolvedValue([
-            { state: 'Done', isClaimable: false },
-            { state: 'Exited', isClaimable: false },
+            { state: 'Claimed', isClaimable: false },
+            { state: 'VtxoAlreadySpent', isClaimable: false },
+            { state: 'Canceled', isClaimable: false },
         ]);
         await expect(hasActiveArkExitRecords()).resolves.toBe(false);
     });
 
     it('is true when only ONE of several records is still active', async () => {
         mockGetExitVtxos.mockResolvedValue([
-            { state: 'Done', isClaimable: false },
-            { state: 'Exited', isClaimable: false },
+            { state: 'Claimed', isClaimable: false },
+            { state: 'VtxoAlreadySpent', isClaimable: false },
             { state: 'Processing', isClaimable: false },
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('treats an unrecognised state as ACTIVE, not complete', async () => {
+        // Deliberate asymmetry. Mis-reading an in-flight exit as finished is
+        // what retired an exit early and deleted a wallet mid-exit (2026-07-31);
+        // mis-reading a finished exit as live only delays a refresh.
+        mockGetExitVtxos.mockResolvedValue([
+            { state: 'SomeFutureSdkState', isClaimable: false },
         ]);
         await expect(hasActiveArkExitRecords()).resolves.toBe(true);
     });
@@ -105,6 +120,95 @@ describe('hasActiveArkExitRecords', () => {
     it('is false when getExitVtxos resolves null rather than an array', async () => {
         mockGetExitVtxos.mockResolvedValue(null);
         await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+});
+
+/**
+ * bark 0.6.1 turned `ExitVtxo.state` from a plain string into a UniFFI
+ * tagged-enum object. Every fixture above uses the OLD string shape, which is
+ * why this suite stayed green while the guard was broken in production: the
+ * implementation regexed `String(v.state)` for /^(Processing|Awaiting)/, and
+ * against a real object that is "[object Object]", which matches nothing. The
+ * check silently collapsed to `v.isClaimable`.
+ *
+ * Read off the device on 2026-08-18 during a live mainnet exit with 2794 sats
+ * in flight: three capsules AwaitingDelta, one ClaimInProgress, every one of
+ * them isClaimable=false. hasActiveArkExitRecords() returned false, so the
+ * cooperative-round guard was open for essentially the whole exit.
+ *
+ * These fixtures are those exact payloads. They fail against the regex.
+ */
+describe('hasActiveArkExitRecords with bark 0.6.1 tagged-enum states', () => {
+    const awaitingDelta = {
+        state: {
+            tag: 'AwaitingDelta',
+            inner: {
+                tipHeight: 962962,
+                confirmedBlock: { height: 962957, hash: '0000000000000000000217a2e759c9143db1946b6a49ddf6a07c2c59b7e9341c' },
+                claimableHeight: 963101,
+            },
+        },
+        isClaimable: false,
+    };
+    const claimInProgress = {
+        state: {
+            tag: 'ClaimInProgress',
+            inner: {
+                tipHeight: 963060,
+                claimableSince: { height: 963046, hash: '00000000000000000000e17fac82dcb0cb9c5d78a7dfc2328c3bb970fd2a2cbc' },
+                claimTxid: 'fcdfa310ecd61bdbea44d03d88412a7756ad65a8c0483c1f5ca6bd8d7d558482',
+            },
+        },
+        isClaimable: false,
+    };
+
+    it('is true during AwaitingDelta, the ~24h CSV wait', async () => {
+        mockGetExitVtxos.mockResolvedValue([awaitingDelta]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is true during ClaimInProgress, after the claim is broadcast', async () => {
+        mockGetExitVtxos.mockResolvedValue([claimInProgress]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is true for the exact 4-capsule set read off the device', async () => {
+        mockGetExitVtxos.mockResolvedValue([
+            claimInProgress,
+            awaitingDelta,
+            awaitingDelta,
+            awaitingDelta,
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it.each(['Start', 'Processing', 'AwaitingDelta', 'Claimable', 'ClaimInProgress'])(
+        'is true for tagged-enum %s',
+        async (tag) => {
+            mockGetExitVtxos.mockResolvedValue([{ state: { tag }, isClaimable: false }]);
+            await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+        },
+    );
+
+    it.each(['Claimed', 'VtxoAlreadySpent', 'Canceled'])(
+        'is false for terminal tagged-enum %s',
+        async (tag) => {
+            mockGetExitVtxos.mockResolvedValue([{ state: { tag }, isClaimable: false }]);
+            await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+        },
+    );
+
+    it('blocks a background refresh mid-exit with a clean store', async () => {
+        // The end-to-end shape of the production bug: store flag lost (or not
+        // yet hydrated), bark holding a live AwaitingDelta exit. Before the
+        // fix this resolved, letting a cooperative round spend a coin already
+        // committed on-chain.
+        mockStoreState.arkExitInProgress = false;
+        mockStoreState.arkVtxos = [];
+        mockGetExitVtxos.mockResolvedValue([awaitingDelta]);
+        await expect(assertNoActiveArkExitAsync('Background refresh')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
     });
 });
 


### PR DESCRIPTION
A refresh is a **cooperative spend**: it consumes the VTXO and takes a new one from the ASP. Running one against a coin that is mid-unilateral-exit commits the same coin twice, once cooperatively and once on-chain, and one of the two loses.

Confirmed with Second on 2026-08-13 that bark does **not** defend against this:

> "No, we allow VTXOs to be marked for exit and for the user to still spend them."

They suggest locking the VTXOs after starting an exit, but **no lock/unlock API is exposed in `bark-react-native` 0.16.1** (nor any exit cancellation), so the client is currently the only thing standing here.

## The gap

`assertNoActiveArkExit` already guarded send, offboard and fee conversion, but `refresh.ts`, `backgroundRefresh.ts` and `foregroundSweep.ts` contained no exit reference at all, and `arkBgRefreshEnabled` defaults to `true`.

The background wake was the worst case: `maintenanceDelegated()` picks its own VTXOs inside bark, so there is no input list to filter, and it runs headless from a silent push, outside `useArkSync`'s exit early-return.

## Change

- `hasActiveArkExitRecords()` asks **bark's DB**, not zustand, because the background wake can execute before the store hydrates (at which point `arkExitInProgress` reads its default `false` and a sync guard silently passes). Treats any Processing or Awaiting\* state, plus claimable, as live.
- `assertNoActiveArkExitAsync()` checks the cheap sync signals first, then the DB.
- Guards `refreshArkVtxos`, `refreshArkVtxosDelegated` and `maintenanceArkDelegated`. The `*AndSync` wrappers and `foregroundSweep` inherit it (verified they chain through).
- `backgroundRefresh` bails early with a new `exit_in_progress` telemetry outcome, so a deliberate skip is not recorded as an `error` and does not feed the consecutive-failure escalation.

`hasActiveArkExitRecords` returns `false` when the handle is missing or the read throws: a failed read is not evidence of an exit, and the in-call guard covers that case.

## Verification

- `npx jest tests/unit/refreshBatch.test.ts tests/unit/refreshDeferral.test.ts` — 96 passed.
- All four touched files parse.

**Needs device QA.** Start an exit, then confirm a manual capsule refresh is refused and a background wake logs `skipped: unilateral exit in progress` rather than submitting a round.

Follow-up worth asking Second for: expose lock/unlock and exit cancellation in the RN binding, so this guard is belt-and-braces rather than the only defence.

Commit is unsigned.