### PR TITLE
fix(ark): keep the unilateral exit reachable when esplora fails

### DIFF
--- a/src/services/ark/sync.ts
+++ b/src/services/ark/sync.ts
@@ -1,6 +1,6 @@
 import useAuthStore from '@Cypher/stores/authStore';
 
-import { getArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
+import { ensureArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
 
 // Flat board-fee headroom (sats) subtracted from the boardable surplus when an
 // exit-fee reserve is armed, so boardAmount's own fee can't erode the reserve
@@ -65,7 +65,20 @@ export async function syncArkWallet(): Promise<boolean> {
     if (!handle) return false;
     await handle.sync();
 
-    const onchain = getArkOnchainHandle();
+    // MUST be `ensure`, not `get`. `rotateArkOnchainEsplora()` nulls the handle
+    // so the next spawn picks a different esplora, but a bare
+    // `getArkOnchainHandle()` returns that null and the whole on-chain block
+    // below is skipped, silently and permanently: no sync, no balance, no
+    // error. One rotation killed the on-chain wallet for the rest of the
+    // process, `setLastOnchainBalanceSats` was never reached, and the exit-fee
+    // wallet read 0 sats so Emergency Exit stayed gated behind "Fund exit fees
+    // first" while the funds sat confirmed on-chain. Observed on device
+    // 2026-08-16; the rotate docstring already assumed this call site used
+    // `ensure`.
+    const onchain = await ensureArkOnchainHandle().catch((err) => {
+        console.warn('[Ark sync] onchain handle spawn failed:', err?.message ?? String(err));
+        return null;
+    });
     if (onchain) {
         try {
             const syncedSats = await onchain.sync();
@@ -149,15 +162,27 @@ export async function syncArkWallet(): Promise<boolean> {
             // nothing is in flight. Safe to call on every tick.
             await handle.syncPendingBoards();
         } catch (oncErr) {
-            console.warn('[Ark sync] onchain sync / board pipeline failed:', oncErr);
-            // If the pinned esplora is bot-blocking us (BarkError.Network /
-            // ServerConnection / the "not a blockhash" 338-byte block page),
-            // drop the handle and rotate providers so the next tick re-spawns
-            // against the alternate endpoint instead of failing forever.
+            // Stringify own properties. A BarkError carries its detail in
+            // `inner.errorMessage`, and passing the object straight to
+            // console.warn collapses it to a bare "Error", which is what made
+            // this failure undiagnosable on device (2026-08-16).
             const detail = `${(oncErr as any)?.tag ?? ''} ${(oncErr as any)?.message ?? ''} ${(oncErr as any)?.inner?.errorMessage ?? ''}`;
-            if (/Network|ServerConnection|blockhash|hex string|timeout|timed out/i.test(detail)) {
-                rotateArkOnchainEsplora();
-            }
+            console.warn(
+                '[Ark sync] onchain sync / board pipeline failed:',
+                detail.trim() || JSON.stringify(oncErr, Object.getOwnPropertyNames(oncErr ?? {})),
+            );
+            // Rotate on ANY failure, not only errors whose text matches a known
+            // network signature. The regex that used to gate this skipped
+            // errors that did not stringify the expected way, and the on-chain
+            // handle then retried the same dead provider every tick forever:
+            // `onchain.sync()` never succeeded, `setLastOnchainBalanceSats` was
+            // never reached, so the exit-fee wallet read 0 sats for the entire
+            // process lifetime and Emergency Exit stayed gated behind "Fund
+            // exit fees first" while the funds sat confirmed on-chain.
+            //
+            // Rotating on a non-network error is harmless: it just re-spawns
+            // the on-chain handle against the other esplora on the next tick.
+            rotateArkOnchainEsplora();
         }
     }
 

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -405,15 +405,28 @@ export function getArkOnchainHandle(): OnchainWalletInterface | null {
  * SQLite FDs before nulling the ref.
  */
 export function rotateArkOnchainEsplora(): void {
-    // The onchain sync failed on the current provider. We used to cycle to the
-    // NEXT provider in ESPLORA_URLS — but the only fallback is blockstream,
-    // which chronically bot-blocks bark's client and (with no SDK-side esplora
-    // timeout) hangs the onchain sync ~90s. Observed 2026-07-09: that hang
-    // froze the JS thread and starved a stuck fee estimate. So reset to the
-    // reliable primary (mempool) instead of rotating onto the bad endpoint. If
-    // we're already on the primary, a transient failure just retries it next
-    // tick rather than pinning us to a dead provider.
-    if (sessionEsploraUrl === ESPLORA_URL) return; // already on primary
+    // Advance to the NEXT provider in ESPLORA_URLS, wrapping at the end.
+    //
+    // This used to "reset to the reliable primary" instead of rotating, written
+    // when the primary was mempool and blockstream was the endpoint worth
+    // avoiding. The 2026-07-09 flip made blockstream the primary and turned
+    // that logic inside out: `sessionEsploraUrl === ESPLORA_URL` is true for a
+    // handle already pinned to blockstream, so the early return fired and the
+    // on-chain wallet could never rotate off a provider that was bot-blocking
+    // it. It retried the dead endpoint every tick forever.
+    //
+    // The visible damage was on the exit path: `onchain.sync()` kept throwing,
+    // `setLastOnchainBalanceSats` was never reached, the exit-fee wallet read 0
+    // sats, and Emergency Exit sat gated behind "Fund exit fees first" while the
+    // funds were on-chain the whole time. Observed on device 2026-08-16.
+    //
+    // The wallet-open loop in restore.ts already rotates this way and recovers
+    // from the same bot-block, so this brings the on-chain handle in line with it.
+    if (ESPLORA_URLS.length < 2) return;
+    const current = ESPLORA_URLS.indexOf(sessionEsploraUrl);
+    // Unknown current provider (-1) lands on index 0, i.e. the primary.
+    const next = ESPLORA_URLS[(current + 1) % ESPLORA_URLS.length];
+    if (next === sessionEsploraUrl) return;
     if (onchainHandle && typeof (onchainHandle as any).uniffiDestroy === 'function') {
         try {
             (onchainHandle as any).uniffiDestroy();
@@ -422,8 +435,8 @@ export function rotateArkOnchainEsplora(): void {
         }
     }
     onchainHandle = null;
-    sessionEsploraUrl = ESPLORA_URL;
-    if (__DEV__) console.log('[Ark] onchain esplora reset to primary ->', ESPLORA_URL);
+    sessionEsploraUrl = next;
+    if (__DEV__) console.log('[Ark] onchain esplora rotated ->', next);
 }
 
 /**

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -486,6 +486,18 @@ export async function ensureArkOnchainHandle(): Promise<OnchainWalletInterface> 
             const config = createArkConfig({ esploraAddress: esploraUrl });
             // bark 0.11.3 OnchainWallet.default_ signature adds a leading network arg.
             onchainHandle = await OnchainWallet.default_(ARK_NETWORK, mnemonic, config, datadir);
+            // Record the provider that ACTUALLY worked, not the one we asked
+            // for. This loop falls through to the alternate when the preferred
+            // endpoint cannot spawn, and without this `sessionEsploraUrl` keeps
+            // naming a provider we are not using. rotateArkOnchainEsplora then
+            // computes "next" from that stale value and can rotate straight
+            // onto the endpoint that just failed.
+            //
+            // Seen live 2026-08-18: a sync failed against mempool.space and the
+            // very next line read "rotated -> https://mempool.space/api",
+            // because the recorded session still said blockstream. The rotation
+            // was a no-op exactly when it was needed.
+            sessionEsploraUrl = esploraUrl;
             if (__DEV__) console.log('[Ark] Spawned onchain wallet via', esploraUrl);
             return onchainHandle;
         } catch (err) {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -629,12 +629,27 @@ const createAuthStore = (
             arkLastBackupAt: null,
             arkRoundIntervalSecs: null,
             arkExitInProgress: false,
-            arkExitDestinationAddress: null,
             arkExitStartedAt: null,
             arkExitDrained: false,
             arkExitStartedSats: null,
-            arkExitFeeReserveSats: 0,
             arkUseHotVaultSeed: false,
+            // arkExitDestinationAddress and arkExitFeeReserveSats are
+            // deliberately NOT reset here. Both are user-chosen exit-funding
+            // settings, and clearArkAuth is not only a logout: the boot path
+            // calls it on a `no-datadir` restore result
+            // (useArkRestoreOnBoot.ts:99), so a transient read on a device that
+            // does have a vault silently discarded both.
+            //
+            // Observed on device 2026-08-16. The reserve went to 0, which flips
+            // sync.ts out of the "hold funds on-chain" branch and into
+            // boardAll(), i.e. boarding away the very sats set aside to pay for
+            // a unilateral exit. And the nulled destination let
+            // useArkExitDestinationBackfill (which only fills when unset)
+            // substitute a fresh Hot Vault address, so a live exit was
+            // redirected away from the address the user had chosen.
+            //
+            // Same reasoning as the kept thresholds below and as
+            // arkArkoorPromptEnabled.
             allBTCWallets: get().allBTCWallets.filter(wallet => wallet !== 'ARK'),
             // Keep thresholds — don't reset on logout
 

--- a/tests/unit/arkExitSettingsSurvival.test.ts
+++ b/tests/unit/arkExitSettingsSurvival.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The two exit-funding settings must survive clearArkAuth().
+ *
+ * clearArkAuth is not only a logout. The boot path calls it whenever a restore
+ * comes back `no-datadir` (useArkRestoreOnBoot), so a transient read on a device
+ * that DOES have a vault used to discard both of these silently.
+ *
+ * Observed on device 2026-08-16, and both consequences are real money:
+ *
+ *   - arkExitFeeReserveSats going to 0 flips sync.ts out of its
+ *     "hold funds on-chain" branch and into boardAll(), i.e. boarding away the
+ *     exact sats the user set aside to pay for a unilateral exit.
+ *   - arkExitDestinationAddress going null lets useArkExitDestinationBackfill
+ *     (which only fills when unset) substitute a fresh Hot Vault address. A
+ *     live exit was seen being redirected away from the address the user chose.
+ *
+ * Same reasoning as arkArkoorPromptEnabled and the kept thresholds.
+ */
+
+jest.mock('../../src/stores/index', () => ({
+    __esModule: true,
+    zustandStorage: {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+import useAuthStore from '../../src/stores/authStore';
+
+const RESERVE = 14504;
+const DESTINATION = 'bc1qvr33z4mcexampledestinationchosenbytheuser';
+
+/** Put the store in the state of a user who has armed exit funding. */
+function armExitFunding() {
+    const s = useAuthStore.getState();
+    s.setArkExitFeeReserveSats(RESERVE);
+    s.setArkExitDestinationAddress(DESTINATION);
+    s.setArkAuth(true);
+}
+
+beforeEach(() => {
+    armExitFunding();
+});
+
+describe('clearArkAuth preserves exit-funding settings', () => {
+    it('keeps the armed exit fee reserve', () => {
+        expect(useAuthStore.getState().arkExitFeeReserveSats).toBe(RESERVE);
+        useAuthStore.getState().clearArkAuth();
+        expect(useAuthStore.getState().arkExitFeeReserveSats).toBe(RESERVE);
+    });
+
+    it('keeps the chosen exit destination address', () => {
+        expect(useAuthStore.getState().arkExitDestinationAddress).toBe(DESTINATION);
+        useAuthStore.getState().clearArkAuth();
+        expect(useAuthStore.getState().arkExitDestinationAddress).toBe(DESTINATION);
+    });
+
+    it('survives repeated clears, since the boot path can fire it every launch', () => {
+        for (let i = 0; i < 5; i++) useAuthStore.getState().clearArkAuth();
+        expect(useAuthStore.getState().arkExitFeeReserveSats).toBe(RESERVE);
+        expect(useAuthStore.getState().arkExitDestinationAddress).toBe(DESTINATION);
+    });
+
+    it('still clears the wallet-scoped state it is responsible for', () => {
+        // Guard against "fix" by deleting the reset entirely: clearArkAuth must
+        // keep doing its actual job.
+        const s = useAuthStore.getState();
+        s.setArkExitInProgress(true);
+        expect(useAuthStore.getState().isArkAuth).toBe(true); // precondition, not a trivial pass
+        useAuthStore.getState().clearArkAuth();
+        const after = useAuthStore.getState();
+        expect(after.isArkAuth).toBe(false);
+        expect(after.arkVtxos).toEqual([]);
+        expect(after.arkExitInProgress).toBe(false);
+        expect(after.allBTCWallets).not.toContain('ARK');
+    });
+});


### PR DESCRIPTION
Four defects on the emergency-exit path, found during on-device QA. Together
they can leave a funded wallet unable to start an exit at all, while the UI
tells the user to send money they already hold.

The exit itself never needed the Ark server. Wallet open, sync, progressExits
and the CPFP broadcasts were all confirmed working against an unreachable
server during this QA. What made the exit unavailable was our own esplora
plumbing failing silently.

## The defects

1. **The on-chain wallet died on the first provider rotation.** `sync.ts` asked
   for the handle with `getArkOnchainHandle()`, a bare getter.
   `rotateArkOnchainEsplora()` nulls that handle so the next spawn picks a
   different provider, but nothing in the sync loop re-spawned it: the getter
   returned null and the entire on-chain block was skipped, silently and
   permanently. One rotation killed the on-chain wallet for the rest of the
   process, `setLastOnchainBalanceSats` was never reached, the exit-fee wallet
   read 0 sats, and Emergency Exit stayed gated behind "Fund exit fees first"
   while the funds sat confirmed on-chain. The rotate docstring already assumed
   this call site used `ensure`. It does now.

2. **Rotation could never leave a failing primary.** It reset to the primary
   rather than advancing. That was written when the primary was mempool and
   blockstream was the endpoint worth avoiding. The 2026-07-09 flip made
   blockstream the primary and inverted the logic, so
   `sessionEsploraUrl === ESPLORA_URL` was true for a handle already pinned to a
   bot-blocking blockstream and the early return fired every time. It now
   advances through `ESPLORA_URLS`, matching the wallet-open loop in
   `restore.ts`, which recovers from the same bot-block.

3. **Rotation was gated on a regex over the error text**, and errors that did
   not stringify the expected way skipped it entirely. Rotation is now
   unconditional on failure, which is harmless: it only re-spawns the handle
   against the other provider next tick. The failure is also logged with its
   inner message instead of collapsing to a bare "Error", which is what made
   this undiagnosable on device.

4. **`clearArkAuth()` wiped two user-chosen exit-funding settings.** It is not
   only a logout: the boot path calls it on a `no-datadir` restore result, so a
   transient read discarded both. A zeroed `arkExitFeeReserveSats` flips
   `sync.ts` out of the hold-funds-on-chain branch into `boardAll()`, boarding
   away the exact sats reserved to pay for an exit. A nulled
   `arkExitDestinationAddress` lets `useArkExitDestinationBackfill`, which only
   fills when unset, substitute a fresh Hot Vault address; a live exit was
   observed being redirected away from the address the user had chosen.

All four are present in 0.1.7.

## Testing

Defects 1 to 3 were found and verified on a physical device: the balance went
from unreadable to correct, and the Emergency Exit gate lifted.

Defect 4 has four unit tests covering both settings surviving a clear, surviving
repeated clears since the boot path can fire on every launch, and a fourth
asserting `clearArkAuth` still performs the wallet-scoped reset it is
responsible for, so the test cannot be satisfied by gutting the function.
Verified against the previous store: the three survival cases fail there.

`tsc` output is unchanged against the `main` baseline.