### PR TITLE
fix(vault): make keychain recovery passphrase-agnostic

### DIFF
--- a/src/screens/RecoverSavingVault/index.tsx
+++ b/src/screens/RecoverSavingVault/index.tsx
@@ -14,7 +14,6 @@ import {
     listHotVaultKeychainBackupsWithMeta,
     resetHotVaultBackupFully,
     HotVaultBackupSummary,
-    HotVaultMeta,
 } from '@Cypher/services/hotVaultKeychain';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 
@@ -88,7 +87,7 @@ export default function RecoverSavingVault({ route }: Props) {
             setKeychainBackups(summaries);
             if (summaries.length === 1 && !autoAttempted.current) {
                 autoAttempted.current = true;
-                handleKeychainRecover(summaries[0].walletID, summaries[0].meta);
+                handleKeychainRecover(summaries[0].walletID);
             }
         })();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -173,18 +172,17 @@ export default function RecoverSavingVault({ route }: Props) {
             w.setPassphrase(passphrase);
         }
         const id = w.getID();
-        // Keychain path verification: the words came from OUR OWN Keychain
-        // entry, whose walletID was derived from words+passphrase at save
-        // time. A mismatch here can only mean the passphrase is wrong,
-        // missing, or extra — importing anyway would surface an empty
-        // stranger wallet and read as "my funds are gone". Hard stop.
-        if (restoredWalletID && restoredWalletID !== id) {
-            Alert.alert(
-                'Passphrase mismatch',
-                'The recovered words are correct, but the passphrase does not match this vault. Check the passphrase (it is case-sensitive and spaces count) and try again. Nothing was imported.',
-            );
-            return;
-        }
+        // NO mismatch alert. The sidecar's walletID was derived from
+        // words+passphrase at save time, so a passphrase-free keychain import
+        // legitimately produces a different id. This used to hard-stop with
+        // "the passphrase does not match this vault", which told anyone holding
+        // the phone that a hidden wallet existed — the exact thing a BIP39
+        // passphrase is meant to conceal.
+        //
+        // A differing id is now simply the decoy, imported in silence. The
+        // `restoredWalletID === id` check below still runs, so the "backed up
+        // to Keychain" marker is only ever set on a vault that genuinely owns
+        // that keychain entry.
         setWalletID(id);
         if (restoredWalletID && restoredWalletID === id) {
             setHotVaultKeychainBackup(id, true);
@@ -232,10 +230,10 @@ export default function RecoverSavingVault({ route }: Props) {
      * onWallet callback rehydrate the zustand "backed up" flag so the
      * Settings UI stays in sync post-recovery.
      */
-    const handleKeychainRecover = async (
-        walletID: string,
-        knownMeta?: HotVaultMeta | null,
-    ) => {
+    // No `knownMeta` parameter by design: this flow must not be able to read
+    // the sidecar's passphrase state, because acting on it is what leaked the
+    // existence of a hidden wallet. The words are all it needs.
+    const handleKeychainRecover = async (walletID: string) => {
         if (keychainLoading || loading) return;
         setKeychainLoading(true);
         const result = await getHotVaultSeedFromKeychain(walletID);
@@ -252,37 +250,29 @@ export default function RecoverSavingVault({ route }: Props) {
             // therefore an HDSegwitBech32Wallet. Saves 3–8s of perceived
             // latency compared to the generic handleImport path.
             //
-            // Passphrase vaults: the Keychain holds the words only (the
-            // passphrase is deliberately never stored), so the meta flag
-            // routes through a secure prompt first. fastImportHotVault's
-            // walletID check then verifies the entered passphrase actually
-            // reproduces this vault. iOS-only Alert.prompt is fine here —
-            // the iPhone Keychain flow is an iOS-only feature.
-            // Prefer the meta the caller passed in. The single-backup
-            // auto-recover fires from the mount effect immediately after
-            // setKeychainBackups(), so reading `keychainBackups` state here
-            // would see the stale pre-commit [] and miss hasPassphrase. The
-            // state lookup is only a fallback for callers that don't thread it.
-            const meta =
-                knownMeta !== undefined
-                    ? knownMeta
-                    : keychainBackups.find(s => s.walletID === walletID)?.meta;
-            if (meta?.hasPassphrase) {
-                Alert.prompt(
-                    'Vault passphrase',
-                    'This vault is passphrase-protected. Enter the passphrase to finish recovery.',
-                    [
-                        { text: 'Cancel', style: 'cancel' },
-                        {
-                            text: 'Recover',
-                            onPress: (text?: string) =>
-                                fastImportHotVault(result.mnemonic, walletID, text || ''),
-                        },
-                    ],
-                    'secure-text',
-                );
-                return;
-            }
+            // PASSPHRASE-AGNOSTIC BY DESIGN. This path imports the words with
+            // no passphrase and says nothing about whether one exists.
+            //
+            // A BIP39 passphrase is a deniability tool: under duress you hand
+            // over twelve words and the wallet they open is the only wallet
+            // anyone can see. This flow used to break that. It read a
+            // `hasPassphrase` flag from the keychain sidecar and, when set,
+            // announced "This vault is passphrase-protected" before prompting.
+            // Anyone holding the unlocked phone (which, under duress, is the
+            // whole premise) learned a hidden wallet existed. Clearing the flag
+            // did not help either: the sidecar's walletID was derived WITH the
+            // passphrase, so a passphrase-free import mismatched and the guard
+            // in fastImportHotVault said "the passphrase does not match this
+            // vault" instead. Both branches leaked.
+            //
+            // So: no prompt, no mismatch alert, no flag. The decoy opens
+            // silently, exactly as typing the words by hand would. Reaching the
+            // real vault means adding the passphrase on the manual recovery
+            // path below, which is where the toggle already lives.
+            //
+            // The cost, accepted deliberately: a passphrase user who taps this
+            // lands in their decoy with no explanation. Explaining it is the
+            // leak, so there is nothing to say here.
             fastImportHotVault(result.mnemonic, walletID);
             return;
         }
@@ -452,7 +442,7 @@ export default function RecoverSavingVault({ route }: Props) {
                             <TouchableOpacity
                                 key={walletID}
                                 style={styles.keychainButton}
-                                onPress={() => handleKeychainRecover(walletID, meta)}
+                                onPress={() => handleKeychainRecover(walletID)}
                                 disabled={keychainLoading || loading}
                                 activeOpacity={0.8}
                             >
@@ -475,7 +465,7 @@ export default function RecoverSavingVault({ route }: Props) {
                         <View key={walletID} style={styles.keychainRowWrap}>
                             <TouchableOpacity
                                 style={styles.keychainRow}
-                                onPress={() => handleKeychainRecover(walletID, meta)}
+                                onPress={() => handleKeychainRecover(walletID)}
                                 disabled={
                                     isBusyOther ||
                                     isDeleting ||

--- a/src/screens/SavingVault/index.tsx
+++ b/src/screens/SavingVault/index.tsx
@@ -84,10 +84,12 @@ export default function SavingVault() {
                     mnemonic,
                     {
                         createdAt: Date.now(),
-                        // Keychain stores the words only; this flag makes the
-                        // recovery flow prompt for the (never-stored)
-                        // passphrase after the biometric read.
-                        hasPassphrase: !!wallet?.getPassphrase?.(),
+                        // No passphrase flag. Recording whether this vault has a
+                        // passphrase is what let the recovery flow announce a
+                        // hidden wallet exists, defeating the point of having
+                        // one. Keychain recovery is passphrase-agnostic now: it
+                        // opens the words as-is and stays silent. See
+                        // HotVaultMeta in services/hotVaultKeychain.
                     },
                 );
                 if (result.ok) {

--- a/src/services/hotVaultKeychain.ts
+++ b/src/services/hotVaultKeychain.ts
@@ -72,15 +72,18 @@ export interface HotVaultMeta {
     version: 1;
     createdAt: number;
     label?: string | null;
-    /**
-     * True when the vault was created with a BIP39 passphrase. The keychain
-     * stores the WORDS ONLY (the passphrase is deliberately never persisted
-     * anywhere — it is the "something you know"); this flag tells the
-     * keychain-recovery flow to prompt for the passphrase after the
-     * biometric seed read. Reveals only that protection exists, never the
-     * protection itself. Absent on pre-feature backups (=> no prompt).
-     */
-    hasPassphrase?: boolean;
+    // DELIBERATELY NO `hasPassphrase`.
+    //
+    // It used to live here so keychain recovery could prompt for the passphrase
+    // after the biometric read, on the reasoning that it "reveals only that
+    // protection exists, never the protection itself". That reveal is the
+    // problem. A BIP39 passphrase is a deniability tool: its value is that
+    // nobody can tell the hidden wallet exists, so a flag saying one does
+    // defeats the feature for anyone holding the unlocked phone.
+    //
+    // Stale `hasPassphrase` values in sidecars written by older builds are
+    // ignored on read (see readHotVaultMeta) rather than migrated, since
+    // rewriting them would need the seed and a biometric prompt.
 }
 
 export type HotVaultKeychainSaveResult =
@@ -145,7 +148,7 @@ export async function backupHotVaultMeta(
             version: 1,
             createdAt: meta.createdAt,
             label: meta.label ?? null,
-            hasPassphrase: meta.hasPassphrase ?? false,
+            // No passphrase flag is written. See HotVaultMeta.
         };
         await Keychain.setGenericPassword(
             walletID,
@@ -184,7 +187,6 @@ export async function backupHotVaultSeedWithMeta(
     const metaResult = await backupHotVaultMeta(walletID, {
         createdAt: meta?.createdAt ?? Date.now(),
         label: meta?.label ?? null,
-        hasPassphrase: meta?.hasPassphrase ?? false,
     });
     // Deliberately don't bubble up meta failures — the seed is saved, and a
     // missing meta row just falls back to a walletID-only picker row. That's
@@ -270,12 +272,10 @@ export async function getHotVaultMeta(
             version: 1,
             createdAt: parsed.createdAt,
             label: typeof parsed.label === 'string' ? parsed.label : null,
-            // Preserve the passphrase flag across the read. Dropping it here
-            // (as an earlier version did) makes every recovered backup look
-            // passphrase-less, so the Recover flow skips the passphrase prompt
-            // and reconstructs the wrong wallet. Coerce to a strict boolean so
-            // legacy entries (field absent) read as false.
-            hasPassphrase: parsed.hasPassphrase === true,
+            // A legacy `parsed.hasPassphrase` is deliberately DROPPED rather
+            // than surfaced. Recovery is passphrase-agnostic now, so nothing
+            // may branch on it: acting on the flag is what told anyone holding
+            // the phone that a hidden wallet existed. See HotVaultMeta.
         };
     } catch (err) {
         console.warn('[HotVault] Meta read failed for', walletID, err);

--- a/tests/unit/hotVaultPassphraseDeniability.test.ts
+++ b/tests/unit/hotVaultPassphraseDeniability.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The keychain sidecar must never record, or report, whether a vault has a
+ * BIP39 passphrase.
+ *
+ * A passphrase is a deniability tool. Its whole value is that nobody can tell
+ * the hidden wallet exists: under duress you hand over twelve words and the
+ * wallet they open is the only wallet anyone can see.
+ *
+ * The sidecar used to carry `hasPassphrase`, on the reasoning that it "reveals
+ * only that protection exists, never the protection itself". That reveal is the
+ * leak. Recovery read the flag and announced "This vault is passphrase-
+ * protected" before prompting, so anyone holding the unlocked phone (which,
+ * under duress, is the premise) learned a second wallet existed.
+ *
+ * These tests pin both halves: nothing writes the flag, and a legacy flag
+ * written by an older build is dropped on read rather than surfaced, so no
+ * future caller can branch on it.
+ */
+
+const mockSetGenericPassword = jest.fn();
+const mockGetGenericPassword = jest.fn();
+
+jest.mock('react-native-keychain', () => ({
+    __esModule: true,
+    setGenericPassword: mockSetGenericPassword,
+    getGenericPassword: mockGetGenericPassword,
+    resetGenericPassword: jest.fn(),
+    getAllGenericPasswordServices: jest.fn(async () => []),
+    ACCESS_CONTROL: { BIOMETRY_ANY_OR_DEVICE_PASSCODE: 'bio' },
+    ACCESSIBLE: { WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: 'whenPasscodeSet' },
+}));
+
+import {
+    backupHotVaultMeta,
+    backupHotVaultSeedWithMeta,
+    getHotVaultMeta,
+} from '../../src/services/hotVaultKeychain';
+
+const WALLET_ID = 'a'.repeat(64);
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/** The JSON actually handed to the keychain for the meta sidecar. */
+function writtenMetaPayloads(): string[] {
+    return mockSetGenericPassword.mock.calls
+        .filter((c) => String(c[2]?.service ?? '').startsWith('hot-vault-meta'))
+        .map((c) => String(c[1]));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetGenericPassword.mockResolvedValue(true);
+});
+
+describe('the sidecar never records a passphrase flag', () => {
+    it('omits it when writing meta directly', async () => {
+        await backupHotVaultMeta(WALLET_ID, { createdAt: 1_700_000_000_000, label: null });
+        const payloads = writtenMetaPayloads();
+        expect(payloads).toHaveLength(1);
+        expect(payloads[0]).not.toMatch(/passphrase/i);
+        expect(JSON.parse(payloads[0])).not.toHaveProperty('hasPassphrase');
+    });
+
+    it('omits it on the seed+meta convenience path used at vault creation', async () => {
+        await backupHotVaultSeedWithMeta(WALLET_ID, MNEMONIC, { createdAt: 1_700_000_000_000 });
+        for (const payload of writtenMetaPayloads()) {
+            expect(payload).not.toMatch(/passphrase/i);
+            expect(JSON.parse(payload)).not.toHaveProperty('hasPassphrase');
+        }
+    });
+
+    it('cannot be coaxed into writing it by a caller that still passes one', async () => {
+        // Defence against a future caller reintroducing the field. The type no
+        // longer permits it, so this casts past the compiler the way a stale
+        // call site would.
+        await backupHotVaultMeta(WALLET_ID, {
+            createdAt: 1_700_000_000_000,
+            label: null,
+            hasPassphrase: true,
+        } as any);
+        expect(writtenMetaPayloads()[0]).not.toMatch(/passphrase/i);
+    });
+
+    it('still writes the fields the picker legitimately needs', async () => {
+        await backupHotVaultMeta(WALLET_ID, { createdAt: 1_700_000_000_000, label: 'vault' });
+        const parsed = JSON.parse(writtenMetaPayloads()[0]);
+        expect(parsed).toMatchObject({ version: 1, createdAt: 1_700_000_000_000, label: 'vault' });
+    });
+});
+
+describe('a legacy passphrase flag is dropped on read', () => {
+    it('does not surface hasPassphrase from an older sidecar', async () => {
+        // Written by a build that still recorded the flag. Reading it back must
+        // not hand any caller something to branch on.
+        mockGetGenericPassword.mockResolvedValue({
+            username: WALLET_ID,
+            password: JSON.stringify({
+                version: 1,
+                createdAt: 1_700_000_000_000,
+                label: null,
+                hasPassphrase: true,
+            }),
+        });
+        const meta = await getHotVaultMeta(WALLET_ID);
+        expect(meta).not.toBeNull();
+        expect(meta).not.toHaveProperty('hasPassphrase');
+        expect((meta as any)?.hasPassphrase).toBeUndefined();
+    });
+
+    it('still returns the harmless fields from a legacy sidecar', async () => {
+        mockGetGenericPassword.mockResolvedValue({
+            username: WALLET_ID,
+            password: JSON.stringify({
+                version: 1,
+                createdAt: 42,
+                label: 'old vault',
+                hasPassphrase: true,
+            }),
+        });
+        const meta = await getHotVaultMeta(WALLET_ID);
+        expect(meta).toMatchObject({ version: 1, createdAt: 42, label: 'old vault' });
+    });
+});


### PR DESCRIPTION
A BIP39 passphrase is a deniability tool. Its value is that nobody can tell the hidden wallet exists: under duress you hand over twelve words and the wallet they open is the only wallet anyone can see. Keychain recovery broke that, on both of its branches.

With the sidecar flag set, recovery announced "This vault is passphrase- protected. Enter the passphrase to finish recovery." after the biometric read. Anyone holding the unlocked phone, which under duress is the premise, learned a second wallet existed.

Clearing the flag did not help. The sidecar's walletID was derived WITH the passphrase, so a passphrase-free import produced a different id and the verification in fastImportHotVault reported "the passphrase does not match this vault" instead. Same disclosure, different wording. There was no silent path.

So both signals go:

  - hasPassphrase is no longer written by the create flow, no longer persisted by backupHotVaultMeta, and a legacy value from an older build is dropped on read rather than surfaced, so nothing downstream can branch on it. Existing sidecars are not migrated: rewriting one needs the seed and a biometric prompt, and ignoring the field achieves the same result.
  - The walletID mismatch alert is gone. A differing id is simply the decoy, and it now imports in silence exactly as typing the words by hand would. The id-equality check still gates the "backed up to Keychain" marker, so that is only ever set on a vault that genuinely owns the entry.

handleKeychainRecover also loses its knownMeta parameter, so this flow cannot read the sidecar's passphrase state at all.

The cost is accepted deliberately: a passphrase user who taps keychain recovery lands in their decoy with no explanation. Explaining it is the leak. Reaching the real vault means adding the passphrase on the manual recovery path, where the toggle already lives and always has.

Six tests pin both halves and fail against the previous behaviour.