### PR TITLE
docs(readme): roadmap a user-supplied chain source, and stop hedging on the exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ npm start
 
 * ✅ Bark SDK upgrade (bark 0.6.1): capsules stay spendable while refreshing, dust consolidation, safer exit
 * ⏳ Revive the e2e test suite on RN 0.77
+* ⏳ **Bring your own chain source**: point the Bark Vault at your own esplora endpoint (Umbrel, Start9, self-hosted Electrs) instead of a public block explorer, so your addresses never leave your node. Bitcoin Core RPC to follow. Changing the chain source touches refresh, unilateral exit, backup and recovery, so it ships only after all four are re-tested end to end.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Swap between rails in-app: Lightning ↔ Bark, top-up vaults from Lightning, wit
 ## ⛵ Bark Vault — non-custodial Lightning (Ark protocol)
 
 Read full user guide: https://cypherbox.io/how-to-use-your-bark-vault/
-Your sats live in **lightning capsules (VTXOs)** on Bitcoin mainnet via the [Ark protocol](https://ark-protocol.org) and [Second's Bark SDK](https://gitlab.com/ark-bitcoin/bark). Self-custodial: you can exit to the chain without the server's permission (not completed ⏳).
+Your sats live in **lightning capsules (VTXOs)** on Bitcoin mainnet via the [Ark protocol](https://ark-protocol.org) and [Second's Bark SDK](https://gitlab.com/ark-bitcoin/bark). Self-custodial: you can exit to the chain without the server's permission.
 
 
 * Send & receive over Lightning, receive on Ark addresses, board from on-chain


### PR DESCRIPTION
Two README changes.

**Stop contradicting ourselves on the unilateral exit.** The Bark Vault section claimed you can exit
without the server's permission, then immediately appended "(not completed)". As of today that
qualifier is wrong. A real mainnet exit ran end to end with the Ark server pointed at a dead
endpoint: wallet open, sync, balance, progressExits, CPFP broadcast and the drainExits claim all
worked with no server reachable, and the claim confirmed on-chain. The qualifier is removed.

**Roadmap bring-your-own chain source.** The same run showed the real single point of failure is
esplora, not the ASP. In one hour the device hit five distinct chain-source failures across both
providers (Blockstream 429, Blockstream Cloudflare bot-block, mempool TCP timeout, mempool TLS
truncation). Pointing the vault at your own Umbrel, Start9 or self-hosted Electrs fixes both the
availability problem and the privacy one, since addresses stop leaving your node. Bitcoin Core RPC
to follow.

Scoped honestly: changing the chain source touches refresh, unilateral exit, backup and recovery,
so it ships only after all four are re-tested end to end.