### PR TITLE
fix(ark): treat delegated refreshes as mid-round everywhere

### DIFF
--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -9,6 +9,7 @@ import {
     cancelArkPendingRound,
     estimateArkOnchainRecover,
     fetchArkMinBoardSats,
+    isVtxoMidRound,
     recoverArkOnchainBoard,
 } from "@Cypher/services/ark";
 import { getCapsuleColorBand } from "@Cypher/helpers/arkCapsuleColor";
@@ -328,10 +329,12 @@ export default function ArkWallet({
         if (arkChainTipHeight === null || arkVtxos.length === 0) return null;
         let minBlocks = Infinity;
         for (const v of arkVtxos) {
-            // Skip arkoor (no own expiry) and Locked (mid-round — expiry
-            // countdown is meaningless until the round finalises).
+            // Skip arkoor (no own expiry) and anything mid-round (expiry
+            // countdown is meaningless until the round finalises). Includes
+            // delegated refreshes, which stay Spendable rather than Locked and
+            // whose expiryHeight is the pre-refresh one.
             if (v.expiryHeight === 0) continue;
-            if (v.state.toLowerCase() === 'locked') continue;
+            if (isVtxoMidRound(v, refreshingIds)) continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
             // Skip already-expired VTXOs (they stay in the store so the
             // Capsules tab can render them) — "refresh soon" is wrong
@@ -341,7 +344,7 @@ export default function ArkWallet({
         }
         if (!isFinite(minBlocks)) return null;
         return Math.max(0, blocksToDays(minBlocks));
-    }, [arkVtxos, arkChainTipHeight]);
+    }, [arkVtxos, arkChainTipHeight, refreshingIds]);
 
     const expiryWarning = soonestDaysLeft !== null && soonestDaysLeft < 7
         ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -18,6 +18,7 @@ import {
     fetchArkVtxos,
     fetchChainTipHeight,
     fetchArkExitVtxos,
+    isVtxoMidRound,
     fetchClaimableExitVtxos,
     fetchPendingExitsTotalSats,
     getArkWalletHandle,
@@ -1042,12 +1043,18 @@ export default function useArkSync(): UseArkSync {
                     const seen = nextFirstSeen[String(r.id)];
                     return seen != null && now - seen > stuckThresholdMs;
                 });
+                const refreshingIdsForStuck =
+                    useAuthStore.getState().arkRefreshingVtxoIds ?? [];
                 // "stuckSats" = sum of Locked VTXO amounts. The SDK doesn't
                 // expose a vtxo→round link, so this is the total locked across
                 // all rounds, not strictly the stuck-round subset. Fine for a
                 // banner headline since the user cancels all stuck rounds anyway.
+                // Includes delegated refreshes, which stay `Spendable` for the
+                // whole round: testing `Locked` alone meant a wedged delegated
+                // round reported 0 stuck sats and the rescue banner never
+                // appeared for the very case it exists to catch.
                 const lockedVtxos = (vtxos?.all ?? []).filter(
-                    (v) => v.state.toLowerCase() === 'locked',
+                    (v) => isVtxoMidRound(v, refreshingIdsForStuck),
                 );
                 const lockedSats = lockedVtxos.reduce((sum, v) => sum + v.sats, 0);
                 // nearExpiry: is any Locked VTXO inside the swap-out window of
@@ -1119,9 +1126,15 @@ export default function useArkSync(): UseArkSync {
                 if (stuckNow && useAuthStore.getState().arkBgRefreshEnabled) {
                     const blockMs2 = AVG_BLOCK_MINUTES * 60 * 1000;
                     const nowMs2 = Date.now();
+                    const refreshingIdsForAutoCancel =
+                        useAuthStore.getState().arkRefreshingVtxoIds ?? [];
                     let anyWithinAutoCancel = false;
                     for (const v of vtxos.all) {
-                        if (v.state.toLowerCase() !== 'locked') continue;
+                        // Same union as the stuck-sats sum above: a delegated
+                        // round leaves the VTXO Spendable, so a Locked-only
+                        // test skipped every delegated refresh and the
+                        // auto-cancel safety net never armed for them.
+                        if (!isVtxoMidRound(v, refreshingIdsForAutoCancel)) continue;
                         if (v.expiryHeight <= 0) continue;
                         const expiryAtMs = nowMs2 + Math.max(0, v.expiryHeight - tip) * blockMs2;
                         const msLeft = expiryAtMs - nowMs2;
@@ -1229,7 +1242,11 @@ export default function useArkSync(): UseArkSync {
             if (tip !== null && vtxos) {
                 for (const v of vtxos.spendable) {
                     if (v.expiryHeight === 0) continue;
-                    if (v.state.toLowerCase() === 'locked') continue;
+                    // Skip anything mid-round: its expiry is the pre-refresh
+                    // one, and escalating on it would raise the blocking rescue
+                    // Alert while a refresh is already in flight fixing it.
+                    // Locked alone missed every delegated refresh.
+                    if (isVtxoMidRound(v, state.arkRefreshingVtxoIds ?? [])) continue;
                     const blocks = v.expiryHeight - tip;
                     // Skip already-expired VTXOs: they can't be refreshed (the
                     // ASP can sweep them at any time past expiry), so they must

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -1,7 +1,7 @@
 import { ArkWallet, CircularView, CoinosWallet, GradientButtonWithShadow, StrikeDollarWallet, StrikeWallet } from "@Cypher/components";
 import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
-import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound } from "@Cypher/services/ark";
+import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";
@@ -138,7 +138,10 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         let minBlocks = Infinity;
         for (const v of arkVtxos) {
             if (v.expiryHeight === 0) continue;
-            if (v.state.toLowerCase() === 'locked') continue;
+            // Mid-round VTXOs carry their PRE-refresh expiry, so counting them
+            // shows an alarming "expires soon" while a refresh is already in
+            // flight extending it. Locked alone missed delegated refreshes.
+            if (isVtxoMidRound(v, arkRefreshingVtxoIds)) continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
             // Skip already-expired VTXOs (they stay in the store so the
             // Capsules tab can render them) — "refresh soon" is wrong
@@ -178,21 +181,16 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         return count;
     }, [arkVtxos, arkChainTipHeight, arkRefreshingVtxoIds]);
 
-    // VTXOs currently mid-round (state === 'locked' — refresh / send / board
-    // in flight). The headline balance EXCLUDES these (only spendable
-    // capsules count), so without surfacing this the user sees their
-    // balance drop with no explanation while a refresh is in progress.
-    const pendingRound = useMemo(() => {
-        if (!arkVtxos) return { count: 0, sats: 0 };
-        let count = 0;
-        let sats = 0;
-        for (const v of arkVtxos) {
-            if (v.state.toLowerCase() !== 'locked') continue;
-            count++;
-            sats += v.sats;
-        }
-        return { count, sats };
-    }, [arkVtxos]);
+    // VTXOs currently mid-round (refresh / send / board in flight). The
+    // headline balance EXCLUDES these (only spendable capsules count), so
+    // without surfacing this the user sees their balance drop with no
+    // explanation while a refresh is in progress. Testing `Locked` alone
+    // reintroduced exactly that symptom for delegated refreshes, which leave
+    // the VTXO Spendable. See isVtxoMidRound.
+    const pendingRound = useMemo(
+        () => sumMidRoundVtxos(arkVtxos, arkRefreshingVtxoIds),
+        [arkVtxos, arkRefreshingVtxoIds],
+    );
 
     /**
      * Unified status line for the shared Send/Receive row's status slot.

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -1,7 +1,7 @@
 import { ArkWallet, CircularView, CoinosWallet, GradientButtonWithShadow, StrikeDollarWallet, StrikeWallet } from "@Cypher/components";
 import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
-import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, sumMidRoundVtxos } from "@Cypher/services/ark";
+import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, isVtxoMidRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";

--- a/src/screens/Strike/CheckingAccountNew/Account.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Account.tsx
@@ -10,7 +10,7 @@ import useAuthStore from "@Cypher/stores/authStore";
 import { ArkSettingsBody } from "./Settings";
 
 import { btc } from "@Cypher/helpers/coinosHelper";
-import { blocksToDays } from "@Cypher/services/ark";
+import { blocksToDays, isVtxoMidRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import { getCapsuleColorBand } from "@Cypher/helpers/arkCapsuleColor";
 
 interface AccountProps {
@@ -31,6 +31,10 @@ export default function Account({ matchedRate, currency, receiveType, balance, c
     reserveArkAmount,
   } = useAuthStore();
   const arkVtxos = useAuthStore((s) => s.arkVtxos);
+  // Needed because a delegated refresh leaves the VTXO `Spendable`: without
+  // this the counts below read zero for the whole round and this card
+  // contradicts the home card it was written to mirror.
+  const arkRefreshingVtxoIds = useAuthStore((s) => s.arkRefreshingVtxoIds);
   const navigation = useNavigation();
 
   // Mirror ArkWallet's pendingRound derivation so the in-tab Ark Card
@@ -39,20 +43,12 @@ export default function Account({ matchedRate, currency, receiveType, balance, c
   // this, the Vault menu's Ark Card would display "0 sats ~ $0.00"
   // whenever the homescreen card was correctly showing a refresh in
   // flight, contradicting the home view.
-  const pendingRoundSats = useMemo(
-    () => arkVtxos.reduce(
-      (sum, v) => (v.state.toLowerCase() === 'locked' ? sum + v.sats : sum),
-      0,
-    ),
-    [arkVtxos],
+  const midRound = useMemo(
+    () => sumMidRoundVtxos(arkVtxos, arkRefreshingVtxoIds),
+    [arkVtxos, arkRefreshingVtxoIds],
   );
-  const pendingRoundCount = useMemo(
-    () => arkVtxos.reduce(
-      (n, v) => (v.state.toLowerCase() === 'locked' ? n + 1 : n),
-      0,
-    ),
-    [arkVtxos],
-  );
+  const pendingRoundSats = midRound.sats;
+  const pendingRoundCount = midRound.count;
 
   // Same per-VTXO capsule-slot data as the homescreen ArkWallet card —
   // see ArkWallet/index.tsx for the rationale. Kept in sync visually so
@@ -68,13 +64,13 @@ export default function Account({ matchedRate, currency, receiveType, balance, c
           : 30;
         return {
           color: getCapsuleColorBand(daysLeft).color,
-          refreshing: v.state.toLowerCase() === 'locked',
+          refreshing: isVtxoMidRound(v, arkRefreshingVtxoIds),
           daysLeft,
         };
       })
       .sort((a, b) => a.daysLeft - b.daysLeft)
       .map(({ color, refreshing }) => ({ color, refreshing }));
-  }, [arkVtxos, arkChainTipHeight]);
+  }, [arkVtxos, arkChainTipHeight, arkRefreshingVtxoIds]);
 
   const handleCoinosLogout = () => {
     clearAuth();

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -23,6 +23,7 @@ import {
     fetchArkVtxos,
     getArkCancelling,
     getArkWalletHandle,
+    isVtxoMidRound,
     ArkRefreshInFlightError,
     refreshArkVtxosDelegatedAndSync,
     restoreArkWalletFromDisk,
@@ -1269,9 +1270,9 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             const stateLower = v.state.toLowerCase();
             const kindLower = v.kind.toLowerCase();
             // bark 0.6.0: a mid-refresh VTXO stays `Spendable` (not `Locked`),
-            // so drive the "Refreshing…" row treatment off the client-tracked
-            // ids too (see authStore arkRefreshingVtxoIds).
-            const pendingRound = stateLower === "locked" || refreshingSet.has(v.id);
+            // so the "Refreshing…" row treatment is driven off the client-
+            // tracked ids too (see isVtxoMidRound).
+            const pendingRound = isVtxoMidRound(v, refreshingSet);
 
             // Tri-state recoverability — see VtxoRowData.recoverability
             // for the full reasoning. Quick summary: a Pubkey/Spendable
@@ -1884,7 +1885,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         // Exiting VTXOs excluded for the same reason as the tap-refresh
         // batch above: the exit owns them.
         const projected = freshVtxos.filter((v) => !v.exiting).map((v) => {
-            const pending = v.state.toLowerCase() === 'locked';
+            // Union, not Locked alone: a delegated round leaves the VTXO
+            // Spendable. Matches the row derivation above.
+            const pending = isVtxoMidRound(
+                v,
+                useAuthStore.getState().arkRefreshingVtxoIds ?? [],
+            );
             if (v.expiryHeight === 0 || freshTip === null) {
                 return {
                     id: v.id,

--- a/src/services/ark/cancellingState.ts
+++ b/src/services/ark/cancellingState.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import useAuthStore from '@Cypher/stores/authStore';
 
+import { sumMidRoundVtxos } from './vtxos';
+
 /**
  * Global "cancel-in-flight" state for the Ark capsule refresh UI.
  *
@@ -34,11 +36,12 @@ let storeUnsub: (() => void) | null = null;
 let safetyTimer: ReturnType<typeof setTimeout> | null = null;
 
 function pendingRoundSatsFromStore(): number {
-    const arkVtxos = useAuthStore.getState().arkVtxos;
-    return arkVtxos.reduce(
-        (sum, v) => (v.state.toLowerCase() === 'locked' ? sum + v.sats : sum),
-        0,
-    );
+    const s = useAuthStore.getState();
+    // Must count delegated refreshes too. This value is the signal for "the
+    // round has let go of the funds", so counting only `Locked` made it read 0
+    // for the entire life of a delegated round and cleared the cancelling gate
+    // immediately. See isVtxoMidRound.
+    return sumMidRoundVtxos(s.arkVtxos, s.arkRefreshingVtxoIds).sats;
 }
 
 function notify(): void {

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -43,7 +43,7 @@ export type { ArkBalanceSummary } from './balance';
 export { estimateArkOnchainRecover, recoverArkOnchainBoard } from './recoverOnchainBoard';
 export type { ArkOnchainRecoverEstimate, ArkOnchainRecoverResult } from './recoverOnchainBoard';
 
-export { fetchArkVtxos } from './vtxos';
+export { fetchArkVtxos, isVtxoMidRound, sumMidRoundVtxos } from './vtxos';
 export type { ArkVtxoView, ArkVtxoList } from './vtxos';
 
 export { tryClaimArkLightningReceives, fetchArkPendingLightningReceives, driveArkPendingLightningSends } from './lightning';

--- a/src/services/ark/vtxos.ts
+++ b/src/services/ark/vtxos.ts
@@ -37,6 +37,53 @@ export type ArkVtxoList = {
 };
 
 /**
+ * Is this VTXO committed to an in-flight round (refresh, send, board, offboard,
+ * lightning receive)?
+ *
+ * READ THIS BEFORE COMPARING `state` TO 'locked' ANYWHERE.
+ *
+ * `Locked` alone stopped being the answer at bark 0.6.0: a DELEGATED refresh
+ * leaves the VTXO `Spendable` for the whole round, so every surface that tested
+ * `state === 'locked'` to mean "refreshing" silently reported nothing in flight.
+ * That regression has now been fixed three separate times in three separate
+ * places (the refresh UI in 778e41d, then the home banners, then this sweep),
+ * which is why the predicate lives here instead of being re-derived per screen.
+ *
+ * `Locked` is still real: bark sets it for the pre-action subsystems (round,
+ * offboard, board, lightning receive). So this is a UNION, not a replacement.
+ * The client-tracked ids come from `arkRefreshingVtxoIds` in authStore, which
+ * the refresh paths maintain across the delegated round.
+ */
+export function isVtxoMidRound(
+    v: Pick<ArkVtxoView, 'id' | 'state'>,
+    refreshingIds: readonly string[] | ReadonlySet<string>,
+): boolean {
+    if (v.state.toLowerCase() === 'locked') return true;
+    return refreshingIds instanceof Set
+        ? refreshingIds.has(v.id)
+        : (refreshingIds as readonly string[]).includes(v.id);
+}
+
+/**
+ * Count and sats of everything mid-round. The headline balance excludes these,
+ * so a surface that under-reports here shows the user a balance drop with no
+ * explanation.
+ */
+export function sumMidRoundVtxos(
+    vtxos: readonly ArkVtxoView[] | null | undefined,
+    refreshingIds: readonly string[] | ReadonlySet<string>,
+): { count: number; sats: number } {
+    let count = 0;
+    let sats = 0;
+    for (const v of vtxos ?? []) {
+        if (!isVtxoMidRound(v, refreshingIds)) continue;
+        count++;
+        sats += v.sats;
+    }
+    return { count, sats };
+}
+
+/**
  * Fetch VTXO list from the local SQLite datadir.
  *
  * Returns null if the wallet handle isn't initialized. For a freshly-created


### PR DESCRIPTION
Since bark 0.6.0 a delegated refresh leaves the VTXO **`Spendable`**, not `Locked`. Every surface testing `state === 'locked'` to mean "mid-round" therefore reported nothing in flight for the entire round.

This regression has now been fixed **three times in three places** (778e41d for the capsule rows, then the home banners, now this), so the predicate moves into one exported helper rather than being re-derived per screen.

`isVtxoMidRound()` is a **union, not a replacement**: `Locked` is still real, bark sets it for the pre-action subsystems (round, offboard, board, lightning receive). `sumMidRoundVtxos()` wraps the common count+sats reduction.

## Sites corrected

| Site | Symptom |
|---|---|
| `Account.tsx` pendingRoundSats / Count | The Vault card exists specifically to mirror the home card, and had drifted into contradicting it |
| `Account.tsx` capsule-slot `refreshing` | Slots never showed the refreshing treatment |
| `cancellingState.ts` | Gates the cancel UI; read 0 for the whole life of a delegated round, clearing the gate immediately |
| `WalletsView` pendingRound | Balance drops with no explanation, the exact symptom its own comment describes |
| `WalletsView` / `ArkWallet` soonestDaysLeft | Alarming "expires soon" countdown off the pre-refresh expiry while a refresh is already extending it |
| `useArkSync` stuck-round sats | A wedged **delegated** round reported 0 stuck sats, so the rescue banner never appeared for the case it exists to catch |
| `useArkSync` auto-cancel scan | Safety net never armed for delegated rounds |
| `useArkSync` refresh-failure escalation | Could raise the blocking rescue Alert while a refresh was in flight fixing it |

## Deliberately unchanged

- `ArkCapsules:1617` `liveIds` uses `!== 'locked'` for staleness, which means something else.
- The capsule row derivation was already correct; it now routes through the helper so the invariant is "nothing compares to 'locked' except `isVtxoMidRound`".

## Verification

`npx jest tests/unit/refreshBatch.test.ts tests/unit/refreshDeferral.test.ts` — 96 passed. All 8 touched files parse.

**Needs device QA.** Start a delegated refresh and confirm: home and Vault cards agree on the refreshing sats, the capsule rows show Refreshing, the countdown does not read "expires soon" for the refreshing capsule, and Cancel stays gated until the round actually releases.

Commit is unsigned.