### PR TITLE
fix(ark): price the exit claim explicitly instead of letting bark bid for speed

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -9,6 +9,7 @@ import {
     cancelVtxoExpiryWarnings,
     cancelVtxoStuckSwapWarnings,
     claimArkExitsToAddress,
+    fetchClaimFeeRateSatPerVb,
     getArkCancelling,
     setArkCancelling,
     fetchArkBalance,
@@ -428,9 +429,20 @@ export default function useArkSync(): UseArkSync {
                         // return is NOT proof the funds left, and treating it as
                         // such pinned the exit "active" forever (the claim VTXO
                         // stayed claimable because nothing was ever relayed).
+                        let claimRateForLog = 0;
                         try {
+                            // Price the claim explicitly. Passing undefined lets
+                            // bark pick, and it picks for speed: observed live
+                            // bidding 779 sats to sweep a 698 sat output, which
+                            // it then refuses to build. The claim races nothing
+                            // once the CSV has matured, and its fee comes out of
+                            // the claimed value, so the 1-hour rate is correct
+                            // and "fastest" is actively harmful.
+                            const claimRate = await fetchClaimFeeRateSatPerVb();
+                            claimRateForLog = claimRate;
                             const claim = await claimArkExitsToAddress(
                                 arkExitDestinationAddress,
+                                BigInt(claimRate),
                             );
                             if (claim.txid) {
                                 _stamp(
@@ -445,10 +457,24 @@ export default function useArkSync(): UseArkSync {
                             // as-is so the next cycle retries; the claim VTXO
                             // stays listClaimableExits()-visible until the tx
                             // actually lands, which is the correct retry gate.
-                            console.warn(
-                                '[Ark exit] claim sweep failed (will retry next cycle):',
-                                claimErr?.message ?? claimErr,
-                            );
+                            // "Claim Fee Exceeds Output" is not a transient
+                            // failure and retrying identically cannot fix it:
+                            // the capsule is worth less than it costs to sweep
+                            // at the current rate. Name it, so it is not just
+                            // an anonymous warning repeating every drive tick.
+                            const msg = String(claimErr?.message ?? claimErr);
+                            if (/Claim Fee Exceeds Output/i.test(msg)) {
+                                console.warn(
+                                    '[Ark exit] claim UNECONOMIC at',
+                                    claimRateForLog, 'sat/vB:', msg,
+                                    '- will retry, but this cannot clear until the fee rate drops or more capsules ripen and batch.',
+                                );
+                            } else {
+                                console.warn(
+                                    '[Ark exit] claim sweep failed (will retry next cycle):',
+                                    msg,
+                                );
+                            }
                         }
                     }
 

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -99,6 +99,58 @@ export type ExitFeeConvertEstimate = {
  * mempool.space rather than the configured esplora (blockstream), which the
  * codebase repeatedly notes bot-blocks bark's client.
  */
+/** Claim-fee bounds. The claim is NOT the exit-tree CPFP and must not be priced
+ *  like it: see fetchClaimFeeRateSatPerVb. Floor 1 because anything below the
+ *  relay minimum is unrelayable; ceiling because an unbounded spike would
+ *  reproduce the exact bug this exists to prevent. */
+const CLAIM_RATE_MIN = 1;
+const CLAIM_RATE_MAX = 5;
+
+/**
+ * Fee rate for the exit CLAIM, which is a different problem from the exit-tree
+ * CPFP that `fetchFastFeeRateSatPerVb` prices.
+ *
+ * The CPFP children are time-critical: the exit tree has to confirm before the
+ * VTXO expires, so paying for speed there is buying something real, and it is
+ * paid out of the on-chain reserve.
+ *
+ * A claim is the opposite. It spends an output whose CSV has already matured,
+ * it races nothing, and its fee comes out of the claimed value itself. Paying
+ * a "fastest" rate there buys no safety and directly destroys small claims.
+ *
+ * Observed live 2026-08-19 on a real mainnet exit: with no rate passed, bark
+ * priced a single-capsule claim at 779 sats against a 698 sat output and
+ * refused to build it ("Claim Fee Exceeds Output: Cost to claim exits was
+ * 0.00000779 BTC, but the total output was 0.00000698 BTC"). That is ~6.6
+ * sat/vB over the measured 117.5 vB claim, at a moment when the mempool wanted
+ * 1. The two claims that had already succeeded went at 1.1 and 1.9 sat/vB. The
+ * failure is caught and retried every drive tick, so the exit sat in an
+ * infinite retry loop that could never succeed.
+ *
+ * So: take the 1-hour rate, not the fastest, and clamp it.
+ */
+export async function fetchClaimFeeRateSatPerVb(): Promise<number> {
+    const clamp = (n: number) =>
+        Math.min(CLAIM_RATE_MAX, Math.max(CLAIM_RATE_MIN, Math.ceil(n)));
+    try {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 4000);
+        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
+            signal: controller.signal,
+        });
+        clearTimeout(t);
+        if (!res.ok) return CLAIM_RATE_MIN;
+        const rec = await res.json();
+        const raw = Number(rec?.hourFee ?? rec?.economyFee);
+        if (!isFinite(raw) || raw <= 0) return CLAIM_RATE_MIN;
+        return clamp(raw);
+    } catch {
+        // Unreachable fee API. Floor rather than the reserve's congestion hedge:
+        // an over-priced claim does not fail slowly, it fails permanently.
+        return CLAIM_RATE_MIN;
+    }
+}
+
 export async function fetchFastFeeRateSatPerVb(): Promise<number> {
     try {
         const controller = new AbortController();

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -162,6 +162,7 @@ export { estimateArkOffboardFee, offboardArkVtxos } from './offboard';
 export type { ArkOffboardFeeView } from './offboard';
 export {
     computeExitFeeReserveSats,
+    fetchClaimFeeRateSatPerVb,
     convertToExitFees,
     estimateExitFeeConvert,
     fetchFastFeeRateSatPerVb,


### PR DESCRIPTION
Found while running a real mainnet unilateral exit. It stopped the exit dead, and it did so silently.

## What happened

`claimArkExitsToAddress` accepts an optional fee rate and `useArkSync` never passed one, so
`drainExits(ids, dest, undefined)` left the choice to bark. bark optimises for speed, which is the
wrong objective for this particular transaction.

Live, mid-exit: bark priced a single-capsule claim at **779 sats against a 698 sat output** and
refused to build it.

```
[Ark exit] claim sweep failed (will retry next cycle):
Drain exits failed: Claim Fee Exceeds Output:
Cost to claim exits was 0.00000779 BTC, but the total output was 0.00000698 BTC
```

That is roughly 6.6 sat/vB across the measured 117.5 vB claim, at a moment when the mempool wanted
1 (`economyFee: 1, hourFee: 1, fastestFee: 4`). The two claims that had already succeeded in the
same exit went at 1.1 and 1.9 sat/vB.

Worse than the price was the silence. The `catch` logged a generic warning and left state untouched,
so the drive rebuilt the identical doomed claim every ~120s on a loop that could never succeed, with
nothing surfaced to the user. The exit simply stopped making progress and said nothing.

## Why the two fee decisions are different

The exit has two costs and they are not the same problem.

* **CPFP children** bumping the exit tree ARE time-critical: the tree has to confirm before the VTXO
  expires, and they are paid from the on-chain reserve. Paying for speed there buys something real.
  That is what `fetchFastFeeRateSatPerVb` is for and it is unchanged.
* **The claim** is the opposite. It spends an output whose CSV has already matured, so it races
  nothing, and its fee comes out of the claimed value itself. Bidding for speed buys no safety and
  takes the money straight off the top. On a small capsule it takes all of it.

So `fetchClaimFeeRateSatPerVb` takes the **1-hour** rate rather than the fastest, clamped to [1, 5],
and falls back to the floor rather than the reserve's congestion hedge when the fee API is
unreachable. An over-priced claim does not fail slowly, it fails permanently.

`Claim Fee Exceeds Output` is also now recognised and logged as an uneconomic claim naming the rate,
instead of hiding among generic retry warnings.

## Verified on live money

Applied to the stuck exit, same capsule, next drive cycle:

```
[Ark exit] drainExits built claim PSBT, fee=118 sats
[Ark exit] claim broadcast txid=b5babc43ad97fe14e9e9dcb091a427bb329baedfe56d63e63cf241ff6b6cd14d
```

On chain: 117.5 vB, fee 118, exactly 1.00 sat/vB, 698 sats in and 580 out to the exit destination.
The fee went from 112 percent of the output to 17 percent.

* 36 suites, 251 tests green
* `tsc` error set byte-identical to `origin/main` (405 errors, 19 TS2304), zero differing lines, no
  errors in any touched file

## Note for review

Expect a small conflict with #181, which also edits the claim block in `useArkSync.ts`. Both are
additive and they are orthogonal: #181 decides *when* to claim, this decides *what to pay*. They
want each other, since batching several capsules into one claim is the other half of making small
capsules recoverable.

This does not yet surface in the UI. A claim that cannot clear at any rate the wallet will pay is a
state the user has to be told about, and right now it is only visible in the logs.