### PR TITLE
fix(ark): stop a stale armed reserve claiming the exit is funded

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -32,6 +32,7 @@ import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods, revokeStrikeT
 import {
   AUTO_BACKUP_PATH,
   computeExitFeeReserveSats,
+  resolveExitReserveTarget,
   connectGoogleDrive,
   convertToExitFees,
   disconnectGoogleDrive,
@@ -913,13 +914,18 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const [reserveTargetInput, setReserveTargetInput] = useState('');
 
   const onchainReserveSats: number = arkBalanceDetail?.onchainBoardingSats ?? 0;
-  // Reserve target: the user's chosen hold amount if they've set/armed one
-  // (persisted), otherwise the computed recommendation. Drives the gate, the
-  // funded state, and (via arkExitFeeReserveSats) how much auto-board keeps
-  // on-chain. While recommended is still null (first compute) and nothing is
+  // Reserve target: the GREATER of what the user armed and what an exit is
+  // currently estimated to cost. Drives the gate, the funded state and the
+  // shortfall. While recommended is still null (first compute) and nothing is
   // armed, the target is 0 so we don't gate; the button shows "checking".
-  const reserveTargetSats: number =
-    (arkExitFeeReserveSats ?? 0) > 0 ? arkExitFeeReserveSats : (recommendedReserveSats ?? 0);
+  //
+  // This used to be `armed > 0 ? armed : recommended`, which let a stale armed
+  // figure declare the reserve funded no matter how far the estimate had moved.
+  // See resolveExitReserveTarget for the device case that exposed it.
+  const reserveTargetSats: number = resolveExitReserveTarget({
+    armedSats: arkExitFeeReserveSats,
+    recommendedSats: recommendedReserveSats,
+  });
   const exitFeeGated = reserveTargetSats > 0 && onchainReserveSats < reserveTargetSats;
   const exitFeeShortfallSats = Math.max(0, reserveTargetSats - onchainReserveSats);
   // The user armed a target below the recommended safe amount (warn them).

--- a/src/services/ark/exitReserveTarget.ts
+++ b/src/services/ark/exitReserveTarget.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helper: which reserve figure the exit-fee gate measures against.
+ *
+ * Deliberately free of imports so it stays unit-testable without the native
+ * bark module, matching exitFundingPlan.ts and refreshBatch.ts.
+ */
+
+/**
+ * Which reserve figure the exit-fee gate, the shortfall and all the funding
+ * copy should measure against.
+ *
+ * `arkExitFeeReserveSats` is the amount the user armed, and it is a snapshot of
+ * a decision made at one moment. `computeExitFeeReserveSats` is what an exit is
+ * estimated to cost RIGHT NOW, and it moves with the wallet: capsule count, and
+ * far more sharply, exit depth, which is linear in the reserve and was measured
+ * varying 25x inside a single wallet.
+ *
+ * The screen used to let an armed value REPLACE the recommendation outright:
+ *
+ *     armed > 0 ? armed : recommended
+ *
+ * so an armed figure silently went stale as the wallet grew. Observed on device
+ * 2026-08-20: armed 3,654, on-chain 6,259, recommendation 233,120. The gate
+ * reported the reserve fully funded and the shortfall as 0, on the same screen
+ * that recommended 233,120, leaving the user 227k short of the app's own
+ * estimate while being told they were ready. `reserveBelowRecommended` already
+ * detected exactly this and only produced a warning the gate ignored.
+ *
+ * Taking the greater of the two keeps user agency in the safe direction (arming
+ * MORE than recommended is a deliberate fee-spike buffer and is honoured) and
+ * removes it in the dangerous one (an armed value can no longer claim the exit
+ * is funded when the estimate says otherwise).
+ *
+ * Returns 0 when neither is known, which is the pre-compute state: callers gate
+ * on `> 0` so a 0 target means "do not gate yet", not "nothing needed".
+ */
+export function resolveExitReserveTarget(input: {
+    armedSats: number | null | undefined;
+    recommendedSats: number | null | undefined;
+}): number {
+    const armed = Math.max(0, Math.floor(input.armedSats ?? 0));
+    const recommended = Math.max(0, Math.floor(input.recommendedSats ?? 0));
+    return Math.max(armed, recommended);
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -209,3 +209,5 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export { resolveExitReserveTarget } from './exitReserveTarget';

--- a/tests/unit/exitReserveTarget.test.ts
+++ b/tests/unit/exitReserveTarget.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Which reserve figure the exit-fee gate measures against.
+ *
+ * The bug this pins was found on device, not in review: an armed reserve of
+ * 3,654 sats against a live recommendation of 233,120 made the gate report the
+ * reserve fully funded and the shortfall 0, on the same screen that displayed
+ * the 233,120. The user was 227k short of the app's own estimate and was told
+ * they were ready to exit.
+ */
+import { resolveExitReserveTarget } from '../../src/services/ark/exitReserveTarget';
+
+describe('resolveExitReserveTarget', () => {
+    it('is 0 when neither figure is known, so callers do not gate yet', () => {
+        expect(resolveExitReserveTarget({ armedSats: null, recommendedSats: null })).toBe(0);
+        expect(resolveExitReserveTarget({ armedSats: undefined, recommendedSats: undefined })).toBe(0);
+    });
+
+    it('uses the recommendation when nothing is armed', () => {
+        expect(resolveExitReserveTarget({ armedSats: 0, recommendedSats: 233_120 })).toBe(233_120);
+    });
+
+    it('uses the armed value while the recommendation is still computing', () => {
+        expect(resolveExitReserveTarget({ armedSats: 3_654, recommendedSats: null })).toBe(3_654);
+    });
+
+    it('THE BUG: a stale armed value can no longer claim the exit is funded', () => {
+        // Exact figures read off the device on 2026-08-20.
+        const target = resolveExitReserveTarget({ armedSats: 3_654, recommendedSats: 233_120 });
+        expect(target).toBe(233_120);
+        const onchain = 6_259;
+        expect(Math.max(0, target - onchain)).toBe(226_861);
+        // The old rule was `armed > 0 ? armed : recommended`, which gave 3_654
+        // and therefore a shortfall of 0 against the same 6,259 on-chain.
+        expect(target).not.toBe(3_654);
+    });
+
+    it('honours an armed value ABOVE the recommendation, since that is a deliberate buffer', () => {
+        expect(resolveExitReserveTarget({ armedSats: 300_000, recommendedSats: 233_120 })).toBe(300_000);
+    });
+
+    it('never returns a negative or fractional target', () => {
+        expect(resolveExitReserveTarget({ armedSats: -50, recommendedSats: -10 })).toBe(0);
+        expect(resolveExitReserveTarget({ armedSats: 10.9, recommendedSats: 0 })).toBe(10);
+    });
+
+    it('is stable as the recommendation grows, which is how the wallet actually moves', () => {
+        // Depth drives the reserve and rises as capsules are spent through
+        // arkoor hops, so the recommendation climbs over a wallet's life.
+        const armed = 3_654;
+        const climbing = [3_654, 12_000, 60_000, 233_120];
+        const targets = climbing.map((r) => resolveExitReserveTarget({ armedSats: armed, recommendedSats: r }));
+        expect(targets).toEqual([3_654, 12_000, 60_000, 233_120]);
+    });
+});


### PR DESCRIPTION
Found on device. The screen contradicted itself, and the safe-looking side was the wrong one.

## What it did

The exit-fee gate measured the shortfall against whatever reserve the user had armed, and let that
value replace the live recommendation outright:

```js
armed > 0 ? armed : recommended
```

An armed figure is a snapshot of one decision. The recommendation is what an exit is estimated to
cost now, and it moves with the wallet: with capsule count, and far more sharply with **exit depth**,
which the reserve is linear in and which measures 25x apart inside a single wallet. So the armed
value goes stale and nothing notices.

## Observed 2026-08-20

| | |
|---|---|
| armed reserve | 3,654 |
| on-chain | 6,259 |
| recommendation | **233,120** |
| reported shortfall | **0** |

The same screen recommended 233,120 sats and reported the shortfall as 0, said the reserve was fully
funded, and rendered "Send at least 0 sats to this address". The user was 227k short of the app's own
estimate while being told they were ready to exit.

`reserveBelowRecommended` already detected exactly this condition. It produced a warning the gate
ignored.

That 0 also propagated: the funding confirm screen received `shortfallSats: 0`, `planExitFunding`
correctly answered "The exit-fee reserve is already funded", and the screen rendered that permanent
state as a spinner captioned "Please wait". Fixed separately in #183.

## The fix

Take the greater of the two. Agency is kept in the safe direction, since arming MORE than recommended
is a deliberate fee-spike buffer and is honoured, and removed in the dangerous one, since an armed
value can no longer assert the exit is funded when the estimate disagrees.

Extracted as a pure module so it is testable without the native bark module, matching
`exitFundingPlan.ts` and `refreshBatch.ts`.

## Verification

* 7 tests using the exact figures read off the device, **mutation-checked**: restoring the old rule
  fails 2 of them
* 37 suites, 258 tests green
* `tsc` error set byte-identical to `origin/main` (405 errors), zero differing lines, none in any
  touched file

## Follow-up, not in scope here

Auto-board is unaffected: it holds `arkExitFeeReserveSats`, which this does not change, and the
CoinOS funding path already arms that to `current + sent` before sending. But if a user funds toward
a recommendation far above their armed value by **external deposit**, auto-board would board the
excess away once the on-chain balance clears the board minimum. That wants fixing before anyone
funds a six-figure reserve that way.