### PR TITLE
fix(ark): say which side of the network is down instead of pasting the SDK error

### DIFF
--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -5,7 +5,13 @@ import SimpleToast from "react-native-simple-toast";
 import { ScreenLayout } from "@Cypher/component-library";
 import { CustomKeyboard, GradientInput } from "@Cypher/components";
 import { getStrikeCurrency, SATS } from "@Cypher/helpers/coinosHelper";
-import { createArkLightningInvoice } from "@Cypher/services/ark";
+import {
+    ARK_SERVER_URL,
+    ESPLORA_URLS,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+    createArkLightningInvoice,
+} from "@Cypher/services/ark";
 import { colors } from "@Cypher/style-guide";
 
 import styles from "./styles";
@@ -97,8 +103,21 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
             });
         } catch (err) {
             console.error("Ark invoice creation failed:", err);
+            // Minting an invoice needs the Ark server, so this fails whenever
+            // the ASP is unreachable. Naming the side that is down beats
+            // pasting a raw SDK string, and it decides whether "try mobile
+            // data" is useful advice or a waste of the user's time. Falls back
+            // to the raw message when the cause is not recognisable.
+            const faultMsg = arkNetworkFaultMessage(
+                classifyArkNetworkFault(err, {
+                    chainUrls: ESPLORA_URLS,
+                    arkUrl: ARK_SERVER_URL,
+                }),
+            );
             SimpleToast.show(
-                `Failed to create Ark invoice: ${(err as Error)?.message ?? "unknown error"}`,
+                faultMsg
+                    ? `Could not create the invoice. ${faultMsg}`
+                    : `Failed to create Ark invoice: ${(err as Error)?.message ?? "unknown error"}`,
                 SimpleToast.LONG,
             );
         } finally {

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -8,6 +8,7 @@ export {
     ARK_EXIT_RUNWAY_HOURS,
     ARK_SWEEP_MAX_RUNWAY_HOURS,
     ESPLORA_URL,
+    ESPLORA_URLS,
     createArkConfig,
 } from './config';
 
@@ -209,3 +210,10 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export {
+    arkErrorText,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+} from './networkFault';
+export type { ArkNetworkFault } from './networkFault';

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -1,0 +1,99 @@
+/**
+ * Which side of the network is unreachable, and what to tell the user.
+ *
+ * The Bark Vault talks to two independent services and a failure in either
+ * surfaces to the user as the same shrug of a raw SDK error string. They need
+ * opposite responses:
+ *
+ *   - CHAIN SOURCE (esplora): the wallet cannot read the chain. Observed on
+ *     device when Blockstream served its Cloudflare bot-block page and
+ *     mempool.space TCP-timed out from the same Wi-Fi, while both answered
+ *     instantly from a browser on the same network. Switching to mobile data
+ *     fixed it. So here, suggesting a network change is genuinely useful.
+ *
+ *   - ARK SERVER (the ASP): rounds, sends and Lightning invoices need it.
+ *     Changing network will not help if the server itself is down, and telling
+ *     someone to fiddle with Wi-Fi while their funds look stuck is worse than
+ *     saying nothing. What matters here is the reassurance: the unilateral exit
+ *     does not need this server.
+ *
+ * DISCRIMINATION IS BY HOSTNAME, deliberately. The tempting shortcut, matching
+ * `BarkError.ServerConnection`, is wrong: our own config notes that exact tag
+ * appearing for an esplora 429 during recovery, so it does not identify a side.
+ * Hostnames do. Phrase matching is only a fallback for errors that name no host.
+ *
+ * Returns 'unknown' rather than guessing. A wrong suggestion (telling someone to
+ * switch networks when the server is down) costs more than no suggestion.
+ */
+
+export type ArkNetworkFault = 'chain-source' | 'ark-server' | 'unknown';
+
+/** Flatten a thrown value into searchable text. BarkError hides detail in `inner`. */
+export function arkErrorText(err: unknown): string {
+    if (err == null) return '';
+    if (typeof err === 'string') return err;
+    const e = err as {
+        tag?: unknown;
+        message?: unknown;
+        inner?: { errorMessage?: unknown; message?: unknown };
+    };
+    return [
+        e.tag,
+        e.message,
+        e.inner?.errorMessage,
+        e.inner?.message,
+    ]
+        .filter((p) => typeof p === 'string')
+        .join(' ');
+}
+
+function hostOf(url: string): string | null {
+    // Deliberately not `new URL()`: it is available in Hermes but throws on the
+    // malformed values that can reach here from user-supplied endpoints, and a
+    // classifier must never throw on the error path.
+    const m = /^[a-z]+:\/\/([^/:?#]+)/i.exec(url.trim());
+    return m ? m[1].toLowerCase() : null;
+}
+
+/** Phrases only ever produced by the chain-data client. */
+const CHAIN_SOURCE_PHRASES =
+    /not a blockhash|failed to parse hex|esplora|chain source|Sync failed/i;
+
+export function classifyArkNetworkFault(
+    err: unknown,
+    endpoints: { chainUrls?: readonly string[]; arkUrl?: string | null } = {},
+): ArkNetworkFault {
+    const text = arkErrorText(err);
+    if (!text) return 'unknown';
+    const haystack = text.toLowerCase();
+
+    // Hostname match first: unambiguous, and survives SDK wording changes.
+    for (const url of endpoints.chainUrls ?? []) {
+        const host = hostOf(url);
+        if (host && haystack.includes(host)) return 'chain-source';
+    }
+    const arkHost = endpoints.arkUrl ? hostOf(endpoints.arkUrl) : null;
+    if (arkHost && haystack.includes(arkHost)) return 'ark-server';
+
+    if (CHAIN_SOURCE_PHRASES.test(text)) return 'chain-source';
+
+    return 'unknown';
+}
+
+/**
+ * User-facing sentence for a fault, or null when we do not know enough to say
+ * anything useful. Callers append this to their own context rather than
+ * replacing it, so the user still learns which action failed.
+ */
+export function arkNetworkFaultMessage(fault: ArkNetworkFault): string | null {
+    switch (fault) {
+        case 'chain-source':
+            return "Can't reach the Bitcoin network data provider. If you're on Wi-Fi, try mobile data, then try again.";
+        case 'ark-server':
+            // No network advice: if the server is down, switching networks
+            // achieves nothing and wastes the user's time.
+            return 'The Ark server is not responding right now. Your funds are safe, and an emergency exit does not need this server.';
+        default:
+            return null;
+    }
+}

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Telling the user which side of the network is unreachable.
+ *
+ * Chain-source failures and Ark-server failures look identical to a user and
+ * need opposite advice. Switching to mobile data genuinely fixed a chain-source
+ * outage on device; suggesting it while the ASP is down is noise at the exact
+ * moment someone thinks their money is stuck.
+ *
+ * Every error string below is one we actually captured on device.
+ */
+
+import {
+    arkErrorText,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+} from '../../src/services/ark/networkFault';
+
+const ENDPOINTS = {
+    chainUrls: ['https://blockstream.info/api', 'https://mempool.space/api'],
+    arkUrl: 'https://ark.second.tech',
+};
+
+const classify = (err: unknown) => classifyArkNetworkFault(err, ENDPOINTS);
+
+describe('chain-source failures', () => {
+    it('recognises the Blockstream bot-block page', () => {
+        // The literal error from the device, typo and all.
+        const err = {
+            tag: 'Inner',
+            message:
+                'Exception.Inner: Failed to create chain source: bad response from server (not a blockhash). Esplora client possibly misconfigured: failed to parse hex: invilad hex string length 338 (expected 64)',
+        };
+        expect(classify(err)).toBe('chain-source');
+    });
+
+    it('recognises the mempool.space TCP timeout by hostname', () => {
+        const err = {
+            tag: 'Inner',
+            message:
+                'Sync failed: Reqwest(reqwest::Error { kind: Request, url: "https://mempool.space/api/scripthash/abc/txs", source: Os { code: 60, kind: TimedOut } })',
+        };
+        expect(classify(err)).toBe('chain-source');
+    });
+
+    it('reads detail out of a BarkError inner payload', () => {
+        const err = { tag: 'ServerConnection', inner: { errorMessage: 'esplora request failed' } };
+        expect(classify(err)).toBe('chain-source');
+    });
+
+    it('suggests switching networks, which is the fix that worked', () => {
+        expect(arkNetworkFaultMessage('chain-source')).toMatch(/mobile data/i);
+    });
+});
+
+describe('ark-server failures', () => {
+    it('recognises the ASP by hostname', () => {
+        const err = { message: 'transport error connecting to https://ark.second.tech' };
+        expect(classify(err)).toBe('ark-server');
+    });
+
+    it('does NOT suggest switching networks', () => {
+        // The whole point of splitting the two. A network switch cannot fix a
+        // server that is down, and the advice wastes the user's time while
+        // their balance looks wrong.
+        const msg = arkNetworkFaultMessage('ark-server');
+        expect(msg).not.toMatch(/wi-?fi|mobile data|cellular/i);
+    });
+
+    it('says the exit does not depend on that server', () => {
+        expect(arkNetworkFaultMessage('ark-server')).toMatch(/exit/i);
+    });
+});
+
+describe('what it refuses to guess', () => {
+    it('does not treat ServerConnection alone as an Ark-server fault', () => {
+        // The tempting shortcut, and wrong: config.ts records that exact tag
+        // appearing for an esplora 429 during recovery. It identifies no side.
+        expect(classify({ tag: 'ServerConnection', message: 'BarkError.ServerConnection' })).toBe('unknown');
+    });
+
+    it('returns unknown for an unrelated failure', () => {
+        expect(classify(new Error('Insufficient balance'))).toBe('unknown');
+    });
+
+    it.each([null, undefined, '', {}])('returns unknown for %p', (v) => {
+        expect(classify(v)).toBe('unknown');
+    });
+
+    it('offers no message when it does not know', () => {
+        // Better silent than misleading: the caller still shows its own
+        // context, so the user is not left with nothing.
+        expect(arkNetworkFaultMessage('unknown')).toBeNull();
+    });
+
+    it('never throws on a malformed endpoint', () => {
+        expect(() =>
+            classifyArkNetworkFault({ message: 'boom' }, { chainUrls: ['not a url', ''], arkUrl: '::::' }),
+        ).not.toThrow();
+    });
+});
+
+describe('arkErrorText', () => {
+    it('flattens tag, message and inner detail together', () => {
+        const t = arkErrorText({ tag: 'Inner', message: 'outer', inner: { errorMessage: 'deep cause' } });
+        expect(t).toContain('outer');
+        expect(t).toContain('deep cause');
+    });
+
+    it('passes a plain string through', () => {
+        expect(arkErrorText('just text')).toBe('just text');
+    });
+
+    it('is empty for a value carrying no text', () => {
+        expect(arkErrorText({ code: 7 })).toBe('');
+    });
+});


### PR DESCRIPTION
The Bark Vault talks to two independent services, and a failure in either reached the user as the
same raw SDK string. They need opposite responses.

A chain-source outage is fixable by the user. Observed on device: Blockstream served its Cloudflare
bot-block page while mempool.space TCP-timed out from the same Wi-Fi, and both answered instantly
from a browser on that network. Switching to mobile data fixed it. Worth suggesting.

An Ark-server outage is not. Changing network achieves nothing if the ASP is down, and telling
someone to fiddle with Wi-Fi while their balance looks stuck wastes their time. What matters there
is that an emergency exit does not need that server, which is now what the message says.

Discrimination is by hostname, deliberately. The tempting shortcut, matching
`BarkError.ServerConnection`, is wrong: `config.ts` already records that exact tag appearing for an
esplora 429 during recovery, so it identifies no side. Phrase matching is a fallback for errors
naming no host, and anything unrecognised returns `unknown` with no message rather than guessing.
A wrong suggestion costs more than no suggestion, so callers keep their own context and only append
ours when we actually know something.

Wired into the Ark Lightning invoice screen first, since minting an invoice needs the ASP and that
is where this was reported from the field. The helper is pure and takes its endpoints as arguments,
so other call sites can adopt it without further plumbing.

18 tests, every error string taken from a real device log, including the two that must NOT produce
network advice.