### PR TITLE
fix(ark): batch the exit claim instead of paying a fee per capsule

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -18,6 +18,7 @@ import {
     fetchArkVtxos,
     fetchChainTipHeight,
     fetchArkExitVtxos,
+    decideExitClaimBatch,
     fetchClaimableExitVtxos,
     fetchPendingExitsTotalSats,
     getArkWalletHandle,
@@ -115,6 +116,20 @@ const URGENCY_THRESHOLD_BLOCKS = Math.round(
 // in practice: switch networks and retry, then Emergency Exit while
 // there is still time. Re-shown at most once per gap window so the sync
 // tick doesn't nag while the user is following the steps.
+/**
+ * How long the claim sweep waits for slower capsules before going without them.
+ *
+ * Each claim is one transaction paying one fee, and drainExits already batches
+ * every claimable capsule into it, so the only thing that costs money is
+ * claiming more than once. Six hours comfortably covers capsules whose exit
+ * branches confirmed a few blocks apart, which is the normal case, while
+ * bounding how long a healthy capsule can be held up by a wedged sibling.
+ *
+ * Safe to wait: past its CSV a claimable exit output is an ordinary UTXO only
+ * this wallet can spend. There is no deadline and nobody to race.
+ */
+const EXIT_CLAIM_BATCH_MAX_WAIT_MS = 6 * 60 * 60 * 1000;
+
 const REFRESH_FAIL_ESCALATE_STREAK = 3;
 const REFRESH_FAIL_ALERT_GAP_MS = 6 * 60 * 60 * 1000;
 
@@ -421,7 +436,58 @@ export default function useArkSync(): UseArkSync {
 
                     const claimable = await fetchClaimableExitVtxos();
                     _stamp(`fetchClaimableExitVtxos: ${claimable.length} ready`);
-                    if (claimable.length > 0 && arkExitDestinationAddress) {
+
+                    // CLAIM BATCHING.
+                    //
+                    // drainExits([]) already sweeps every currently-claimable
+                    // capsule into ONE transaction, so the cost of claiming is
+                    // per-claim, not per-capsule. Firing the moment the first
+                    // capsule ripens therefore pays a separate fee for each one.
+                    // Observed on a five-capsule exit: the first claim cost 225
+                    // sats to move 877, and four more were queued behind it, on
+                    // an exit-fee wallet that had already dropped from 3654 to
+                    // 699 sats. Five fees where one would have done.
+                    //
+                    // Capsules ripen apart because each has its own exit branch
+                    // and its own CSV, timed from when THAT branch's tx
+                    // confirmed. A single block between two confirmations is
+                    // enough to split the batch.
+                    //
+                    // So wait for the stragglers, but never indefinitely: one
+                    // wedged leaf must not hold the others hostage. Claim when
+                    // nothing else is still working its way through, or when the
+                    // window expires, whichever comes first.
+                    //
+                    // Waiting is safe. Past its CSV a claimable exit output is
+                    // an ordinary UTXO that only this wallet can spend, with no
+                    // deadline and nobody to race.
+                    const exitVtxosForBatch = await fetchArkExitVtxos();
+                    const stillProgressing = exitVtxosForBatch.filter(
+                        (v) => isActiveExit(v) && !v.isClaimable,
+                    ).length;
+
+                    const batchDecision = decideExitClaimBatch({
+                        claimableCount: claimable.length,
+                        stillProgressingCount: stillProgressing,
+                        batchSince: useAuthStore.getState().arkExitClaimBatchSince ?? null,
+                        now: Date.now(),
+                        maxWaitMs: EXIT_CLAIM_BATCH_MAX_WAIT_MS,
+                    });
+                    if (
+                        (useAuthStore.getState().arkExitClaimBatchSince ?? null) !==
+                        batchDecision.batchSince
+                    ) {
+                        useAuthStore.getState().setArkExitClaimBatchSince(batchDecision.batchSince);
+                    }
+                    const claimBatchReady = batchDecision.claim;
+                    if (claimable.length > 0 && !claimBatchReady) {
+                        _stamp(
+                            `exit claim held for batching (${batchDecision.reason}): ` +
+                            `${claimable.length} ready, ${stillProgressing} still progressing`,
+                        );
+                    }
+
+                    if (claimable.length > 0 && arkExitDestinationAddress && claimBatchReady) {
                         // claimArkExitsToAddress now finalizes AND broadcasts the
                         // claim (drainExits alone only builds a PSBT). Gate
                         // arkExitDrained on a real broadcast txid: a non-throwing
@@ -437,6 +503,10 @@ export default function useArkSync(): UseArkSync {
                                     `exit claim broadcast txid=${claim.txid} fee=${claim.feeSats} sats`,
                                 );
                                 setArkExitDrained(true);
+                                // Batch consumed. A later capsule ripening
+                                // opens a fresh window rather than inheriting
+                                // this one's elapsed time.
+                                useAuthStore.getState().setArkExitClaimBatchSince(null);
                             } else {
                                 _stamp('exit claim returned no txid, NOT marking drained');
                             }
@@ -456,7 +526,9 @@ export default function useArkSync(): UseArkSync {
                     // block comment above). `pendingTotal` is kept only as a
                     // belt-and-suspenders OR-term in case a future SDK
                     // version starts counting something we don't model.
-                    const exitVtxos = await fetchArkExitVtxos();
+                    // Reuses the list fetched for the batching decision above:
+                    // this runs every drive tick and the call is not cheap.
+                    const exitVtxos = exitVtxosForBatch;
                     // bark 0.6.1: count in-flight exits by the not-terminal
                     // check so we never under-count active exits, which would
                     // retire an exit early (the mid-exit wallet-deletion bug).

--- a/src/services/ark/exitClaimBatch.ts
+++ b/src/services/ark/exitClaimBatch.ts
@@ -1,0 +1,67 @@
+/**
+ * When should the exit claim sweep fire?
+ *
+ * `drainExits([])` already sweeps every currently-claimable capsule into ONE
+ * transaction, so cost is per-claim, not per-capsule. Claiming the moment the
+ * first capsule ripens therefore pays a separate fee for every one of them.
+ * Seen on a five-capsule exit: 225 sats to move 877, with four more queued
+ * behind it, on a fee wallet that had already fallen from 3654 to 699 sats.
+ *
+ * Capsules ripen apart because each has its own exit branch and its own CSV,
+ * timed from when THAT branch's transaction confirmed. One block between two
+ * confirmations is enough to split the batch.
+ *
+ * Waiting is safe: past its CSV a claimable exit output is an ordinary UTXO
+ * that only this wallet can spend, with no deadline and nobody to race. What is
+ * NOT safe is waiting forever, so a wedged capsule cannot hold the rest hostage.
+ *
+ * Lives here rather than inline in useArkSync so the rule can be tested without
+ * standing up the sync loop.
+ */
+
+export type ExitClaimBatchInput = {
+    /** Capsules ready to sweep right now. */
+    claimableCount: number;
+    /** Active exits NOT yet claimable, i.e. stragglers still worth waiting for. */
+    stillProgressingCount: number;
+    /** Epoch ms when the first capsule became claimable, null before that. */
+    batchSince: number | null;
+    /** Current epoch ms. */
+    now: number;
+    /** How long to wait for stragglers before sweeping without them. */
+    maxWaitMs: number;
+};
+
+export type ExitClaimBatchDecision = {
+    /** Sweep now. */
+    claim: boolean;
+    /** Start (or keep) the batching window at this epoch ms, null to clear it. */
+    batchSince: number | null;
+    /** Why, for the drive log. */
+    reason: 'nothing-claimable' | 'all-ready' | 'window-expired' | 'waiting';
+};
+
+export function decideExitClaimBatch(input: ExitClaimBatchInput): ExitClaimBatchDecision {
+    const { claimableCount, stillProgressingCount, batchSince, now, maxWaitMs } = input;
+
+    if (claimableCount <= 0) {
+        // Nothing to sweep. Clear the window so a future capsule starts a fresh
+        // one instead of inheriting stale elapsed time from a previous batch.
+        return { claim: false, batchSince: null, reason: 'nothing-claimable' };
+    }
+
+    // First capsule of this batch: the window opens now.
+    const since = batchSince ?? now;
+
+    // Nothing else is coming, so batching can only cost time.
+    if (stillProgressingCount === 0) {
+        return { claim: true, batchSince: since, reason: 'all-ready' };
+    }
+
+    // A straggler is wedged or simply slow. Bounded wait, then go without it.
+    if (now - since >= maxWaitMs) {
+        return { claim: true, batchSince: since, reason: 'window-expired' };
+    }
+
+    return { claim: false, batchSince: since, reason: 'waiting' };
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -209,3 +209,6 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export { decideExitClaimBatch } from './exitClaimBatch';
+export type { ExitClaimBatchInput, ExitClaimBatchDecision } from './exitClaimBatch';

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -242,6 +242,15 @@ export type AuthStateType = {
      */
     arkExitStartedAt: number | null;
     /**
+     * When the current exit first had ANY claimable capsule, epoch ms.
+     *
+     * Drives the claim batching window: each claim is its own on-chain
+     * transaction with its own fee, so sweeping five capsules one at a time
+     * costs five fees where one would do. Persisted rather than held in a ref
+     * because the exit outlives the process by a day or more.
+     */
+    arkExitClaimBatchSince: number | null;
+    /**
      * Spendable sats captured at the moment the exit was started. Display
      * fallback for the "X sats pending exit" panel: the SDK's live counters
      * read 0 mid-broadcast (see useArkSync exit block) and any live read
@@ -291,6 +300,7 @@ export type AuthStateType = {
     setArkExitInProgress: (state: boolean) => void;
     setArkExitDestinationAddress: (state: string | null) => void;
     setArkExitStartedAt: (state: number | null) => void;
+    setArkExitClaimBatchSince: (state: number | null) => void;
     setArkExitDrained: (state: boolean) => void;
     setArkExitStartedSats: (state: number | null) => void;
     setArkExitFeeReserveSats: (state: number) => void;
@@ -512,6 +522,7 @@ const createAuthStore = (
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
+    arkExitClaimBatchSince: null,
     arkExitDrained: false,
     arkExitStartedSats: null,
     arkExitFeeReserveSats: 0,
@@ -588,6 +599,7 @@ const createAuthStore = (
     setArkExitInProgress: (state: boolean) => set({ arkExitInProgress: state }),
     setArkExitDestinationAddress: (state: string | null) => set({ arkExitDestinationAddress: state }),
     setArkExitStartedAt: (state: number | null) => set({ arkExitStartedAt: state }),
+    setArkExitClaimBatchSince: (state: number | null) => set({ arkExitClaimBatchSince: state }),
     setArkExitDrained: (state: boolean) => set({ arkExitDrained: state }),
     setArkExitStartedSats: (state: number | null) => set({ arkExitStartedSats: state }),
     setArkExitFeeReserveSats: (state: number) => set({ arkExitFeeReserveSats: state }),
@@ -631,6 +643,7 @@ const createAuthStore = (
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,
+            arkExitClaimBatchSince: null,
             arkExitDrained: false,
             arkExitStartedSats: null,
             arkExitFeeReserveSats: 0,

--- a/tests/unit/exitClaimBatch.test.ts
+++ b/tests/unit/exitClaimBatch.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The exit claim sweep must batch, and must not wait forever.
+ *
+ * drainExits([]) already sweeps every claimable capsule into one transaction,
+ * so the cost is per-claim, not per-capsule. Firing on the first ripe capsule
+ * pays a separate fee for each one. Observed on a live five-capsule exit: 225
+ * sats to move 877, four more queued behind it, on a fee wallet that had
+ * already fallen from 3654 to 699 sats.
+ *
+ * The opposing risk is a wedged capsule holding healthy ones hostage forever,
+ * which is why the wait is bounded.
+ */
+
+import { decideExitClaimBatch } from '../../src/services/ark/exitClaimBatch';
+
+const HOUR = 60 * 60 * 1000;
+const MAX_WAIT = 6 * HOUR;
+const T0 = 1_700_000_000_000;
+
+const decide = (over: Partial<Parameters<typeof decideExitClaimBatch>[0]> = {}) =>
+    decideExitClaimBatch({
+        claimableCount: 1,
+        stillProgressingCount: 0,
+        batchSince: null,
+        now: T0,
+        maxWaitMs: MAX_WAIT,
+        ...over,
+    });
+
+describe('nothing to claim', () => {
+    it('does not claim and clears the window', () => {
+        const d = decide({ claimableCount: 0, batchSince: T0 - HOUR });
+        expect(d.claim).toBe(false);
+        expect(d.batchSince).toBeNull();
+        expect(d.reason).toBe('nothing-claimable');
+    });
+
+    it('clears a stale window so the next batch starts fresh', () => {
+        // Otherwise a capsule ripening tomorrow would inherit today's elapsed
+        // time and skip batching entirely.
+        expect(decide({ claimableCount: 0, batchSince: T0 - 5 * HOUR }).batchSince).toBeNull();
+    });
+});
+
+describe('everything is ready', () => {
+    it('claims immediately when no capsule is still progressing', () => {
+        const d = decide({ claimableCount: 3, stillProgressingCount: 0 });
+        expect(d.claim).toBe(true);
+        expect(d.reason).toBe('all-ready');
+    });
+
+    it('claims a lone capsule when it is the whole exit', () => {
+        // A one-capsule exit must not sit through the window for company that
+        // is never coming.
+        const d = decide({ claimableCount: 1, stillProgressingCount: 0 });
+        expect(d.claim).toBe(true);
+    });
+});
+
+describe('stragglers still progressing', () => {
+    it('holds the claim and opens the window on first sight', () => {
+        const d = decide({ claimableCount: 1, stillProgressingCount: 4, batchSince: null });
+        expect(d.claim).toBe(false);
+        expect(d.reason).toBe('waiting');
+        expect(d.batchSince).toBe(T0);
+    });
+
+    it('keeps waiting inside the window', () => {
+        const d = decide({
+            claimableCount: 2,
+            stillProgressingCount: 1,
+            batchSince: T0 - 3 * HOUR,
+            now: T0,
+        });
+        expect(d.claim).toBe(false);
+        expect(d.batchSince).toBe(T0 - 3 * HOUR);
+    });
+
+    it('preserves the original window start rather than restarting the clock', () => {
+        // Restarting on each tick would make the bound unreachable and the
+        // straggler could stall the batch indefinitely.
+        const since = T0 - 5 * HOUR;
+        expect(decide({ stillProgressingCount: 2, batchSince: since }).batchSince).toBe(since);
+    });
+
+    it('gives up and claims once the window expires', () => {
+        const d = decide({
+            claimableCount: 1,
+            stillProgressingCount: 3,
+            batchSince: T0 - MAX_WAIT,
+            now: T0,
+        });
+        expect(d.claim).toBe(true);
+        expect(d.reason).toBe('window-expired');
+    });
+
+    it('claims at exactly the boundary, not a tick later', () => {
+        expect(decide({ stillProgressingCount: 1, batchSince: T0 - MAX_WAIT }).claim).toBe(true);
+        expect(decide({ stillProgressingCount: 1, batchSince: T0 - MAX_WAIT + 1 }).claim).toBe(false);
+    });
+
+    it('a wedged capsule cannot hold the others past the bound', () => {
+        // The whole point of the ceiling: one leaf stuck forever must not mean
+        // funds never sweep.
+        const d = decide({
+            claimableCount: 4,
+            stillProgressingCount: 1,
+            batchSince: T0 - 30 * HOUR,
+            now: T0,
+        });
+        expect(d.claim).toBe(true);
+    });
+});
+
+describe('the batch we actually lived through', () => {
+    it('would have held the first capsule instead of paying five fees', () => {
+        // Five-capsule exit, one ripe, four still working: the old code claimed
+        // straight away.
+        const d = decide({ claimableCount: 1, stillProgressingCount: 4, batchSince: null });
+        expect(d.claim).toBe(false);
+    });
+
+    it('sweeps all five together once the last one ripens', () => {
+        const d = decide({
+            claimableCount: 5,
+            stillProgressingCount: 0,
+            batchSince: T0 - 2 * HOUR,
+            now: T0,
+        });
+        expect(d.claim).toBe(true);
+        expect(d.reason).toBe('all-ready');
+    });
+});


### PR DESCRIPTION
drainExits([]) already sweeps every currently-claimable capsule into ONE transaction, so the cost of claiming is per-claim, not per-capsule. The drive fired the moment the first capsule ripened, which meant a separate transaction and a separate fee for each one.

Seen on a live five-capsule exit: the first claim paid 225 sats to move 877, with four more queued behind it, on an exit-fee wallet that had already fallen from 3654 to 699 sats. Four more solo claims would not have fit in what was left, and a capsule that cannot pay its claim stays exited-but-unswept until the user tops the wallet up.

Capsules ripen apart because each has its own exit branch and its own CSV, timed from when THAT branch's transaction confirmed. A single block between two confirmations is enough to split the batch, so this is the normal case rather than an unlucky one.

The sweep now waits for stragglers, bounded at six hours so one wedged leaf cannot hold healthy capsules hostage. Waiting is safe: past its CSV a claimable exit output is an ordinary UTXO that only this wallet can spend, with no deadline and nobody to race.

The decision itself moves to decideExitClaimBatch() in services/ark, a pure function taking counts and timestamps, so it can be tested without standing up the sync loop. The window start persists in the store because an exit outlives the process by a day or more, and it is cleared both when a claim broadcasts and when nothing is claimable, so a later capsule opens a fresh window rather than inheriting stale elapsed time.

Twelve tests cover both directions: batching when stragglers remain, claiming immediately when nothing else is coming, holding the window start steady across ticks rather than restarting the clock, the exact boundary, and a wedged capsule being abandoned once the ceiling is reached.

Also stops re-fetching the exit list twice per drive tick, since the batching decision needs the same data the liveness check below already asked for.