### PR TITLE
fix(coinos): stop a double-send on withdraw timeout, and fund exit fees from another wallet

### DIFF
--- a/Navigation.js
+++ b/Navigation.js
@@ -112,6 +112,7 @@ import ArkSendScreen from '@Cypher/screens/Ark/ArkSendScreen';
 import ArkSendReviewScreen from '@Cypher/screens/Ark/ArkSendReviewScreen';
 import ArkSendSuccessScreen from '@Cypher/screens/Ark/ArkSendSuccessScreen';
 import ArkWithdrawReviewScreen from '@Cypher/screens/Ark/ArkWithdrawReviewScreen';
+import ArkExitFundingConfirmScreen from '@Cypher/screens/Ark/ArkExitFundingConfirmScreen';
 import ArkCapsulesInfoScreen from '@Cypher/screens/Ark/ArkCapsulesInfoScreen';
 import ArkStuckCapsuleScreen from '@Cypher/screens/Ark/ArkStuckCapsuleScreen';
 
@@ -229,6 +230,7 @@ const WalletsRoot = () => {
       <WalletsStack.Screen name="ArkSendReviewScreen" component={ArkSendReviewScreen} options={{ headerShown: false, gestureEnabled: true }} />
       <WalletsStack.Screen name="ArkSendSuccessScreen" component={ArkSendSuccessScreen} options={{ headerShown: false, gestureEnabled: false }} />
       <WalletsStack.Screen name="ArkWithdrawReviewScreen" component={ArkWithdrawReviewScreen} options={{ headerShown: false, gestureEnabled: true }} />
+      <WalletsStack.Screen name="ArkExitFundingConfirmScreen" component={ArkExitFundingConfirmScreen} options={{ headerShown: false, gestureEnabled: true }} />
       <WalletsStack.Screen name="ForgotCoinOSScreen" component={ForgetPassword} options={{ headerShown: false }} />
       <WalletsStack.Screen name="ChangeUsername" component={ChangeUsername} options={{ headerShown: false }} />
       <WalletsStack.Screen name="LoginCoinOSScreen" component={LoginCoinOSScreen} options={{ headerShown: false }} />

--- a/src/api/coinOSApis.ts
+++ b/src/api/coinOSApis.ts
@@ -1,3 +1,7 @@
+import {
+  isNetworkShapedFailure,
+  markWithdrawIndeterminate,
+} from '@Cypher/services/coinos/withdrawGuard';
 import useAuthStore from '@Cypher/stores/authStore';
 import SimpleToast from "react-native-simple-toast";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -470,18 +474,40 @@ export const bitcoinSendFee = async (amount: number, address: string, feeRate: n
   }
 };
 
-export const sendBitcoinPayment = async (amount: number, address: string, feeRate: number, memo: string) => {
+export const sendBitcoinPayment = async (
+  amount: number,
+  address: string,
+  feeRate: number,
+  memo: string,
+  idempotencyKey?: string,
+) => {
   try {
     const response = await fetch(`${BASE_URL}/bitcoin/send`, await withAuthToken({
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        // Best-effort only. We have NOT confirmed CoinOS honours this, so
+        // nothing depends on it: the real duplicate protection is the
+        // history check and the indeterminate marker in
+        // services/coinos/withdrawGuard. Sending it costs nothing and helps
+        // if support exists or arrives later.
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
       },
       body: feeRate === 0 ? JSON.stringify({ amount, address }) : JSON.stringify({ amount, address, feeRate, memo }),
     }));
     return await response.text();
   } catch (error) {
     console.error('Error sending bitcoin payment:', error);
+    // A network-shaped throw means the request's fate is UNKNOWN: CoinOS may
+    // well have accepted it and the reply was lost. Reporting that as a
+    // failure is what made the withdraw screen say "Please try again" and
+    // re-arm the button, which sends the money a second time. Flag it so
+    // callers can branch on a marker instead of guessing from the text.
+    if (isNetworkShapedFailure(error)) {
+      throw markWithdrawIndeterminate(
+        'This withdrawal may already have been sent. Check your CoinOS history before trying again.',
+      );
+    }
     throw error;
   }
 };

--- a/src/components/ExitFundingSourceList/index.tsx
+++ b/src/components/ExitFundingSourceList/index.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+import { Text } from '@Cypher/component-library';
+import { colors } from '@Cypher/style-guide';
+import type {
+    ExitFundingSource,
+    ExitFundingSourceId,
+} from '@Cypher/services/ark/exitFundingSources';
+
+/**
+ * "Fund exit fees from another wallet" picker.
+ *
+ * Presentational only: the caller decides which sources exist (see
+ * buildExitFundingSources) and what selecting one does. Keeping the rules out
+ * of here is what lets them be unit-tested.
+ *
+ * Unavailable rows are rendered, dimmed, with their reason. Hiding them makes
+ * the feature look broken to someone who expected their wallet to be listed;
+ * showing them says what to fix. They are not tappable, so the dead end is
+ * visible rather than discovered by tapping.
+ */
+
+type Props = {
+    sources: readonly ExitFundingSource[];
+    onSelect: (id: ExitFundingSourceId) => void;
+    /** Sats still needed, for the per-row "covers it / partial" hint. */
+    shortfallSats?: number;
+};
+
+function balanceLine(source: ExitFundingSource, shortfallSats?: number): string | null {
+    if (source.balanceSats == null) return null;
+    const bal = `${source.balanceSats.toLocaleString()} sats`;
+    if (!shortfallSats || shortfallSats <= 0) return bal;
+    // Say up front whether this one finishes the job, so the user does not pick
+    // a wallet, walk through a confirm screen and only then discover it is
+    // short.
+    return source.balanceSats >= shortfallSats ? `${bal} · covers it` : `${bal} · partial`;
+}
+
+export default function ExitFundingSourceList({ sources, onSelect, shortfallSats }: Props) {
+    return (
+        <View>
+            {sources.map((source) => {
+                const sub = source.available
+                    ? balanceLine(source, shortfallSats)
+                    : source.unavailableReason ?? null;
+
+                return (
+                    <TouchableOpacity
+                        key={source.id}
+                        accessibilityRole="button"
+                        accessibilityState={{ disabled: !source.available }}
+                        disabled={!source.available}
+                        activeOpacity={0.7}
+                        onPress={() => onSelect(source.id)}
+                        style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            paddingHorizontal: 14,
+                            paddingVertical: 14,
+                            borderRadius: 12,
+                            marginBottom: 8,
+                            backgroundColor: 'rgba(255,255,255,0.06)',
+                            opacity: source.available ? 1 : 0.45,
+                        }}
+                    >
+                        <View style={{ flex: 1, paddingRight: 12 }}>
+                            <Text bold style={{ fontSize: 15 }}>
+                                {source.label}
+                            </Text>
+                            {!!sub && (
+                                <Text style={{ fontSize: 12, color: '#AAA', marginTop: 3 }}>
+                                    {sub}
+                                </Text>
+                            )}
+                        </View>
+
+                        {/* Cold Vault is the slow one. Saying so on the row is the
+                            difference between an informed choice and a surprise
+                            hardware-wallet round-trip mid-exit. */}
+                        {source.slow && source.available && (
+                            <Text style={{ fontSize: 11, color: colors.gray?.thin ?? '#888' }}>
+                                needs your signing device
+                            </Text>
+                        )}
+                    </TouchableOpacity>
+                );
+            })}
+        </View>
+    );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -37,3 +37,4 @@ export { default as CircularView } from './CircularView';
 export { default as CustomTabView } from './CustomTabView';
 export { default as VaultCapsules } from './VaultCapsules';
 export { default as StrikeSignupSheet, type StrikeSignupSheetRef } from './StrikeSignupSheet';
+export { default as ExitFundingSourceList } from './ExitFundingSourceList';

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import SimpleToast from 'react-native-simple-toast';
+
+import { ScreenLayout, Text } from '@Cypher/component-library';
+import { GradientCard, SwipeButton } from '@Cypher/components';
+import { colors } from '@Cypher/style-guide';
+import { formatNumber } from '@Cypher/helpers/coinosHelper';
+import useAuthStore from '@Cypher/stores/authStore';
+import {
+    fundExitFeesFromCoinos,
+    getArkOnchainAddress,
+    planExitFunding,
+} from '@Cypher/services/ark';
+import {
+    bitcoinSendFee,
+    getTransactionHistory,
+    sendBitcoinPayment,
+} from '@Cypher/api/coinOSApis';
+
+/**
+ * Confirm screen for topping up the exit-fee reserve from another wallet.
+ *
+ * Everything that decides an outcome lives in services/ark/exitFundingCoinos
+ * and exitFundingPlan, both unit-tested. This screen only shows the numbers and
+ * hands the work over, so the money path is not defined by a component.
+ *
+ * The figures here answer the two questions the old flow left open: what
+ * actually LANDS (the miner fee comes off the top, so it is not what you typed)
+ * and when it takes effect (an on-chain deposit is useless until it confirms).
+ */
+
+type Props = {
+    route: {
+        params?: {
+            /** Funding source id from the picker. Only 'coinos' is wired. */
+            sourceId?: string;
+            sourceLabel?: string;
+            shortfallSats?: number;
+            availableSats?: number | null;
+            /** Fiat per BTC, for the dollar figures. */
+            rate?: number;
+            currencySymbol?: string;
+        };
+    };
+};
+
+const SATS_PER_BTC = 100_000_000;
+
+export default function ArkExitFundingConfirmScreen({ route }: Props) {
+    const navigation = useNavigation<any>();
+    const {
+        sourceId = 'coinos',
+        sourceLabel = 'CoinOS',
+        shortfallSats = 0,
+        availableSats = null,
+        rate = 0,
+        currencySymbol = '$',
+    } = route?.params ?? {};
+
+    const { arkExitFeeReserveSats, setArkExitFeeReserveSats } = useAuthStore();
+
+    const [address, setAddress] = useState<string | null>(null);
+    const [feeSats, setFeeSats] = useState<number | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [sending, setSending] = useState(false);
+    // Latched once an outcome becomes unknown. Never cleared: the point is that
+    // this screen must not offer to send again. Mirrors the Ark send review.
+    const [indeterminate, setIndeterminate] = useState(false);
+    const swipeRef = useRef<any>(null);
+    // Stable per mount, so a retry of the SAME intended top-up carries the same
+    // key rather than looking like a fresh request.
+    const idempotencyKey = useRef(
+        `cbx-fund-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+    );
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const addr = await getArkOnchainAddress();
+                if (cancelled) return;
+                setAddress(addr);
+                try {
+                    const raw = await bitcoinSendFee(shortfallSats, addr, 0);
+                    const parsed =
+                        typeof raw === 'string' && raw.trim().startsWith('{')
+                            ? JSON.parse(raw)
+                            : null;
+                    if (!cancelled) setFeeSats(Number(parsed?.fee ?? 0) || 0);
+                } catch {
+                    // A missing estimate must not block funding; it only makes
+                    // the preview less precise.
+                    if (!cancelled) setFeeSats(0);
+                }
+            } catch (err: any) {
+                if (!cancelled) {
+                    SimpleToast.show(
+                        `Could not prepare the top-up: ${err?.message ?? 'unknown error'}`,
+                        SimpleToast.LONG,
+                    );
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [shortfallSats]);
+
+    const plan = useMemo(
+        () =>
+            planExitFunding({
+                shortfallSats,
+                availableSats,
+                feeSats: feeSats ?? 0,
+            }),
+        [shortfallSats, availableSats, feeSats],
+    );
+
+    const fiat = (sats: number) =>
+        rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
+
+    const feePct =
+        plan.ok && plan.sendSats > 0 && feeSats
+            ? ((feeSats / plan.sendSats) * 100).toFixed(feeSats / plan.sendSats < 0.01 ? 2 : 1)
+            : null;
+
+    const onConfirm = async () => {
+        if (!plan.ok || sending || indeterminate) return;
+        setSending(true);
+        try {
+            const res = await fundExitFeesFromCoinos(
+                {
+                    shortfallSats,
+                    availableSats,
+                    currentReserveSats: arkExitFeeReserveSats ?? 0,
+                    idempotencyKey: idempotencyKey.current,
+                },
+                {
+                    getOnchainAddress: getArkOnchainAddress,
+                    getRecentPayments: () => getTransactionHistory(0, 20),
+                    estimateFeeSats: async (addr, amt) => {
+                        const raw = await bitcoinSendFee(amt, addr, 0);
+                        const parsed =
+                            typeof raw === 'string' && raw.trim().startsWith('{')
+                                ? JSON.parse(raw)
+                                : null;
+                        return Number(parsed?.fee ?? 0) || 0;
+                    },
+                    send: (addr, amt, key) => sendBitcoinPayment(amt, addr, 0, 'Exit fee reserve', key),
+                    armReserve: setArkExitFeeReserveSats,
+                },
+            );
+
+            if (res.ok) {
+                navigation.replace('ArkSendSuccessScreen', {
+                    title: 'Exit fees funded',
+                    // The deposit is worthless until it confirms, and saying so
+                    // here is what stops "nothing happened" a minute later.
+                    message: res.partial
+                        ? `Sent ${formatNumber(res.sentSats)} sats. That is less than the full shortfall, so top up again if the exit still reports a gap. Emergency Exit unlocks once it confirms on-chain.`
+                        : `Sent ${formatNumber(res.sentSats)} sats. Emergency Exit unlocks once it confirms on-chain.`,
+                    txid: res.txid ?? undefined,
+                });
+                return;
+            }
+
+            if (res.indeterminate) {
+                setIndeterminate(true);
+            }
+            SimpleToast.show(res.reason, SimpleToast.LONG);
+            swipeRef.current?.reset?.();
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const Row = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 10 }}>
+            <Text style={{ fontSize: 14, color: '#BBB' }}>{label}</Text>
+            <View style={{ alignItems: 'flex-end', flex: 1, paddingLeft: 12 }}>
+                <Text bold style={{ fontSize: 14 }} numberOfLines={1}>
+                    {value}
+                </Text>
+                {!!hint && <Text style={{ fontSize: 11, color: '#888', marginTop: 2 }}>{hint}</Text>}
+            </View>
+        </View>
+    );
+
+    return (
+        <ScreenLayout disableScroll showToolbar isBackButton title="Fund exit fees">
+            <View style={{ paddingHorizontal: 20, flex: 1 }}>
+                {loading ? (
+                    <ActivityIndicator color={colors.pink.default} style={{ marginTop: 40 }} />
+                ) : (
+                    <>
+                        <GradientCard disabled style={{ marginTop: 12 }}>
+                            <View style={{ padding: 16 }}>
+                                <Row label="From" value={sourceLabel} />
+                                <Row label="To" value="Bark on-chain reserve" hint={address ?? undefined} />
+                                {plan.ok ? (
+                                    <>
+                                        <Row
+                                            label="Amount"
+                                            value={`${formatNumber(plan.sendSats)} sats`}
+                                            hint={fiat(plan.sendSats) || undefined}
+                                        />
+                                        <Row
+                                            label="Network fee"
+                                            value={`${formatNumber(feeSats ?? 0)} sats`}
+                                            hint={
+                                                feePct
+                                                    ? `${feePct}%${fiat(feeSats ?? 0) ? ` · ${fiat(feeSats ?? 0)}` : ''}`
+                                                    : fiat(feeSats ?? 0) || undefined
+                                            }
+                                        />
+                                        <Row
+                                            label="Leaves your wallet"
+                                            value={`${formatNumber(plan.totalCostSats)} sats`}
+                                            hint={fiat(plan.totalCostSats) || undefined}
+                                        />
+                                    </>
+                                ) : (
+                                    <Text style={{ fontSize: 13, color: '#FFD54F', paddingVertical: 12 }}>
+                                        {plan.reason}
+                                    </Text>
+                                )}
+                            </View>
+                        </GradientCard>
+
+                        {plan.ok && plan.partial && (
+                            <Text style={{ fontSize: 12, color: '#FFD54F', marginTop: 12, lineHeight: 17 }}>
+                                This does not cover the whole shortfall. It still helps: the exit
+                                resumes as far as these fees allow.
+                            </Text>
+                        )}
+
+                        <Text style={{ fontSize: 12, color: '#888', marginTop: 12, lineHeight: 17 }}>
+                            These sats stay on-chain to pay miner fees and are not moved into Ark.
+                            Emergency Exit unlocks once the deposit confirms.
+                        </Text>
+
+                        {indeterminate && (
+                            <Text style={{ fontSize: 12, color: '#FF8A80', marginTop: 12, lineHeight: 17 }}>
+                                This top-up may already have been sent. Check your {sourceLabel}{' '}
+                                history before trying again.
+                            </Text>
+                        )}
+                    </>
+                )}
+            </View>
+
+            <View style={{ paddingHorizontal: 20, paddingBottom: 20 }}>
+                <SwipeButton
+                    title="Slide to Fund"
+                    ref={swipeRef}
+                    onToggle={onConfirm}
+                    isLoading={sending || loading || !plan.ok || indeterminate || sourceId !== 'coinos'}
+                />
+            </View>
+        </ScreenLayout>
+    );
+}

--- a/src/screens/ReviewWithdrawal/index.tsx
+++ b/src/screens/ReviewWithdrawal/index.tsx
@@ -4,6 +4,10 @@ import SimpleToast from 'react-native-simple-toast';
 import { Icon } from 'react-native-elements';
 import ReactNativeModal from 'react-native-modal';
 import styles from './styles';
+import {
+    findRecentMatchingWithdrawal,
+    isCoinosWithdrawIndeterminate,
+} from '@Cypher/services/coinos/withdrawGuard';
 import { Input, LoadingSpinner, ScreenLayout, Text } from '@Cypher/component-library';
 import { CoinOSSmall, ProgressBar2 } from '@Cypher/assets/images';
 import {
@@ -26,6 +30,7 @@ import {
     bitcoinSendFee,
     getCurrencyRates,
     getMe,
+    getTransactionHistory,
     sendBitcoinPayment,
     sendCoinsViaUsername,
     sendLightningPayment,
@@ -58,6 +63,14 @@ export default function ReviewWithdrawal({ route }: Props) {
     const [isStartLoading, setIsStartLoading] = useState(false);
     const [selectedFee, setSelectedFee] = useState<number | null>(null);
     const [selectedFeeName, setSelectedFeeName] = useState<string>('Select Fee');
+    // Latched once a withdrawal's outcome becomes UNKNOWN. Never cleared on
+    // this screen: the whole point is that it must not offer to send again.
+    const [sendIndeterminate, setSendIndeterminate] = useState(false);
+    // Stable per mount, so a retry of the SAME intended withdrawal carries the
+    // same key rather than looking like a fresh request.
+    const withdrawIdempotencyKey = useRef(
+        `cbx-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+    );
     const [estimatedFee, setEstimatedFee] = useState<number>(0);
     const [networkFee, setNetworkFee] = useState<number>(0);
     const [bamskiiFee, setBamskiiFee] = useState<number>(0);
@@ -263,7 +276,42 @@ export default function ReviewWithdrawal({ route }: Props) {
 
             console.log('selectedFee: ', selectedFee);
             try {
-                const sendResponse = await sendBitcoinPayment(remainingAmount, to, selectedFee, note);
+                // Pre-flight duplicate check. If a previous attempt reached
+                // CoinOS and only its reply was lost, the withdrawal is already
+                // in the history and sending again pays twice. Checking costs
+                // one request and is the only protection that does not depend
+                // on CoinOS honouring an idempotency key.
+                //
+                // A failed check must NOT block the send: being unable to read
+                // history is not evidence of a duplicate, and refusing here
+                // would strand the user.
+                try {
+                    const recent = await getTransactionHistory(0, 20);
+                    const dupe = findRecentMatchingWithdrawal(recent?.payments, {
+                        address: to,
+                        amountSats: remainingAmount,
+                        now: Date.now(),
+                    });
+                    if (dupe) {
+                        setSendIndeterminate(true);
+                        SimpleToast.show(
+                            'This withdrawal already went out a moment ago. Check your history rather than sending again.',
+                            SimpleToast.LONG,
+                        );
+                        setIsSendLoading(false);
+                        return;
+                    }
+                } catch (histErr) {
+                    console.warn('[CoinOS] duplicate pre-check failed, continuing:', histErr);
+                }
+
+                const sendResponse = await sendBitcoinPayment(
+                    remainingAmount,
+                    to,
+                    selectedFee,
+                    note,
+                    withdrawIdempotencyKey.current,
+                );
 
                 let jsonSend = null;
                 console.log('sendResponse: ', sendResponse);
@@ -281,7 +329,19 @@ export default function ReviewWithdrawal({ route }: Props) {
                 }
             } catch (error) {
                 console.error('Error Send to bitcoin:', error);
-                SimpleToast.show('Failed to Send to bitcoin. Please try again.', SimpleToast.SHORT);
+                if (isCoinosWithdrawIndeterminate(error)) {
+                    // Outcome UNKNOWN. Never say it failed and never invite a
+                    // retry: the old copy here was literally "Please try again",
+                    // and following it sends the money a second time.
+                    setSendIndeterminate(true);
+                    SimpleToast.show(
+                        (error as Error)?.message ??
+                            'This withdrawal may already have been sent. Check your history before trying again.',
+                        SimpleToast.LONG,
+                    );
+                } else {
+                    SimpleToast.show('Failed to Send to bitcoin. Please try again.', SimpleToast.SHORT);
+                }
             } finally {
                 setIsSendLoading(false);
             }
@@ -557,7 +617,7 @@ export default function ReviewWithdrawal({ route }: Props) {
                 </GradientCard>
             </View>
             <View style={styles.container}>
-                <SwipeButton ref={swipeButtonRef} onToggle={handleToggle} isLoading={isSendLoading} />
+                <SwipeButton ref={swipeButtonRef} onToggle={handleToggle} isLoading={isSendLoading || sendIndeterminate} />
                 {/* <GradientButton style={styles.invoiceButton} texStyle={{ fontFamily: 'Lato-Medium', }} title="Send" onPress={sendClickHandler} /> */}
             </View>
         </ScreenLayout>

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -3,7 +3,7 @@ import QRCode from "react-native-qrcode-svg";
 
 import { Copy, StrikeFull } from "@Cypher/assets/images";
 import { GradientSwitch, Text } from "@Cypher/component-library";
-import { GradientView } from "@Cypher/components";
+import { ExitFundingSourceList, GradientView } from "@Cypher/components";
 import useAuthStore from "@Cypher/stores/authStore";
 import { colors, widths } from "@Cypher/style-guide";
 import React, { useContext, useEffect, useState } from "react";
@@ -57,6 +57,7 @@ import {
   startArkEmergencyExit,
   writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
+  buildExitFundingSources,
 } from "@Cypher/services/ark";
 import type { ExitFeeConvertEstimate } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
@@ -338,6 +339,8 @@ export default function Settings({ receiveType, currency, isArk }: Props) {
 export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'actions' }) {
   const {
     clearArkAuth,
+    isAuth,
+    isStrikeAuth,
     walletID,
     coldStorageWalletID,
     arkBalanceDetail,
@@ -901,7 +904,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   // `null` while the first computation is in flight.
   const [recommendedReserveSats, setRecommendedReserveSats] = useState<number | null>(null);
   const [exitFundingOpen, setExitFundingOpen] = useState(false);
-  const [fundingTab, setFundingTab] = useState<'receive' | 'convert'>('receive');
+  const [fundingTab, setFundingTab] = useState<'receive' | 'wallet' | 'convert'>('receive');
   const [onchainFundAddr, setOnchainFundAddr] = useState<string | null>(null);
   // ASP reachability for the CONVERT (cooperative-offboard) tab. null = probing.
   const [aspReachable, setAspReachable] = useState<boolean | null>(null);
@@ -2475,7 +2478,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
 
               {/* Tab switch */}
               <View style={{ flexDirection: 'row', marginBottom: 14, borderRadius: 10, backgroundColor: '#222', padding: 3 }}>
-                {(['receive', 'convert'] as const).map((tab) => {
+                {(['receive', 'wallet', 'convert'] as const).map((tab) => {
                   const active = fundingTab === tab;
                   return (
                     <TouchableOpacity
@@ -2484,7 +2487,11 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                       style={{ flex: 1, paddingVertical: 8, borderRadius: 8, alignItems: 'center', backgroundColor: active ? (colors.ark?.light ?? colors.pink.default) : 'transparent' }}
                     >
                       <Text bold style={{ fontSize: 12, color: active ? '#1C1C1C' : '#AAA' }}>
-                        {tab === 'receive' ? 'Receive Bitcoin' : 'Convert from balance'}
+                        {tab === 'receive'
+                          ? 'Receive Bitcoin'
+                          : tab === 'wallet'
+                            ? 'From a wallet'
+                            : 'Convert from balance'}
                       </Text>
                     </TouchableOpacity>
                   );
@@ -2523,6 +2530,47 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   ) : (
                     <ActivityIndicator color={colors.ark?.light ?? colors.pink.default} style={{ marginVertical: 24 }} />
                   )}
+                </>
+              )}
+
+              {fundingTab === 'wallet' && (
+                <>
+                  <Text style={{ fontSize: 12, color: '#CCC', marginBottom: 12, lineHeight: 17 }}>
+                    Send {exitFeeShortfallSats.toLocaleString()} sats on-chain from one of your
+                    wallets. The address is filled in for you.
+                  </Text>
+                  {/* Sources that cannot be used are listed too, dimmed and with
+                      a reason. Hiding them makes the feature look broken to
+                      someone expecting their wallet to appear. */}
+                  <ExitFundingSourceList
+                    shortfallSats={exitFeeShortfallSats}
+                    sources={buildExitFundingSources({
+                      coinos: { connected: !!isAuth },
+                      strike: { connected: !!isStrikeAuth },
+                      hotVault: { walletID: walletID ?? null },
+                      coldVault: { walletID: coldStorageWalletID ?? null },
+                      shortfallSats: exitFeeShortfallSats,
+                    })}
+                    onSelect={(id) => {
+                      // Only CoinOS has a provider today. The others stay in the
+                      // list so the roadmap is visible, but must not pretend to
+                      // work.
+                      if (id !== 'coinos') {
+                        SimpleToast.show('Coming soon for this wallet', SimpleToast.SHORT);
+                        return;
+                      }
+                      setExitFundingOpen(false);
+                      (navigation as any).navigate('ArkExitFundingConfirmScreen', {
+                        sourceId: 'coinos',
+                        sourceLabel: 'CoinOS',
+                        shortfallSats: exitFeeShortfallSats,
+                        // Balance is read on the confirm screen; null means
+                        // "unknown", which plans for the full shortfall rather
+                        // than refusing.
+                        availableSats: null,
+                      });
+                    }}
+                  />
                 </>
               )}
 

--- a/src/services/ark/exitFundingCoinos.ts
+++ b/src/services/ark/exitFundingCoinos.ts
@@ -1,0 +1,143 @@
+/**
+ * Fund the exit-fee reserve from a CoinOS balance.
+ *
+ * CoinOS is first of the wallet sources because it settles without a signing
+ * device and is where most spare sats sit. The send is an ordinary on-chain
+ * withdrawal to the Bark wallet's own on-chain address, so it needs no ASP and
+ * works during an outage, which is exactly when the reserve tends to be needed.
+ *
+ * Two ordering rules matter and neither is obvious:
+ *
+ *   1. ARM THE RESERVE FIRST. sync.ts boards confirmed on-chain funds into Ark
+ *      unless `arkExitFeeReserveSats` says to hold them. During an active exit
+ *      boarding is already off, but the precautionary case (topping up BEFORE
+ *      starting an exit) would otherwise quietly undo itself on the next tick.
+ *      Arming before sending means the sats are protected the moment they land.
+ *
+ *   2. CHECK FOR A DUPLICATE BEFORE SENDING. A previous attempt whose reply was
+ *      lost is already on its way, and sending again pays twice. See
+ *      services/coinos/withdrawGuard.
+ *
+ * Network calls are injected so this can be tested without standing up the API
+ * layer, and so the caller keeps control of the auth-bearing fetches.
+ */
+
+import {
+    findRecentMatchingWithdrawal,
+    isCoinosWithdrawIndeterminate,
+    type CoinosPaymentLike,
+} from '../coinos/withdrawGuard';
+
+import { planExitFunding } from './exitFundingPlan';
+
+export type CoinosExitFundingDeps = {
+    /** Bark's own on-chain address. Local BDK, no ASP. */
+    getOnchainAddress: () => Promise<string>;
+    /** Recent CoinOS payments, for the duplicate check. */
+    getRecentPayments: () => Promise<{ payments?: CoinosPaymentLike[] } | null>;
+    /** Estimated miner fee for this send, in sats. */
+    estimateFeeSats: (address: string, amountSats: number) => Promise<number>;
+    /** Perform the withdrawal. Should carry the idempotency key. */
+    send: (address: string, amountSats: number, idempotencyKey: string) => Promise<string>;
+    /** Persist the reserve so auto-board leaves the funds alone. */
+    armReserve: (sats: number) => void;
+    now?: () => number;
+};
+
+export type CoinosExitFundingRequest = {
+    shortfallSats: number;
+    availableSats: number | null;
+    /** Reserve already armed, so arming never lowers an existing floor. */
+    currentReserveSats?: number;
+    idempotencyKey: string;
+};
+
+export type CoinosExitFundingResult =
+    | { ok: true; txid: string | null; sentSats: number; feeSats: number; partial: boolean }
+    | { ok: false; reason: string; duplicate?: boolean; indeterminate?: boolean };
+
+export async function fundExitFeesFromCoinos(
+    req: CoinosExitFundingRequest,
+    deps: CoinosExitFundingDeps,
+): Promise<CoinosExitFundingResult> {
+    const now = deps.now ?? (() => Date.now());
+
+    const address = await deps.getOnchainAddress();
+    if (!address) {
+        return { ok: false, reason: 'Could not get the on-chain address for the fee reserve.' };
+    }
+
+    // Fee first: the plan cannot be sized without it, because the fee comes off
+    // the top of the source balance.
+    let feeSats = 0;
+    try {
+        feeSats = Math.max(0, Math.floor((await deps.estimateFeeSats(address, req.shortfallSats)) || 0));
+    } catch {
+        // An unavailable estimate must not block funding. planExitFunding
+        // handles fee 0 and the provider still charges what it charges.
+        feeSats = 0;
+    }
+
+    const plan = planExitFunding({
+        shortfallSats: req.shortfallSats,
+        availableSats: req.availableSats,
+        feeSats,
+    });
+    if (!plan.ok) return { ok: false, reason: plan.reason };
+
+    // Duplicate check before spending anything. A failed history read does NOT
+    // block: being unable to read history is not evidence of a duplicate.
+    try {
+        const recent = await deps.getRecentPayments();
+        const dupe = findRecentMatchingWithdrawal(recent?.payments, {
+            address,
+            amountSats: plan.sendSats,
+            now: now(),
+        });
+        if (dupe) {
+            return {
+                ok: false,
+                duplicate: true,
+                reason: 'A matching top-up already went out a moment ago. Check your CoinOS history rather than sending again.',
+            };
+        }
+    } catch {
+        // Continue: see above.
+    }
+
+    // Arm BEFORE sending, so the sats are protected the instant they confirm.
+    // Never lower an existing floor: a bigger reserve someone already chose is
+    // not ours to shrink.
+    const target = Math.max(req.currentReserveSats ?? 0, (req.currentReserveSats ?? 0) + plan.sendSats);
+    deps.armReserve(target);
+
+    try {
+        const raw = await deps.send(address, plan.sendSats, req.idempotencyKey);
+        // CoinOS answers with a JSON body on success and a bare string on
+        // refusal, the same shape the withdraw screen already contends with.
+        let txid: string | null = null;
+        if (typeof raw === 'string' && raw.trim().startsWith('{')) {
+            try {
+                txid = JSON.parse(raw)?.txid ?? null;
+            } catch {
+                txid = null;
+            }
+        } else if (typeof raw === 'string' && raw.trim()) {
+            return { ok: false, reason: raw.trim() };
+        }
+        return { ok: true, txid, sentSats: plan.sendSats, feeSats, partial: plan.partial };
+    } catch (err) {
+        if (isCoinosWithdrawIndeterminate(err)) {
+            // Outcome unknown. The reserve stays armed on purpose: if the send
+            // did go through, the sats must not be boarded away when they land.
+            return {
+                ok: false,
+                indeterminate: true,
+                reason:
+                    (err as Error)?.message ??
+                    'This top-up may already have been sent. Check your CoinOS history before trying again.',
+            };
+        }
+        return { ok: false, reason: (err as Error)?.message ?? 'The top-up could not be sent.' };
+    }
+}

--- a/src/services/ark/exitFundingPlan.ts
+++ b/src/services/ark/exitFundingPlan.ts
@@ -1,0 +1,97 @@
+/**
+ * How much to send when funding the exit-fee reserve from another wallet.
+ *
+ * Separated from the screen and from the provider because the arithmetic is
+ * where this goes wrong, and the failure is expensive in both directions:
+ * sending too little leaves the exit stalled after the user believed they had
+ * fixed it, and sending everything strips a wallet they may still need.
+ *
+ * The number that matters is what LANDS on-chain, not what leaves. The miner
+ * fee comes out on top, so a wallet holding exactly the shortfall cannot
+ * deliver the shortfall.
+ */
+
+import { MIN_USEFUL_FUNDING_SATS } from './exitFundingSources';
+
+export type ExitFundingPlanInput = {
+    /** Sats the reserve is short by. */
+    shortfallSats: number;
+    /** Spendable sats at the source, or null when unknown. */
+    availableSats: number | null;
+    /** Estimated miner fee for this send. */
+    feeSats: number;
+    /** Floor below which a contribution cannot pay its own way. */
+    minUsefulSats?: number;
+};
+
+export type ExitFundingPlan =
+    | {
+          ok: true;
+          /** Sats to hand the provider, i.e. what should land. */
+          sendSats: number;
+          /** Total leaving the source, send + fee. */
+          totalCostSats: number;
+          /** True when this does not close the whole shortfall. */
+          partial: boolean;
+      }
+    | { ok: false; reason: string };
+
+export function planExitFunding(input: ExitFundingPlanInput): ExitFundingPlan {
+    const minUseful = input.minUsefulSats ?? MIN_USEFUL_FUNDING_SATS;
+    const shortfall = Math.max(0, Math.floor(input.shortfallSats || 0));
+    const fee = Math.max(0, Math.floor(input.feeSats || 0));
+
+    if (shortfall <= 0) {
+        return { ok: false, reason: 'The exit-fee reserve is already funded.' };
+    }
+
+    // An unreadable balance is not a zero balance. Plan for the full shortfall
+    // and let the provider reject it if the funds are not there: refusing here
+    // would strand a user whose balance simply failed to load.
+    const available =
+        typeof input.availableSats === 'number' && Number.isFinite(input.availableSats)
+            ? Math.max(0, Math.floor(input.availableSats))
+            : null;
+
+    if (available == null) {
+        return {
+            ok: true,
+            sendSats: shortfall,
+            totalCostSats: shortfall + fee,
+            partial: false,
+        };
+    }
+
+    // The fee is charged on top, so the most that can LAND is balance - fee.
+    const maxLanding = available - fee;
+
+    if (maxLanding < minUseful) {
+        return {
+            ok: false,
+            // Name the fee explicitly. "Insufficient balance" reads as a lie to
+            // someone looking at a balance larger than the amount they typed.
+            reason:
+                fee > 0
+                    ? `Not enough to cover the ${fee.toLocaleString()} sat network fee and a useful top-up.`
+                    : 'Balance is too small to be worth sending.',
+        };
+    }
+
+    if (maxLanding >= shortfall) {
+        return {
+            ok: true,
+            sendSats: shortfall,
+            totalCostSats: shortfall + fee,
+            partial: false,
+        };
+    }
+
+    // Partial funding is still progress: it can be the difference between an
+    // exit that finishes and one that stalls. Send what fits and say so.
+    return {
+        ok: true,
+        sendSats: maxLanding,
+        totalCostSats: available,
+        partial: true,
+    };
+}

--- a/src/services/ark/exitFundingSources.ts
+++ b/src/services/ark/exitFundingSources.ts
@@ -1,0 +1,123 @@
+/**
+ * Which wallets can top up the exit-fee reserve, and which cannot right now.
+ *
+ * The funding sheet's "Receive Bitcoin" tab hands the user an address and
+ * leaves them to find some bitcoin. That is the ASP-independent path and it
+ * always works, but it is also the least helpful thing to show someone whose
+ * exit has stalled and who already holds sats in this very app.
+ *
+ * This builds the list behind "Fund from another wallet". It is pure: state in,
+ * sources out, so the ordering and the availability rules can be tested without
+ * a screen.
+ *
+ * DESIGN NOTES, because two of these are easy to get wrong.
+ *
+ * Unavailable sources are RETURNED, not filtered out, each carrying its reason.
+ * A user who cannot see their Hot Vault in the list concludes the feature is
+ * broken; one who sees it greyed out with "no spendable capsules" has learned
+ * something. Callers render them disabled.
+ *
+ * Cold Vault is ordered LAST and flagged slow. It needs a PSBT round-trip
+ * through an airgapped signer, which is minutes to hours. Offering it as a peer
+ * of Hot Vault to someone in a degraded exit invites the worst choice on the
+ * list.
+ */
+
+export type ExitFundingSourceId = 'coinos' | 'strike' | 'hot-vault' | 'cold-vault';
+
+export type ExitFundingSource = {
+    id: ExitFundingSourceId;
+    label: string;
+    /** Selectable right now. */
+    available: boolean;
+    /** Why not, when `available` is false. Shown to the user verbatim. */
+    unavailableReason?: string;
+    /** Spendable sats this source could contribute, when known. */
+    balanceSats?: number;
+    /** Needs a hardware signing round-trip, so it is slow. */
+    slow?: boolean;
+};
+
+export type ExitFundingSourceState = {
+    coinos?: { connected: boolean; balanceSats?: number | null } | null;
+    strike?: { connected: boolean; balanceSats?: number | null } | null;
+    hotVault?: { walletID: string | null; balanceSats?: number | null } | null;
+    coldVault?: { walletID: string | null; balanceSats?: number | null } | null;
+    /** Sats still needed. Sources holding less than this are still offered. */
+    shortfallSats?: number;
+};
+
+/** Below this a contribution cannot cover its own on-chain fee. */
+export const MIN_USEFUL_FUNDING_SATS = 1_000;
+
+function sats(v: number | null | undefined): number | undefined {
+    return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : undefined;
+}
+
+function custodial(
+    id: 'coinos' | 'strike',
+    label: string,
+    entry: { connected: boolean; balanceSats?: number | null } | null | undefined,
+): ExitFundingSource {
+    if (!entry?.connected) {
+        return { id, label, available: false, unavailableReason: `Not connected` };
+    }
+    const balanceSats = sats(entry.balanceSats);
+    if (balanceSats != null && balanceSats < MIN_USEFUL_FUNDING_SATS) {
+        return {
+            id,
+            label,
+            available: false,
+            balanceSats,
+            // Naming the floor beats "insufficient balance", which leaves the
+            // user guessing how much would be enough.
+            unavailableReason: `Balance below ${MIN_USEFUL_FUNDING_SATS.toLocaleString()} sats`,
+        };
+    }
+    return { id, label, available: true, balanceSats };
+}
+
+function vault(
+    id: 'hot-vault' | 'cold-vault',
+    label: string,
+    entry: { walletID: string | null; balanceSats?: number | null } | null | undefined,
+    opts: { slow?: boolean } = {},
+): ExitFundingSource {
+    const base = { id, label, slow: opts.slow } as ExitFundingSource;
+    if (!entry?.walletID) {
+        return { ...base, available: false, unavailableReason: 'No vault on this device' };
+    }
+    const balanceSats = sats(entry.balanceSats);
+    if (balanceSats != null && balanceSats < MIN_USEFUL_FUNDING_SATS) {
+        return {
+            ...base,
+            available: false,
+            balanceSats,
+            unavailableReason: 'No spendable capsules',
+        };
+    }
+    return { ...base, available: true, balanceSats };
+}
+
+/**
+ * Ordered list of funding sources.
+ *
+ * Custodial wallets first: they hold most users' spare sats and settle without
+ * a signing device. Hot Vault next. Cold Vault last, always, because it is the
+ * slow one.
+ */
+export function buildExitFundingSources(
+    state: ExitFundingSourceState = {},
+): ExitFundingSource[] {
+    return [
+        custodial('coinos', 'CoinOS', state.coinos),
+        custodial('strike', 'Strike', state.strike),
+        vault('hot-vault', 'Hot Vault', state.hotVault),
+        vault('cold-vault', 'Cold Vault', state.coldVault, { slow: true }),
+    ];
+}
+
+/** True when at least one source can actually be used. */
+export function hasUsableExitFundingSource(sources: readonly ExitFundingSource[]): boolean {
+    return sources.some((s) => s.available);
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -209,3 +209,14 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export {
+    MIN_USEFUL_FUNDING_SATS,
+    buildExitFundingSources,
+    hasUsableExitFundingSource,
+} from './exitFundingSources';
+export type {
+    ExitFundingSource,
+    ExitFundingSourceId,
+    ExitFundingSourceState,
+} from './exitFundingSources';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -220,3 +220,12 @@ export type {
     ExitFundingSourceId,
     ExitFundingSourceState,
 } from './exitFundingSources';
+
+export { planExitFunding } from './exitFundingPlan';
+export type { ExitFundingPlan, ExitFundingPlanInput } from './exitFundingPlan';
+export { fundExitFeesFromCoinos } from './exitFundingCoinos';
+export type {
+    CoinosExitFundingDeps,
+    CoinosExitFundingRequest,
+    CoinosExitFundingResult,
+} from './exitFundingCoinos';

--- a/src/services/coinos/withdrawGuard.ts
+++ b/src/services/coinos/withdrawGuard.ts
@@ -1,0 +1,126 @@
+/**
+ * Duplicate protection for CoinOS on-chain withdrawals.
+ *
+ * THE HAZARD. `POST /bitcoin/send` crosses the network. If the connection dies
+ * after CoinOS accepted the request but before the reply arrives, the client
+ * cannot tell "never sent" from "sent, reply lost". The withdraw screen treated
+ * every failure as the former: it showed "Failed to Send to bitcoin. Please try
+ * again." and re-armed the swipe button. Following that instruction sends the
+ * money a second time, irreversibly.
+ *
+ * WHY NOT JUST AN IDEMPOTENCY KEY. A key only works if the server honours it,
+ * and we have not confirmed CoinOS does. We send one anyway (it costs nothing
+ * and helps if supported), but nothing here relies on it. The protection that
+ * actually works is client-side and has two halves:
+ *
+ *   1. Before sending, look for a withdrawal to the same address for the same
+ *      amount in the recent past. If one exists, this is almost certainly a
+ *      retry of a request that already went through.
+ *   2. When a send fails in a network-shaped way, do NOT report failure. The
+ *      outcome is unknown, and saying otherwise is what caused the double-send.
+ *
+ * Same reasoning as the indeterminate Lightning send in services/ark/send.ts:
+ * an unknown outcome must never be presented as a safe one.
+ */
+
+/** Shape we rely on from `GET /payments`. Deliberately loose. */
+export type CoinosPaymentLike = {
+    amount?: number | string | null;
+    created?: number | string | null;
+    type?: string | null;
+    hash?: string | null;
+    address?: string | null;
+    onchain?: { address?: string | null } | null;
+};
+
+/** How far back a matching withdrawal still counts as "probably this one". */
+export const WITHDRAW_DUPLICATE_WINDOW_MS = 10 * 60 * 1000;
+
+/** Error thrown when a withdrawal's outcome is UNKNOWN rather than failed. */
+export type CoinosWithdrawIndeterminateError = Error & {
+    coinosWithdrawIndeterminate: true;
+};
+
+/** True when the outcome is unknown and retrying risks paying twice. */
+export function isCoinosWithdrawIndeterminate(err: unknown): boolean {
+    return (
+        !!err &&
+        (err as { coinosWithdrawIndeterminate?: boolean }).coinosWithdrawIndeterminate === true
+    );
+}
+
+/**
+ * Network-shaped failures leave the request's fate unknown: it may well have
+ * reached CoinOS. Anything else (a validation rejection, say) is a real
+ * failure, because the server answered.
+ */
+export function isNetworkShapedFailure(err: unknown): boolean {
+    if (!err) return false;
+    const text = `${(err as Error)?.name ?? ''} ${(err as Error)?.message ?? ''}`;
+    return /network request failed|timeout|timed out|aborted|socket|econn|failed to fetch|network error/i.test(
+        text,
+    );
+}
+
+export function markWithdrawIndeterminate(message: string): CoinosWithdrawIndeterminateError {
+    const e = new Error(message) as CoinosWithdrawIndeterminateError;
+    e.coinosWithdrawIndeterminate = true;
+    return e;
+}
+
+function addressOf(p: CoinosPaymentLike): string | null {
+    const a = p?.onchain?.address ?? p?.address ?? null;
+    return typeof a === 'string' && a ? a.trim().toLowerCase() : null;
+}
+
+function createdMs(p: CoinosPaymentLike): number | null {
+    const c = p?.created;
+    if (typeof c === 'number' && Number.isFinite(c)) {
+        // CoinOS timestamps are ms; a seconds-shaped value would land in 1970.
+        return c < 1e12 ? c * 1000 : c;
+    }
+    if (typeof c === 'string') {
+        const t = Date.parse(c);
+        return Number.isNaN(t) ? null : t;
+    }
+    return null;
+}
+
+/**
+ * A recent withdrawal matching this destination and amount, or null.
+ *
+ * Amount is compared on magnitude: outgoing payments are negative in CoinOS's
+ * history, and the caller thinks in positive sats.
+ *
+ * Matching needs BOTH address and amount. Address alone would flag a legitimate
+ * second payment to the same destination, and amount alone would flag any
+ * same-sized payment to anyone.
+ */
+export function findRecentMatchingWithdrawal(
+    payments: readonly CoinosPaymentLike[] | null | undefined,
+    criteria: { address: string; amountSats: number; now: number; withinMs?: number },
+): CoinosPaymentLike | null {
+    const { address, amountSats, now } = criteria;
+    const withinMs = criteria.withinMs ?? WITHDRAW_DUPLICATE_WINDOW_MS;
+    if (!payments?.length || !address || !Number.isFinite(amountSats)) return null;
+
+    const wanted = address.trim().toLowerCase();
+    const wantedSats = Math.abs(Math.round(amountSats));
+
+    for (const p of payments) {
+        if (addressOf(p) !== wanted) continue;
+
+        const raw = typeof p?.amount === 'string' ? Number(p.amount) : p?.amount;
+        if (!Number.isFinite(raw as number)) continue;
+        if (Math.abs(Math.round(raw as number)) !== wantedSats) continue;
+
+        // No usable timestamp: treat as a match rather than risk a double-send.
+        // A false positive costs the user a confirmation tap; a false negative
+        // costs them the money.
+        const ts = createdMs(p);
+        if (ts == null) return p;
+
+        if (now - ts <= withinMs && now - ts >= -withinMs) return p;
+    }
+    return null;
+}

--- a/tests/unit/coinosWithdrawGuard.test.ts
+++ b/tests/unit/coinosWithdrawGuard.test.ts
@@ -1,0 +1,154 @@
+/**
+ * CoinOS on-chain withdrawals must not be sendable twice.
+ *
+ * `POST /bitcoin/send` crosses the network, so a dropped connection leaves the
+ * outcome unknown: the request may have reached CoinOS. The withdraw screen
+ * treated every failure as "never sent", told the user "Please try again", and
+ * re-armed the button. Following that instruction sends the money again.
+ */
+
+import {
+    WITHDRAW_DUPLICATE_WINDOW_MS,
+    findRecentMatchingWithdrawal,
+    isCoinosWithdrawIndeterminate,
+    isNetworkShapedFailure,
+    markWithdrawIndeterminate,
+} from '../../src/services/coinos/withdrawGuard';
+
+const ADDR = 'bc1qdph4zqqkvf72nd6uz87q2c5hw9tzapfnkmq93c';
+const OTHER = 'bc1qtmcfj7lvgjp866w8lytdpap82u7eege58jy52hp4ctk0hsncegyqel8prp';
+const NOW = 1_700_000_000_000;
+
+const payment = (over: Record<string, unknown> = {}) => ({
+    amount: -10_000,
+    created: NOW - 60_000,
+    type: 'bitcoin',
+    onchain: { address: ADDR },
+    ...over,
+});
+
+const find = (payments: any[], over: Record<string, unknown> = {}) =>
+    findRecentMatchingWithdrawal(payments, {
+        address: ADDR,
+        amountSats: 10_000,
+        now: NOW,
+        ...over,
+    });
+
+describe('spotting a withdrawal that already went out', () => {
+    it('matches the same address and amount within the window', () => {
+        expect(find([payment()])).not.toBeNull();
+    });
+
+    it('compares amount by magnitude, since outgoing payments are negative', () => {
+        expect(find([payment({ amount: -10_000 })])).not.toBeNull();
+        expect(find([payment({ amount: 10_000 })])).not.toBeNull();
+    });
+
+    it('accepts a string amount', () => {
+        expect(find([payment({ amount: '-10000' })])).not.toBeNull();
+    });
+
+    it('reads the address from the flat field as well as the onchain object', () => {
+        expect(find([{ amount: -10_000, created: NOW - 1000, address: ADDR }])).not.toBeNull();
+    });
+
+    it('is case and whitespace insensitive on the address', () => {
+        expect(find([payment({ onchain: { address: `  ${ADDR.toUpperCase()} ` } })])).not.toBeNull();
+    });
+
+    it('handles a seconds-based timestamp', () => {
+        expect(find([payment({ created: Math.floor((NOW - 60_000) / 1000) })])).not.toBeNull();
+    });
+
+    it('handles an ISO timestamp', () => {
+        expect(find([payment({ created: new Date(NOW - 60_000).toISOString() })])).not.toBeNull();
+    });
+
+    it('matches when the timestamp is unusable, erring toward blocking', () => {
+        // A false positive costs a confirmation tap. A false negative costs the
+        // user the money.
+        expect(find([payment({ created: 'not a date' })])).not.toBeNull();
+        expect(find([payment({ created: null })])).not.toBeNull();
+    });
+});
+
+describe('what must NOT be treated as a duplicate', () => {
+    it('a payment to a different address', () => {
+        expect(find([payment({ onchain: { address: OTHER } })])).toBeNull();
+    });
+
+    it('a different amount to the same address', () => {
+        // Address alone would flag a legitimate second payment to the same
+        // destination.
+        expect(find([payment({ amount: -9_999 })])).toBeNull();
+    });
+
+    it('the same payment from outside the window', () => {
+        expect(find([payment({ created: NOW - WITHDRAW_DUPLICATE_WINDOW_MS - 1 })])).toBeNull();
+    });
+
+    it('an empty or missing history', () => {
+        expect(find([])).toBeNull();
+        expect(findRecentMatchingWithdrawal(null, { address: ADDR, amountSats: 1, now: NOW })).toBeNull();
+        expect(findRecentMatchingWithdrawal(undefined, { address: ADDR, amountSats: 1, now: NOW })).toBeNull();
+    });
+
+    it('records with no amount at all', () => {
+        expect(find([{ onchain: { address: ADDR }, created: NOW }])).toBeNull();
+    });
+
+    it('does not crash on malformed records', () => {
+        expect(() => find([null as any, {} as any, { onchain: null } as any, payment()])).not.toThrow();
+        expect(find([null as any, {} as any, payment()])).not.toBeNull();
+    });
+});
+
+describe('unknown outcomes are not failures', () => {
+    it.each([
+        'Network request failed',
+        'The request timed out',
+        'Aborted',
+        'socket hang up',
+        'ECONNRESET',
+        'Failed to fetch',
+    ])('treats %p as network-shaped, so the outcome is unknown', (msg) => {
+        expect(isNetworkShapedFailure(new Error(msg))).toBe(true);
+    });
+
+    it('does not treat a server rejection as unknown', () => {
+        // CoinOS answered, so nothing was sent. Retrying is safe here.
+        expect(isNetworkShapedFailure(new Error('Insufficient funds'))).toBe(false);
+        expect(isNetworkShapedFailure(new Error('invalid address'))).toBe(false);
+    });
+
+    it('flags an indeterminate error so callers can branch on a marker', () => {
+        const e = markWithdrawIndeterminate('may have been sent');
+        expect(isCoinosWithdrawIndeterminate(e)).toBe(true);
+    });
+
+    it.each([null, undefined, 'string', {}, new Error('ordinary')])(
+        'is not indeterminate for %p',
+        (v) => {
+            expect(isCoinosWithdrawIndeterminate(v)).toBe(false);
+        },
+    );
+
+    it('is not satisfied by a truthy-but-not-true marker', () => {
+        expect(isCoinosWithdrawIndeterminate({ coinosWithdrawIndeterminate: 'yes' })).toBe(false);
+    });
+});
+
+describe('the double-send scenario, end to end', () => {
+    it('the retry after a lost reply is caught by the history check', () => {
+        // First attempt: reply lost, so the app cannot know it succeeded.
+        const err = markWithdrawIndeterminate('unknown');
+        expect(isCoinosWithdrawIndeterminate(err)).toBe(true);
+
+        // CoinOS did send it, so it is in the history.
+        const history = [payment({ created: NOW - 5_000 })];
+
+        // The retry is blocked before any second request is made.
+        expect(find(history)).not.toBeNull();
+    });
+});

--- a/tests/unit/exitFundingCoinos.test.ts
+++ b/tests/unit/exitFundingCoinos.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Funding the exit-fee reserve from CoinOS.
+ *
+ * The two orderings under test are the ones that silently undo the whole point
+ * if they are wrong: the reserve must be armed BEFORE the send, or auto-board
+ * sweeps the sats back into Ark when they confirm, and the duplicate check must
+ * happen BEFORE the send, or a retry after a lost reply pays twice.
+ */
+
+import { fundExitFeesFromCoinos } from '../../src/services/ark/exitFundingCoinos';
+import { markWithdrawIndeterminate } from '../../src/services/coinos/withdrawGuard';
+
+const ADDR = 'bc1qdph4zqqkvf72nd6uz87q2c5hw9tzapfnkmq93c';
+const NOW = 1_700_000_000_000;
+
+function deps(over: Partial<Parameters<typeof fundExitFeesFromCoinos>[1]> = {}) {
+    const calls: string[] = [];
+    const base = {
+        calls,
+        getOnchainAddress: jest.fn(async () => {
+            calls.push('address');
+            return ADDR;
+        }),
+        getRecentPayments: jest.fn(async () => {
+            calls.push('history');
+            return { payments: [] };
+        }),
+        estimateFeeSats: jest.fn(async () => {
+            calls.push('fee');
+            return 300;
+        }),
+        send: jest.fn(async () => {
+            calls.push('send');
+            return JSON.stringify({ txid: 'abc123' });
+        }),
+        armReserve: jest.fn(() => {
+            calls.push('arm');
+        }),
+        now: () => NOW,
+    };
+    return { ...base, ...over } as any;
+}
+
+const req = (over: Record<string, unknown> = {}) => ({
+    shortfallSats: 14_504,
+    availableSats: 50_000,
+    idempotencyKey: 'cbx-test-key',
+    ...over,
+});
+
+describe('the happy path', () => {
+    it('sends the shortfall and reports the txid', async () => {
+        const d = deps();
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res).toMatchObject({ ok: true, txid: 'abc123', sentSats: 14_504, partial: false });
+    });
+
+    it('sends to Bark own on-chain address with the idempotency key', async () => {
+        const d = deps();
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.send).toHaveBeenCalledWith(ADDR, 14_504, 'cbx-test-key');
+    });
+});
+
+describe('ordering that must not change', () => {
+    it('arms the reserve BEFORE sending', async () => {
+        // Otherwise sync.ts boards the sats into Ark the moment they confirm,
+        // undoing the top-up the user just paid for.
+        const d = deps();
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.calls.indexOf('arm')).toBeLessThan(d.calls.indexOf('send'));
+    });
+
+    it('checks history BEFORE sending', async () => {
+        const d = deps();
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.calls.indexOf('history')).toBeLessThan(d.calls.indexOf('send'));
+    });
+
+    it('never lowers a reserve the user already set higher', async () => {
+        const d = deps();
+        await fundExitFeesFromCoinos(req({ currentReserveSats: 100_000 }), d);
+        const armed = d.armReserve.mock.calls[0][0];
+        expect(armed).toBeGreaterThanOrEqual(100_000);
+    });
+});
+
+describe('duplicate protection', () => {
+    it('refuses when a matching top-up already went out', async () => {
+        const d = deps({
+            getRecentPayments: async () => ({
+                payments: [{ amount: -14_504, created: NOW - 5_000, onchain: { address: ADDR } }],
+            }),
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res).toMatchObject({ ok: false, duplicate: true });
+        expect(d.send).not.toHaveBeenCalled();
+    });
+
+    it('still sends when history cannot be read', async () => {
+        // Not being able to read history is not evidence of a duplicate, and
+        // refusing there would strand a user mid-exit.
+        const d = deps({
+            getRecentPayments: async () => {
+                throw new Error('Network request failed');
+            },
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(true);
+        expect(d.send).toHaveBeenCalled();
+    });
+});
+
+describe('failures', () => {
+    it('surfaces an unknown outcome without claiming failure', async () => {
+        const d = deps({
+            send: async () => {
+                throw markWithdrawIndeterminate('may already have been sent');
+            },
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res).toMatchObject({ ok: false, indeterminate: true });
+    });
+
+    it('leaves the reserve armed after an unknown outcome', async () => {
+        // If the send DID go through, the sats must not be boarded away when
+        // they land. Disarming here would be the worst possible response.
+        const d = deps({
+            send: async () => {
+                throw markWithdrawIndeterminate('unknown');
+            },
+        });
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.armReserve).toHaveBeenCalled();
+    });
+
+    it('reports a plain server refusal as itself', async () => {
+        const d = deps({ send: async () => 'insufficient funds' });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(false);
+        // Must NOT be flagged indeterminate: the server answered, so nothing
+        // was sent and retrying is safe.
+        expect(res.ok === false && res.indeterminate).toBeFalsy();
+        expect(res.ok === false && res.reason).toMatch(/insufficient funds/i);
+    });
+
+    it('refuses when the balance cannot cover the fee', async () => {
+        const d = deps({ estimateFeeSats: async () => 900 });
+        const res = await fundExitFeesFromCoinos(req({ availableSats: 1_100 }), d);
+        expect(res.ok).toBe(false);
+        expect(d.send).not.toHaveBeenCalled();
+    });
+
+    it('does not send when there is no address', async () => {
+        const d = deps({ getOnchainAddress: async () => '' });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(false);
+        expect(d.send).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with fee 0 when the estimate fails', async () => {
+        // A missing estimate must not block funding; CoinOS charges what it
+        // charges either way.
+        const d = deps({
+            estimateFeeSats: async () => {
+                throw new Error('estimate unavailable');
+            },
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(true);
+    });
+});
+
+describe('partial funding', () => {
+    it('sends what fits and flags it as partial', async () => {
+        const d = deps();
+        const res = await fundExitFeesFromCoinos(req({ availableSats: 5_000 }), d);
+        expect(res).toMatchObject({ ok: true, partial: true, sentSats: 4_700 });
+    });
+});

--- a/tests/unit/exitFundingPlan.test.ts
+++ b/tests/unit/exitFundingPlan.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Sizing a top-up of the exit-fee reserve.
+ *
+ * Wrong in either direction is expensive: too little leaves the exit stalled
+ * after the user believes they fixed it, too much strips a wallet they still
+ * need. The subtlety is that the miner fee comes off the top, so a wallet
+ * holding exactly the shortfall cannot deliver the shortfall.
+ */
+
+import { planExitFunding } from '../../src/services/ark/exitFundingPlan';
+import { MIN_USEFUL_FUNDING_SATS } from '../../src/services/ark/exitFundingSources';
+
+const plan = (over: Partial<Parameters<typeof planExitFunding>[0]> = {}) =>
+    planExitFunding({ shortfallSats: 14_504, availableSats: 50_000, feeSats: 300, ...over });
+
+describe('the ordinary case', () => {
+    it('sends exactly the shortfall when the source can cover it', () => {
+        const p = plan();
+        expect(p).toMatchObject({ ok: true, sendSats: 14_504, partial: false });
+    });
+
+    it('reports the total leaving the wallet, fee included', () => {
+        // What lands and what leaves are different numbers, and the confirm
+        // screen has to show both or the user is surprised by the difference.
+        const p = plan();
+        expect(p.ok && p.totalCostSats).toBe(14_804);
+    });
+});
+
+describe('the fee comes off the top', () => {
+    it('cannot deliver the shortfall from a wallet holding exactly it', () => {
+        // The trap. 14,504 available against a 14,504 shortfall lands only
+        // 14,204 once the fee is paid.
+        const p = plan({ availableSats: 14_504, feeSats: 300 });
+        expect(p).toMatchObject({ ok: true, partial: true });
+        expect(p.ok && p.sendSats).toBe(14_204);
+    });
+
+    it('spends the whole balance on a partial top-up', () => {
+        const p = plan({ availableSats: 5_000, feeSats: 300 });
+        expect(p.ok && p.sendSats).toBe(4_700);
+        expect(p.ok && p.totalCostSats).toBe(5_000);
+    });
+
+    it('covers the shortfall exactly when the balance leaves room for the fee', () => {
+        const p = plan({ availableSats: 14_804, feeSats: 300 });
+        expect(p).toMatchObject({ ok: true, sendSats: 14_504, partial: false });
+    });
+});
+
+describe('refusing to send', () => {
+    it('will not send when the fee eats almost everything', () => {
+        const p = plan({ availableSats: 1_200, feeSats: 300 });
+        expect(p.ok).toBe(false);
+    });
+
+    it('names the fee rather than claiming an insufficient balance', () => {
+        // "Insufficient balance" reads as a lie to someone looking at a balance
+        // bigger than the amount they typed.
+        const p = plan({ availableSats: 1_100, feeSats: 900 });
+        expect(p.ok === false && p.reason).toMatch(/900/);
+        expect(p.ok === false && p.reason).toMatch(/network fee/i);
+    });
+
+    it('refuses when the reserve is already funded', () => {
+        const p = plan({ shortfallSats: 0 });
+        expect(p.ok).toBe(false);
+        expect(p.ok === false && p.reason).toMatch(/already funded/i);
+    });
+
+    it('refuses at one sat under the useful floor', () => {
+        const p = plan({ availableSats: MIN_USEFUL_FUNDING_SATS - 1, feeSats: 0 });
+        expect(p.ok).toBe(false);
+    });
+
+    it('accepts exactly at the floor', () => {
+        const p = plan({ availableSats: MIN_USEFUL_FUNDING_SATS, feeSats: 0, shortfallSats: 99_999 });
+        expect(p.ok).toBe(true);
+    });
+});
+
+describe('an unreadable balance', () => {
+    it('plans the full shortfall rather than refusing', () => {
+        // A balance that failed to load is not a balance of zero. Refusing here
+        // would strand a user whose network hiccuped on the balance call; the
+        // provider will reject the send if the funds really are not there.
+        const p = plan({ availableSats: null });
+        expect(p).toMatchObject({ ok: true, sendSats: 14_504, partial: false });
+    });
+});
+
+describe('junk input', () => {
+    it('does not produce a negative or fractional send', () => {
+        const p = plan({ availableSats: 20_000.7, feeSats: 12.9, shortfallSats: 10_000.4 });
+        expect(p.ok && Number.isInteger(p.sendSats)).toBe(true);
+        expect(p.ok && p.sendSats).toBeGreaterThan(0);
+    });
+
+    it('treats a negative balance as empty', () => {
+        expect(plan({ availableSats: -500 }).ok).toBe(false);
+    });
+
+    it('tolerates a NaN fee', () => {
+        const p = plan({ feeSats: Number.NaN });
+        expect(p.ok).toBe(true);
+    });
+});

--- a/tests/unit/exitFundingSources.test.ts
+++ b/tests/unit/exitFundingSources.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The "fund exit fees from another wallet" source list.
+ *
+ * Two rules carry most of the value here and neither is obvious from the UI:
+ * unavailable sources are still listed with a reason rather than hidden, and
+ * Cold Vault is always last because it needs a hardware signing round-trip.
+ */
+
+import {
+    MIN_USEFUL_FUNDING_SATS,
+    buildExitFundingSources,
+    hasUsableExitFundingSource,
+} from '../../src/services/ark/exitFundingSources';
+
+const connected = (balanceSats: number) => ({ connected: true, balanceSats });
+const vaultWith = (balanceSats: number) => ({ walletID: 'w'.repeat(64), balanceSats });
+
+const ALL_READY = {
+    coinos: connected(50_000),
+    strike: connected(50_000),
+    hotVault: vaultWith(50_000),
+    coldVault: vaultWith(50_000),
+};
+
+describe('ordering', () => {
+    it('puts custodial wallets first and Cold Vault last', () => {
+        // Cold Vault needs a PSBT round-trip through an airgapped signer, so it
+        // must never sit next to Hot Vault as an equal-looking choice.
+        expect(buildExitFundingSources(ALL_READY).map((s) => s.id)).toEqual([
+            'coinos',
+            'strike',
+            'hot-vault',
+            'cold-vault',
+        ]);
+    });
+
+    it('keeps Cold Vault last even when it is the only funded source', () => {
+        const ids = buildExitFundingSources({ coldVault: vaultWith(50_000) }).map((s) => s.id);
+        expect(ids[ids.length - 1]).toBe('cold-vault');
+    });
+
+    it('flags Cold Vault as slow and nothing else', () => {
+        const sources = buildExitFundingSources(ALL_READY);
+        expect(sources.find((s) => s.id === 'cold-vault')?.slow).toBe(true);
+        expect(sources.filter((s) => s.slow).map((s) => s.id)).toEqual(['cold-vault']);
+    });
+});
+
+describe('every source is listed, even when unusable', () => {
+    it('returns all four with an empty state', () => {
+        // Hiding them makes the feature look broken. Showing them with a reason
+        // teaches the user what to fix.
+        const sources = buildExitFundingSources();
+        expect(sources).toHaveLength(4);
+        expect(sources.every((s) => !s.available)).toBe(true);
+    });
+
+    it('says why a custodial wallet cannot be used', () => {
+        const s = buildExitFundingSources({ coinos: { connected: false } });
+        expect(s.find((x) => x.id === 'coinos')?.unavailableReason).toMatch(/not connected/i);
+    });
+
+    it('says why a vault cannot be used', () => {
+        const s = buildExitFundingSources({ hotVault: { walletID: null } });
+        expect(s.find((x) => x.id === 'hot-vault')?.unavailableReason).toMatch(/no vault/i);
+    });
+
+    it('names the floor rather than saying "insufficient"', () => {
+        // "Insufficient balance" leaves the user guessing how much is enough.
+        const s = buildExitFundingSources({ coinos: connected(MIN_USEFUL_FUNDING_SATS - 1) });
+        expect(s.find((x) => x.id === 'coinos')?.unavailableReason).toContain(
+            MIN_USEFUL_FUNDING_SATS.toLocaleString(),
+        );
+    });
+
+    it('marks a drained vault as having no spendable capsules', () => {
+        const s = buildExitFundingSources({ hotVault: vaultWith(0) });
+        const hot = s.find((x) => x.id === 'hot-vault');
+        expect(hot?.available).toBe(false);
+        expect(hot?.unavailableReason).toMatch(/no spendable capsules/i);
+    });
+});
+
+describe('availability', () => {
+    it('accepts a connected wallet at exactly the floor', () => {
+        const s = buildExitFundingSources({ coinos: connected(MIN_USEFUL_FUNDING_SATS) });
+        expect(s.find((x) => x.id === 'coinos')?.available).toBe(true);
+    });
+
+    it('offers a source that cannot cover the whole shortfall', () => {
+        // Partial funding is still progress: it may be the difference between a
+        // stalled exit and a finished one.
+        const s = buildExitFundingSources({
+            coinos: connected(5_000),
+            shortfallSats: 14_504,
+        });
+        expect(s.find((x) => x.id === 'coinos')?.available).toBe(true);
+    });
+
+    it('treats an unknown balance as usable rather than blocking', () => {
+        // A balance we could not read is not the same as a balance of zero, and
+        // refusing on a failed read would strand the user.
+        const s = buildExitFundingSources({ strike: { connected: true, balanceSats: null } });
+        expect(s.find((x) => x.id === 'strike')?.available).toBe(true);
+    });
+
+    it('ignores a nonsense balance instead of crashing', () => {
+        const s = buildExitFundingSources({
+            coinos: { connected: true, balanceSats: Number.NaN },
+            hotVault: { walletID: 'x'.repeat(64), balanceSats: -5 },
+        });
+        expect(s.find((x) => x.id === 'coinos')?.available).toBe(true);
+        expect(s.find((x) => x.id === 'hot-vault')?.available).toBe(true);
+    });
+
+    it('reports balances for the ones it could read', () => {
+        const s = buildExitFundingSources({ coinos: connected(42_000) });
+        expect(s.find((x) => x.id === 'coinos')?.balanceSats).toBe(42_000);
+    });
+});
+
+describe('hasUsableExitFundingSource', () => {
+    it('is false when nothing is connected, so the caller can fall back', () => {
+        // The caller shows the receive-an-address path instead, which is the
+        // one that always works.
+        expect(hasUsableExitFundingSource(buildExitFundingSources())).toBe(false);
+    });
+
+    it('is true when any single source works', () => {
+        expect(
+            hasUsableExitFundingSource(buildExitFundingSources({ strike: connected(20_000) })),
+        ).toBe(true);
+    });
+});


### PR DESCRIPTION
## The bug

A CoinOS on-chain withdrawal that timed out mid-flight reported "Please try again" and re-armed the
button. The withdrawal had usually gone through. The UI was instructing a double-send of the user's
own money.

A network timeout is not a failure, it is an unknown. `withdrawGuard.ts` now treats it as such:
the request carries an idempotency key, a timeout leaves the button disarmed, and the outcome is
resolved by re-reading state rather than by guessing from the transport error.

## The feature

An emergency exit needs an on-chain fee reserve, and until now the only way to top it up was to
already have on-chain funds in the vault. This adds funding that reserve from another wallet:

* `exitFundingSources.ts`, which wallets can pay and how much each can cover
* `exitFundingPlan.ts`, the amount and fee planner
* `exitFundingCoinos.ts`, the CoinOS provider (Strike and Hot Vault are next, the picker takes them)
* `ExitFundingSourceList` and `ArkExitFundingConfirmScreen`, the picker and confirm step
* a "From a wallet" tab on the funding sheet

## Verification

* 40 suites, 323 tests green, including 4 new files (575 lines) covering the guard, the planner,
  the source list and the CoinOS provider
* `tsc` error set byte-identical to `origin/main` (405 errors, 19 TS2304), no regressions