### PR TITLE
fix(ark): stop auto-board boarding away the exit-fee reserve

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -353,6 +353,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     arkExitStartedSats,
     setArkExitStartedSats,
     setArkExitFeeReserveSats,
+    setArkExitRecommendedReserveSats,
   } = useAuthStore() as any;
   const arkIosBackupReminderActive = useAuthStore((s) => s.arkIosBackupReminderActive);
   const setArkIosBackupReminderActive = useAuthStore((s) => s.setArkIosBackupReminderActive);
@@ -993,7 +994,13 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     (async () => {
       try {
         const r = await computeExitFeeReserveSats();
-        if (!cancelled) setRecommendedReserveSats(r.recommendedSats);
+        if (!cancelled) {
+          setRecommendedReserveSats(r.recommendedSats);
+          // Persist it: auto-board runs in the sync loop with no access to this
+          // screen, and without the estimate it would hold only the armed
+          // reserve and board the rest away.
+          setArkExitRecommendedReserveSats(r.recommendedSats);
+        }
       } catch (err) {
         // Leave any prior recommendation in place; a transient failure
         // shouldn't flip a gated wallet to ungated.

--- a/src/services/ark/autoBoardDecision.ts
+++ b/src/services/ark/autoBoardDecision.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helper: should the on-chain (BDK) balance be boarded into Ark, and how
+ * much must stay behind.
+ *
+ * Deliberately free of imports beyond the sibling pure helper, so it stays
+ * unit-testable without the native bark module.
+ *
+ * Why this exists as a decision function rather than inline in sync.ts: the
+ * on-chain wallet is where unilateral-exit CPFP fees are paid from, so boarding
+ * the wrong amount does not merely misplace funds, it disarms the exit. Two
+ * separate defects lived in the inline version:
+ *
+ *   1. The hold target was the ARMED reserve only. A user who funds toward a
+ *      recommendation far above what they armed (the recommendation moves with
+ *      exit depth and was measured at 233,120 against an armed 3,654) would
+ *      have the difference boarded straight back into Ark, undoing the top-up
+ *      they had just made specifically to enable the exit.
+ *   2. The unarmed path called boardAll with NO board-minimum guard, while the
+ *      armed path guarded correctly. A sub-minimum on-chain balance can never
+ *      board, so it retried every sync tick forever. The asymmetry was
+ *      acknowledged in the old comment as "the exact old boardAll behavior".
+ */
+import { resolveExitReserveTarget } from './exitReserveTarget';
+
+export type AutoBoardDecision =
+    | { action: 'skip'; reason: 'exit-in-progress' | 'nothing-onchain' | 'board-in-flight' }
+    | { action: 'hold'; reason: 'below-board-minimum'; surplusSats: number; holdSats: number }
+    | { action: 'board-amount'; sats: number; holdSats: number }
+    | { action: 'board-all'; holdSats: 0 };
+
+export type AutoBoardInput = {
+    confirmedSats: number;
+    pendingBoardSats: number;
+    exitInProgress: boolean;
+    /** What the user armed, if anything. */
+    armedReserveSats: number | null | undefined;
+    /** Last computed exit-cost estimate, if one has been persisted. */
+    recommendedReserveSats: number | null | undefined;
+    /** Server board minimum. Below this a board can never succeed. */
+    minBoardSats: number;
+    /** Slack so boardAmount's own fee cannot dip the leftover below the hold. */
+    boardFeeHeadroomSats: number;
+};
+
+export function decideAutoBoard(input: AutoBoardInput): AutoBoardDecision {
+    // An exit in progress means every VTXO is already committed and the whole
+    // on-chain balance is fee money. Board nothing, whatever the numbers say.
+    if (input.exitInProgress) return { action: 'skip', reason: 'exit-in-progress' };
+
+    const confirmed = Math.max(0, Math.floor(input.confirmedSats || 0));
+    if (confirmed <= 0) return { action: 'skip', reason: 'nothing-onchain' };
+
+    // bark has not yet observed the previous board consuming its input; firing
+    // again here double-boards.
+    if ((input.pendingBoardSats || 0) > 0) return { action: 'skip', reason: 'board-in-flight' };
+
+    const holdSats = resolveExitReserveTarget({
+        armedSats: input.armedReserveSats,
+        recommendedSats: input.recommendedReserveSats,
+    });
+    const minBoard = Math.max(0, Math.floor(input.minBoardSats || 0));
+
+    if (holdSats <= 0) {
+        // Nothing to protect, so boardAll keeps its original semantics and
+        // leaves no dust behind. The minimum guard is new: without it this
+        // retried forever on a balance that could never board.
+        if (confirmed >= minBoard) return { action: 'board-all', holdSats: 0 };
+        return { action: 'hold', reason: 'below-board-minimum', surplusSats: confirmed, holdSats: 0 };
+    }
+
+    const surplusSats = confirmed - holdSats - Math.max(0, Math.floor(input.boardFeeHeadroomSats || 0));
+    if (surplusSats >= minBoard) return { action: 'board-amount', sats: surplusSats, holdSats };
+    return { action: 'hold', reason: 'below-board-minimum', surplusSats, holdSats };
+}

--- a/src/services/ark/sync.ts
+++ b/src/services/ark/sync.ts
@@ -1,5 +1,7 @@
 import useAuthStore from '@Cypher/stores/authStore';
 
+import { decideAutoBoard } from './autoBoardDecision';
+
 import { getArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
 
 // Flat board-fee headroom (sats) subtracted from the boardable surplus when an
@@ -99,41 +101,31 @@ export async function syncArkWallet(): Promise<boolean> {
             //      touched the exit-funding flow) keeps the exact old boardAll
             //      behavior.
             const authState = useAuthStore.getState();
-            const reserveSats = authState.arkExitFeeReserveSats ?? 0;
-            const canBoard =
-                !authState.arkExitInProgress &&
-                onchainBal.confirmedSats > 0n &&
-                arkBal.pendingBoardSats === 0n;
-            if (canBoard && reserveSats > 0) {
-                // Board only the surplus above the reserve. Subtract a flat
-                // board-fee headroom so boardAmount's own fee can't dip the
-                // leftover below the reserve. Only board when the surplus
-                // clears the server board minimum (a smaller surplus can never
-                // board and would retry-storm), otherwise hold it on-chain.
-                const confirmed = Number(onchainBal.confirmedSats);
-                const excess = confirmed - reserveSats - BOARD_FEE_HEADROOM_SATS;
-                if (excess >= MIN_BOARD_SATS) {
-                    console.log(
-                        '[Ark sync] auto-board (reserve armed): boarding surplus',
-                        excess, 'sats; keeping', reserveSats, 'on-chain for exit fees',
-                    );
-                    try {
-                        await handle.boardAmount(BigInt(excess));
-                        console.log('[Ark sync] auto-board: boardAmount initiated');
-                    } catch (boardErr) {
-                        console.warn('[Ark sync] auto-board: boardAmount failed:', boardErr);
-                    }
-                } else if (__DEV__) {
-                    console.log(
-                        '[Ark sync] auto-board held: surplus', excess,
-                        'below board minimum; keeping funds on-chain for exit fees',
-                    );
+            const boardDecision = decideAutoBoard({
+                confirmedSats: Number(onchainBal.confirmedSats),
+                pendingBoardSats: Number(arkBal.pendingBoardSats),
+                exitInProgress: authState.arkExitInProgress,
+                armedReserveSats: authState.arkExitFeeReserveSats,
+                recommendedReserveSats: authState.arkExitRecommendedReserveSats,
+                minBoardSats: MIN_BOARD_SATS,
+                boardFeeHeadroomSats: BOARD_FEE_HEADROOM_SATS,
+            });
+            if (boardDecision.action === 'board-amount') {
+                console.log(
+                    '[Ark sync] auto-board: boarding surplus', boardDecision.sats,
+                    'sats; keeping', boardDecision.holdSats, 'on-chain for exit fees',
+                );
+                try {
+                    await handle.boardAmount(BigInt(boardDecision.sats));
+                    console.log('[Ark sync] auto-board: boardAmount initiated');
+                } catch (boardErr) {
+                    console.warn('[Ark sync] auto-board: boardAmount failed:', boardErr);
                 }
-            } else if (canBoard) {
+            } else if (boardDecision.action === 'board-all') {
                 console.log(
                     '[Ark sync] auto-board: detected',
                     String(onchainBal.confirmedSats),
-                    'sats unboarded onchain, initiating boardAll',
+                    'sats unboarded onchain and nothing to hold, initiating boardAll',
                 );
                 try {
                     await handle.boardAll();
@@ -141,8 +133,14 @@ export async function syncArkWallet(): Promise<boolean> {
                 } catch (boardErr) {
                     console.warn('[Ark sync] auto-board: boardAll failed:', boardErr);
                 }
-            } else if (authState.arkExitInProgress && onchainBal.confirmedSats > 0n && __DEV__) {
-                console.log('[Ark sync] auto-board skipped: exit in progress, holding on-chain funds for exit fees');
+            } else if (boardDecision.action === 'hold' && __DEV__) {
+                console.log(
+                    '[Ark sync] auto-board held: surplus', boardDecision.surplusSats,
+                    'below board minimum; keeping', boardDecision.holdSats,
+                    'on-chain for exit fees',
+                );
+            } else if (boardDecision.action === 'skip' && __DEV__) {
+                console.log('[Ark sync] auto-board skipped:', boardDecision.reason);
             }
 
             // Progress any pending boards through their phases. No-op when

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -269,6 +269,13 @@ export type AuthStateType = {
      * the user opens the "Fund exit fees" flow; reset on wallet teardown.
      */
     arkExitFeeReserveSats: number;
+    /**
+     * Last computed exit-cost estimate (computeExitFeeReserveSats). Persisted
+     * ONLY so the sync loop's auto-board can see it: the estimate is computed
+     * on the exit settings screen, but auto-board runs headless and would
+     * otherwise hold just what the user armed and board the rest away.
+     */
+    arkExitRecommendedReserveSats: number | null;
     arkUseHotVaultSeed: boolean;
     withdrawArkThreshold: any | null;
     reserveArkAmount: number;
@@ -294,6 +301,7 @@ export type AuthStateType = {
     setArkExitDrained: (state: boolean) => void;
     setArkExitStartedSats: (state: number | null) => void;
     setArkExitFeeReserveSats: (state: number) => void;
+    setArkExitRecommendedReserveSats: (state: number | null) => void;
     setArkUseHotVaultSeed: (state: boolean) => void;
     setWithdrawArkThreshold: (state: any) => void;
     setReserveArkAmount: (state: number) => void;
@@ -515,6 +523,7 @@ const createAuthStore = (
     arkExitDrained: false,
     arkExitStartedSats: null,
     arkExitFeeReserveSats: 0,
+    arkExitRecommendedReserveSats: null,
     arkUseHotVaultSeed: false,
     withdrawArkThreshold: 500000,
     reserveArkAmount: 100000,
@@ -591,6 +600,8 @@ const createAuthStore = (
     setArkExitDrained: (state: boolean) => set({ arkExitDrained: state }),
     setArkExitStartedSats: (state: number | null) => set({ arkExitStartedSats: state }),
     setArkExitFeeReserveSats: (state: number) => set({ arkExitFeeReserveSats: state }),
+    setArkExitRecommendedReserveSats: (state: number | null) =>
+        set({ arkExitRecommendedReserveSats: state }),
     setArkUseHotVaultSeed: (state: boolean) => set({ arkUseHotVaultSeed: state }),
     setWithdrawArkThreshold: (state: any) => set({ withdrawArkThreshold: state }),
     setReserveArkAmount: (state: number) => set({ reserveArkAmount: state }),
@@ -634,6 +645,7 @@ const createAuthStore = (
             arkExitDrained: false,
             arkExitStartedSats: null,
             arkExitFeeReserveSats: 0,
+            arkExitRecommendedReserveSats: null,
             arkUseHotVaultSeed: false,
             allBTCWallets: get().allBTCWallets.filter(wallet => wallet !== 'ARK'),
             // Keep thresholds — don't reset on logout

--- a/tests/unit/autoBoardDecision.test.ts
+++ b/tests/unit/autoBoardDecision.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Auto-board is the only thing that moves the on-chain balance without the user
+ * asking, and that balance is where unilateral-exit CPFP fees come from. Board
+ * the wrong amount and the exit is disarmed, silently.
+ */
+import { decideAutoBoard, AutoBoardInput } from '../../src/services/ark/autoBoardDecision';
+
+const MIN_BOARD = 50_000;
+const HEADROOM = 1_500;
+
+const base = (over: Partial<AutoBoardInput> = {}): AutoBoardInput => ({
+    confirmedSats: 0,
+    pendingBoardSats: 0,
+    exitInProgress: false,
+    armedReserveSats: 0,
+    recommendedReserveSats: null,
+    minBoardSats: MIN_BOARD,
+    boardFeeHeadroomSats: HEADROOM,
+    ...over,
+});
+
+describe('decideAutoBoard', () => {
+    it('boards nothing at all while an exit is in progress', () => {
+        const d = decideAutoBoard(base({ confirmedSats: 500_000, exitInProgress: true }));
+        expect(d).toEqual({ action: 'skip', reason: 'exit-in-progress' });
+    });
+
+    it('skips when a board is already in flight, which would otherwise double-board', () => {
+        const d = decideAutoBoard(base({ confirmedSats: 500_000, pendingBoardSats: 60_000 }));
+        expect(d).toEqual({ action: 'skip', reason: 'board-in-flight' });
+    });
+
+    it('skips when there is nothing on-chain', () => {
+        expect(decideAutoBoard(base({ confirmedSats: 0 }))).toEqual({
+            action: 'skip', reason: 'nothing-onchain',
+        });
+    });
+
+    describe('THE BUG: a funded reserve above the armed value', () => {
+        // Device figures, 2026-08-20: armed 3,654 while the estimate said
+        // 233,120. Funding to the recommendation by external deposit used to
+        // leave everything above 3,654 eligible for boarding.
+        const funded = base({
+            confirmedSats: 233_120,
+            armedReserveSats: 3_654,
+            recommendedReserveSats: 233_120,
+        });
+
+        it('holds the full recommendation, not the stale armed value', () => {
+            const d = decideAutoBoard(funded);
+            expect(d.action).toBe('hold');
+            expect((d as any).holdSats).toBe(233_120);
+        });
+
+        it('would have boarded 227,966 sats away under the old armed-only rule', () => {
+            // What the previous logic computed: confirmed - armed - headroom.
+            const oldExcess = 233_120 - 3_654 - HEADROOM;
+            expect(oldExcess).toBe(227_966);
+            expect(oldExcess).toBeGreaterThanOrEqual(MIN_BOARD); // so it WOULD have fired
+            const d = decideAutoBoard(funded);
+            expect(d.action).not.toBe('board-amount');
+        });
+    });
+
+    it('boards a genuine surplus above the hold target', () => {
+        const d = decideAutoBoard(base({
+            confirmedSats: 300_000,
+            armedReserveSats: 3_654,
+            recommendedReserveSats: 233_120,
+        }));
+        expect(d).toEqual({ action: 'board-amount', sats: 300_000 - 233_120 - HEADROOM, holdSats: 233_120 });
+    });
+
+    it('honours an armed reserve larger than the recommendation', () => {
+        const d = decideAutoBoard(base({
+            confirmedSats: 400_000,
+            armedReserveSats: 350_000,
+            recommendedReserveSats: 233_120,
+        }));
+        expect((d as any).holdSats).toBe(350_000);
+    });
+
+    describe('the unarmed path', () => {
+        it('boards everything when nothing needs holding', () => {
+            const d = decideAutoBoard(base({ confirmedSats: 60_000 }));
+            expect(d).toEqual({ action: 'board-all', holdSats: 0 });
+        });
+
+        it('THE SECOND BUG: holds instead of retrying a board that can never succeed', () => {
+            // 6,259 on-chain against a 50,000 minimum. The old code called
+            // boardAll here every sync tick, forever.
+            const d = decideAutoBoard(base({ confirmedSats: 6_259 }));
+            expect(d).toEqual({
+                action: 'hold', reason: 'below-board-minimum', surplusSats: 6_259, holdSats: 0,
+            });
+        });
+    });
+
+    it('never boards a surplus below the server minimum', () => {
+        const d = decideAutoBoard(base({
+            confirmedSats: 60_000,
+            armedReserveSats: 20_000,
+            recommendedReserveSats: null,
+        }));
+        // 60,000 - 20,000 - 1,500 = 38,500, under the 50,000 minimum.
+        expect(d).toEqual({
+            action: 'hold', reason: 'below-board-minimum', surplusSats: 38_500, holdSats: 20_000,
+        });
+    });
+
+    it('leaves the headroom so boardAmount fees cannot dip below the hold', () => {
+        const d = decideAutoBoard(base({ confirmedSats: 151_500, armedReserveSats: 100_000 }));
+        expect(d).toEqual({ action: 'board-amount', sats: 50_000, holdSats: 100_000 });
+    });
+});


### PR DESCRIPTION
Stacked on #188, which it needs for `resolveExitReserveTarget`. GitHub will retarget this to `main`
when #188 merges.

Auto-board is the only thing that moves the on-chain balance without the user asking, and that
balance is where unilateral-exit CPFP fees are paid from. Boarding the wrong amount does not misplace
funds, it disarms the exit.

## Defect 1: the hold target ignored the estimate

The estimate of what an exit costs is computed on the exit settings screen and was **never
persisted**, so the sync loop could not see it and held only what the user had armed.

With the device figures from 2026-08-20, armed 3,654 against an estimate of 233,120:

```
old hold = armed = 3,654
surplus  = 233,120 - 3,654 - 1,500 = 227,966   >= 50,000 minimum, so it fires
```

A user who funds to the recommendation by external deposit gets **227,966 sats boarded straight back
into Ark**, undoing the top-up they made specifically to enable the exit. Nobody has hit this because
nobody has funded a six-figure reserve. Now that the gate asks for one (#188), somebody will.

## Defect 2: the unarmed path had no board-minimum guard

The armed path guards correctly. The unarmed path called `boardAll` unconditionally, and a
sub-minimum balance can never board, so it retried every sync tick forever. The old comment
acknowledged the asymmetry as "the exact old boardAll behavior". This device sits at 6,259 sats
on-chain against a 50,000 minimum, which is exactly that case.

## The fix

A pure decision function taking the **greater of armed and recommended** as the hold target, through
the same helper the gate uses in #188, so the screen and the sync loop can no longer disagree about
what "funded" means.

`boardAll` keeps its original semantics when there is genuinely nothing to hold, so no dust is
stranded for users who never touched exit funding, but it is now gated on the minimum like everything
else.

The estimate is persisted as `arkExitRecommendedReserveSats`, written whenever the settings screen
computes it and cleared by `clearArkAuth` so a stale figure from a deleted wallet cannot linger. It
is derived data: if missing, the hold falls back to the armed value, which is the old behaviour.

## Verification

* 11 tests using the device figures, **mutation-checked**: restoring either old behaviour fails 4
* 38 suites, 269 tests green
* `tsc` error set byte-identical to `origin/main`, zero differing lines, none in any touched file