### PR TITLE
fix(ark): let users see and fund the exit-fee reserve during an exit

### DIFF
--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -20,6 +20,27 @@ import {
 } from '@Cypher/api/coinOSApis';
 
 /**
+ * Preparing the deposit needs bark's on-chain (BDK) wallet, and spawning that
+ * hits an esplora endpoint. `ensureArkOnchainHandle` has no timeout of its own,
+ * so a provider that accepts the connection and then never answers hangs this
+ * screen forever with no error. Bound it here rather than leave the user on a
+ * spinner that can never resolve.
+ */
+const PREPARE_TIMEOUT_MS = 20_000;
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+    return Promise.race([
+        p,
+        new Promise<T>((_, reject) =>
+            setTimeout(
+                () => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s`)),
+                ms,
+            ),
+        ),
+    ]);
+}
+
+/**
  * Confirm screen for topping up the exit-fee reserve from another wallet.
  *
  * Everything that decides an outcome lives in services/ark/exitFundingCoinos
@@ -65,6 +86,9 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
     const [feeSats, setFeeSats] = useState<number | null>(null);
     const [loading, setLoading] = useState(true);
     const [sending, setSending] = useState(false);
+    // Why preparation failed, if it did. Distinct from a plan that simply is
+    // not fundable: this one means we never got far enough to compute a plan.
+    const [prepError, setPrepError] = useState<string | null>(null);
     // Latched once an outcome becomes unknown. Never cleared: the point is that
     // this screen must not offer to send again. Mirrors the Ark send review.
     const [indeterminate, setIndeterminate] = useState(false);
@@ -79,11 +103,19 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         let cancelled = false;
         (async () => {
             try {
-                const addr = await getArkOnchainAddress();
+                const addr = await withTimeout(
+                    getArkOnchainAddress(),
+                    PREPARE_TIMEOUT_MS,
+                    'Preparing the deposit address',
+                );
                 if (cancelled) return;
                 setAddress(addr);
                 try {
-                    const raw = await bitcoinSendFee(shortfallSats, addr, 0);
+                    const raw = await withTimeout(
+                        bitcoinSendFee(shortfallSats, addr, 0),
+                        PREPARE_TIMEOUT_MS,
+                        'Estimating the network fee',
+                    );
                     const parsed =
                         typeof raw === 'string' && raw.trim().startsWith('{')
                             ? JSON.parse(raw)
@@ -96,10 +128,13 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                 }
             } catch (err: any) {
                 if (!cancelled) {
-                    SimpleToast.show(
-                        `Could not prepare the top-up: ${err?.message ?? 'unknown error'}`,
-                        SimpleToast.LONG,
-                    );
+                    const msg = err?.message ?? 'unknown error';
+                    // Show it ON the screen, not only as a toast that vanishes.
+                    // The deposit address comes from the on-chain wallet, so the
+                    // usual cause is the chain source being unreachable, which
+                    // the user can often fix by changing network.
+                    setPrepError(msg);
+                    SimpleToast.show(`Could not prepare the top-up: ${msg}`, SimpleToast.LONG);
                 }
             } finally {
                 if (!cancelled) setLoading(false);
@@ -119,6 +154,20 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
             }),
         [shortfallSats, availableSats, feeSats],
     );
+
+    // Reasons the swipe can never succeed, as opposed to "not yet". Ordered so
+    // the most specific wins: an indeterminate send outranks a bad plan.
+    const blockedReason: string | null = loading
+        ? null
+        : indeterminate
+          ? `This top-up may already have been sent. Check your ${sourceLabel} history before trying again.`
+          : prepError
+            ? 'Cannot continue until the deposit address is available.'
+            : sourceId !== 'coinos'
+              ? `Funding from ${sourceLabel} is not available yet.`
+              : !plan.ok
+                ? plan.reason
+                : null;
 
     const fiat = (sats: number) =>
         rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
@@ -197,6 +246,30 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                     <ActivityIndicator color={colors.pink.default} style={{ marginTop: 40 }} />
                 ) : (
                     <>
+                        {prepError && (
+                            <View
+                                style={{
+                                    marginTop: 12,
+                                    padding: 14,
+                                    borderRadius: 12,
+                                    borderWidth: 1,
+                                    borderColor: '#FF8A80',
+                                    backgroundColor: '#1a1a1a',
+                                }}
+                            >
+                                <Text bold style={{ fontSize: 14, color: '#FF8A80', marginBottom: 6 }}>
+                                    Could not prepare the top-up
+                                </Text>
+                                <Text style={{ fontSize: 12, color: '#DDD', lineHeight: 17 }}>
+                                    {prepError}
+                                </Text>
+                                <Text style={{ fontSize: 12, color: '#888', lineHeight: 17, marginTop: 8 }}>
+                                    The deposit address comes from the on-chain wallet, which needs a
+                                    reachable chain source. Changing network often clears this. Go back
+                                    and reopen this screen to retry.
+                                </Text>
+                            </View>
+                        )}
                         <GradientCard disabled style={{ marginTop: 12 }}>
                             <View style={{ padding: 16 }}>
                                 <Row label="From" value={sourceLabel} />
@@ -243,23 +316,40 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                             Emergency Exit unlocks once the deposit confirms.
                         </Text>
 
-                        {indeterminate && (
-                            <Text style={{ fontSize: 12, color: '#FF8A80', marginTop: 12, lineHeight: 17 }}>
-                                This top-up may already have been sent. Check your {sourceLabel}{' '}
-                                history before trying again.
-                            </Text>
-                        )}
                     </>
                 )}
             </View>
 
             <View style={{ paddingHorizontal: 20, paddingBottom: 20 }}>
-                <SwipeButton
-                    title="Slide to Fund"
-                    ref={swipeRef}
-                    onToggle={onConfirm}
-                    isLoading={sending || loading || !plan.ok || indeterminate || sourceId !== 'coinos'}
-                />
+                {blockedReason ? (
+                    // SwipeButton only knows `isLoading`, and that renders a
+                    // spinner captioned "Please wait". Feeding a permanent
+                    // condition (no fundable plan, unsupported source, latched
+                    // indeterminate) into it told the user we were working on
+                    // something that was never going to happen: observed on
+                    // device as an endless "Please wait" with no explanation.
+                    // A blocked state is not a busy state, so say which it is.
+                    <View
+                        style={{
+                            padding: 16,
+                            borderRadius: 12,
+                            backgroundColor: '#1a1a1a',
+                            borderWidth: 1,
+                            borderColor: '#333',
+                        }}
+                    >
+                        <Text style={{ fontSize: 13, color: '#FFD54F', lineHeight: 18 }}>
+                            {blockedReason}
+                        </Text>
+                    </View>
+                ) : (
+                    <SwipeButton
+                        title="Slide to Fund"
+                        ref={swipeRef}
+                        onToggle={onConfirm}
+                        isLoading={sending || loading}
+                    />
+                )}
             </View>
         </ScreenLayout>
     );

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -124,18 +124,37 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
     if (selectedItem === 5) {
       let mounted = true;
       void (async () => {
-        try {
-          const [arkAddr, onchainAddr] = await Promise.all([
-            getArkAddress(),
-            getArkOnchainAddress(),
-          ]);
-          if (!mounted) return;
-          setArkAddress(arkAddr);
-          setArkOnchainAddress(onchainAddr);
-        } catch (err) {
-          if (!mounted) return;
-          console.warn('[Receive] Ark address fetch failed:', err);
-          SimpleToast.show('Failed to fetch Ark addresses', SimpleToast.SHORT);
+        // allSettled, NOT all. These are independent: the Ark address needs
+        // the Ark wallet, the on-chain address is a local BDK call. Promise.all
+        // discarded BOTH when either failed, so a locked wallet threw away a
+        // perfectly good on-chain address and left the sheet spinning on null
+        // state. That is how funding an exit became impossible: the on-chain
+        // address is the ASP-independent way in, and it was collateral damage
+        // from the Ark address failing.
+        const [arkRes, onchainRes] = await Promise.allSettled([
+          getArkAddress(),
+          getArkOnchainAddress(),
+        ]);
+        if (!mounted) return;
+        if (arkRes.status === 'fulfilled') setArkAddress(arkRes.value);
+        if (onchainRes.status === 'fulfilled') setArkOnchainAddress(onchainRes.value);
+
+        if (arkRes.status === 'rejected' || onchainRes.status === 'rejected') {
+          const reason = (arkRes.status === 'rejected' ? arkRes.reason : null)
+            ?? (onchainRes.status === 'rejected' ? onchainRes.reason : null);
+          console.warn('[Receive] Ark address fetch failed:', reason);
+          // Name the actual cause. "Failed to fetch Ark addresses" next to a
+          // spinner that never stops tells the user nothing they can act on,
+          // and the usual cause is simply that the wallet is not open yet.
+          const locked = /not initialized|not ready|no wallet/i.test(
+            String((reason as Error)?.message ?? reason ?? ''),
+          );
+          SimpleToast.show(
+            locked
+              ? 'Bark vault is locked. Open the vault first, then try again.'
+              : 'Could not fetch an address. Pull to retry.',
+            SimpleToast.LONG,
+          );
         }
       })();
       return () => {

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1026,6 +1026,13 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     };
   }, [exitFundingOpen]);
 
+  // Convert is unavailable mid-exit (cooperative offboard, ASP-gated), and its
+  // tab button disappears. If that was the selected tab the sheet would render
+  // nothing at all, so fall back to the path that always works.
+  useEffect(() => {
+    if (arkExitInProgress && fundingTab === 'convert') setFundingTab('receive');
+  }, [arkExitInProgress, fundingTab]);
+
   // Debounced fee estimate for the CONVERT tab. Skipped when the ASP is known
   // unreachable (the offboard would fail) or the amount is empty/invalid.
   useEffect(() => {
@@ -1926,6 +1933,38 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 Started {new Date(arkExitStartedAt).toLocaleString()}. Funds sweep to the destination when the timelock expires; the vault stays afterwards.
               </Text>
             )}
+
+            {/* FEE RESERVE, DURING THE EXIT.
+                Previously this whole section was replaced by the panel above,
+                so the one moment the reserve matters most was the one moment
+                the user could neither see it nor top it up. Worse, the panel
+                promises funds sweep automatically while removing the means to
+                make that true: every exit branch needs a CPFP broadcast and
+                every claim needs a fee, and running dry strands capsules
+                mid-exit until someone tops up.
+                Observed live 2026-08-18 on a five-capsule exit that ran out at
+                699 sats with four claims still owed.
+                The receive path is ASP-independent, so it works during an
+                outage, which is exactly when an exit is running. */}
+            <View style={{ marginTop: 14, paddingTop: 12, borderTopWidth: 1, borderTopColor: '#2A2A2A' }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text style={{ fontSize: 12, color: '#AAA' }}>Fee reserve on-chain</Text>
+                <Text bold style={{ fontSize: 13, color: onchainReserveSats > 0 ? colors.green : '#FFD54F' }}>
+                  {onchainReserveSats.toLocaleString()} sats
+                </Text>
+              </View>
+              <Text style={{ fontSize: 11, color: '#777', marginTop: 6, lineHeight: 15 }}>
+                Pays the miner fees for each capsule's exit and claim. If it runs
+                out, the remaining capsules wait until you top it up.
+              </Text>
+              <TouchableOpacity
+                onPress={() => setExitFundingOpen(true)}
+                activeOpacity={0.7}
+                style={{ marginTop: 10, paddingVertical: 10, borderRadius: 10, alignItems: 'center', backgroundColor: 'rgba(255,255,255,0.08)' }}
+              >
+                <Text bold style={{ fontSize: 13, color: '#FFF' }}>Top up exit fees</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         ) : (
           <>
@@ -2478,7 +2517,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
 
               {/* Tab switch */}
               <View style={{ flexDirection: 'row', marginBottom: 14, borderRadius: 10, backgroundColor: '#222', padding: 3 }}>
-                {(['receive', 'wallet', 'convert'] as const).map((tab) => {
+                {((arkExitInProgress
+                  ? (['receive', 'wallet'] as const)
+                  : (['receive', 'wallet', 'convert'] as const)) as readonly ('receive' | 'wallet' | 'convert')[]).map((tab) => {
                   const active = fundingTab === tab;
                   return (
                     <TouchableOpacity


### PR DESCRIPTION
Stacked on #182. Base is `fix/coinos-withdraw-idempotency`, so the diff here is the single commit
`54bfd1e`. GitHub will retarget this to `main` automatically when #182 merges.

## The bug

While an exit was running, the red "Emergency exit in progress" panel REPLACED the exit-funding UI.
The fee reserve could be neither seen nor topped up at the exact moment it matters, which is the
moment the exit is spending it. If the reserve ran dry mid-exit there was no in-app way to refill it.

The panel and the funding section now coexist.

## Also here

`Promise.all` becomes `Promise.allSettled` in the receive sheet. A failing Ark address was
discarding a perfectly good on-chain address alongside it and leaving a permanent spinner, so a
half-down backend took out the whole receive screen.

## Verification

* 40 suites, 323 tests green
* `tsc` error set byte-identical to `origin/main` (405 errors, 19 TS2304)