### PR TITLE
Exit triage: discard capsules an emergency exit cannot economically recover

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -14,6 +14,7 @@ import {
     fetchArkBalance,
     fetchArkPendingLightningReceives,
     fetchArkPendingRoundStates,
+    fetchArkExitParams,
     fetchArkRoundIntervalSecs,
     fetchArkVtxos,
     fetchChainTipHeight,
@@ -247,6 +248,7 @@ export default function useArkSync(): UseArkSync {
     const setArkLastBackupAt = useAuthStore((s) => s.setArkLastBackupAt);
     const arkRoundIntervalSecs = useAuthStore((s) => s.arkRoundIntervalSecs);
     const setArkRoundIntervalSecs = useAuthStore((s) => s.setArkRoundIntervalSecs);
+    const arkVtxoExitDeltaBlocks = useAuthStore((s) => s.arkVtxoExitDeltaBlocks);
     const arkExitInProgress = useAuthStore((s) => s.arkExitInProgress);
     const arkExitDestinationAddress = useAuthStore((s) => s.arkExitDestinationAddress);
     const setArkExitInProgress = useAuthStore((s) => s.setArkExitInProgress);
@@ -1392,7 +1394,19 @@ export default function useArkSync(): UseArkSync {
                 if (secs != null) setArkRoundIntervalSecs(secs);
             });
         };
+
+        // Same shape, different reason: `vtxoExitDelta` and `maxVtxoExitDepth`
+        // are server-side static config too, but the exit path is not allowed
+        // to ask for them (the user pressing Emergency Exit may be doing it
+        // BECAUSE the server is gone). Cache them while it is reachable so exit
+        // triage can measure a capsule's runway against the real CSV rather
+        // than the worst case it has to assume without them.
+        const maybeFetchExitParams = () => {
+            if (arkVtxoExitDeltaBlocks != null) return;
+            void fetchArkExitParams();
+        };
         maybeFetchRoundInterval();
+        maybeFetchExitParams();
 
         // Fast retry: catch the wallet handle the moment boot finishes.
         let pollTries = 0;
@@ -1404,6 +1418,7 @@ export default function useArkSync(): UseArkSync {
                 clearInterval(fastPollId);
                 void sync();
                 maybeFetchRoundInterval();
+                maybeFetchExitParams();
             } else if (pollTries >= POLL_MAX_TRIES) {
                 clearInterval(fastPollId);
             }
@@ -1416,7 +1431,7 @@ export default function useArkSync(): UseArkSync {
             clearInterval(id);
             clearInterval(fastPollId);
         };
-    }, [isArkAuth, sync, arkRoundIntervalSecs, setArkRoundIntervalSecs]);
+    }, [isArkAuth, sync, arkRoundIntervalSecs, setArkRoundIntervalSecs, arkVtxoExitDeltaBlocks]);
 
     // Foreground kick — refresh the moment the user returns to the app,
     // regardless of where the interval is in its cycle.

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -14,6 +14,7 @@ import {
     fetchArkBalance,
     fetchArkPendingLightningReceives,
     fetchArkPendingRoundStates,
+    fetchArkExitDriveFeeRate,
     fetchArkExitParams,
     fetchArkRoundIntervalSecs,
     fetchArkVtxos,
@@ -405,8 +406,19 @@ export default function useArkSync(): UseArkSync {
                     } catch (syncErr: any) {
                         console.warn('[Ark exit] pre-drive wallet sync failed (continuing):', syncErr?.message ?? syncErr);
                     }
-                    const progressResult = await progressArkExits();
-                    _stamp('progressArkExits done');
+                    // Bid at the runway-derived rate rather than letting bark
+                    // pick. Passing nothing meant the rate actually paid had no
+                    // relationship to the reserve the user was asked to fund;
+                    // now both come from how much runway the tightest capsule
+                    // has left, re-derived here every tick as that shrinks.
+                    let driveFeeRate: bigint | undefined;
+                    try {
+                        driveFeeRate = await fetchArkExitDriveFeeRate();
+                    } catch (rateErr: any) {
+                        console.warn('[Ark exit] drive fee-rate lookup failed, letting the SDK choose:', rateErr?.message ?? rateErr);
+                    }
+                    const progressResult = await progressArkExits(driveFeeRate);
+                    _stamp(`progressArkExits done${driveFeeRate != null ? ` at ${driveFeeRate} sat/vB` : ''}`);
                     // Diagnostic: the per-VTXO progress payload is the only
                     // signal of WHERE the state machine is (build?
                     // broadcast? awaiting confs?). Serialize defensively;

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -60,7 +60,7 @@ import {
   writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
 } from "@Cypher/services/ark";
-import type { ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
+import type { ExitEconomicPolicy, ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
 import Share from "react-native-share";
 import { BlueStorageContext } from "../../../../blue_modules/storage-context";
@@ -1229,7 +1229,18 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     return /^(bc1|tb1|bcrt1|[13]|[mn2])[a-zA-Z0-9]+$/.test(t);
   };
 
-  const startExitWithAddress = async (destLabel: string, address: string) => {
+  /**
+   * `economicPolicy` is how far past the economics the user has agreed to go.
+   * It only ever moves off the default by the user tapping through the
+   * override prompt below, which states the loss in sats first. Never raise it
+   * silently: the whole point of spec principle 4 is that overspending is a
+   * choice, and a choice nobody was offered is not one.
+   */
+  const startExitWithAddress = async (
+    destLabel: string,
+    address: string,
+    economicPolicy: ExitEconomicPolicy = 'default',
+  ) => {
     setExitPickerOpen(false);
     setExitStarting(true);
     // Triage NOW, not at screen mount: fee rates and the chain tip both move
@@ -1240,7 +1251,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     let plan: ExitTriageResult | null = null;
     let freshRecommended = recommendedReserveSats ?? 0;
     try {
-      plan = await computeArkExitPlan();
+      plan = await computeArkExitPlan({ economicPolicy });
       if (plan) {
         freshRecommended = plan.reserveSats;
         setRecommendedReserveSats(plan.reserveSats);
@@ -1261,22 +1272,54 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       return;
     }
 
-    // Nothing survived triage. Say why rather than starting an exit that would
-    // spend the reserve and return nothing.
-    if (plan.selectedIds.length === 0) {
+    // The override, offered only where it would change something. Re-planning
+    // with 'recover-everything' is what actually applies it, so the figures in
+    // the confirm dialog afterwards are the forced ones, not these.
+    const forcePrompt = (bodyPrefix: string) => {
       setExitStarting(false);
       Alert.alert(
         'Emergency Exit',
-        plan.excluded.length === 0
-          ? 'There are no capsules to exit.'
-          : `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
-            plan.excluded
-              .map(
-                (e) =>
-                  `${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`,
-              )
-              .join('\n') +
-            '\n\nThey stay in your vault and stay spendable.',
+        bodyPrefix +
+          `\n\nYou can exit ${plan!.overridableCount === 1 ? 'it' : 'them'} anyway. ` +
+          'That is sometimes worth it, for instance to get your funds out of a server you no longer trust, ' +
+          'but it costs more in miner fees than the funds are worth.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Exit anyway',
+            style: 'destructive',
+            onPress: () => {
+              void startExitWithAddress(destLabel, address, 'recover-everything');
+            },
+          },
+        ],
+      );
+    };
+
+    // Nothing survived triage. Say why rather than starting an exit that would
+    // spend the reserve and return nothing.
+    if (plan.selectedIds.length === 0) {
+      const list = plan.excluded
+        .map((e) => `  ${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`)
+        .join('\n');
+      if (plan.excluded.length === 0) {
+        setExitStarting(false);
+        Alert.alert('Emergency Exit', 'There are no capsules to exit.');
+        return;
+      }
+      if (plan.overridableCount === plan.excluded.length) {
+        forcePrompt(
+          `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} ` +
+            `can be recovered economically right now:\n${list}`,
+        );
+        return;
+      }
+      setExitStarting(false);
+      Alert.alert(
+        'Emergency Exit',
+        `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
+          list +
+          '\n\nThey stay in your vault and stay spendable.',
       );
       return;
     }
@@ -1302,7 +1345,14 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     // Principle: never silently spend more than the funds are worth. The
     // reserve sits next to what comes back, so a reserve larger than the value
     // is impossible to miss.
-    const costNotice = `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n`;
+    const costNotice =
+      `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n` +
+      // The loss, in sats, whenever the exit spends more than it returns. This
+      // is the sentence that makes an overridden exit a choice rather than a
+      // surprise, so it is not conditional on how the policy got here.
+      (plan.netLossSats > 0
+        ? `That is about ${plan.netLossSats.toLocaleString()} sats MORE in fees than the funds are worth.\n\n`
+        : '');
 
     const shortfall = Math.max(0, freshRecommended - onchainReserveSats);
     const underfunded = freshRecommended > 0 && shortfall > 0;
@@ -1325,6 +1375,20 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             style: 'cancel',
             onPress: () => setExitStarting(false),
           },
+          // Partial case: some capsules are worth exiting and some are being
+          // left behind on cost alone. Naming them without offering the choice
+          // would satisfy principle 3 and quietly ignore principle 4.
+          ...(plan.overridableCount > 0
+            ? [
+                {
+                  text: `Include all ${(plan.selected.length + plan.overridableCount)}`,
+                  style: 'destructive' as const,
+                  onPress: () => {
+                    void startExitWithAddress(destLabel, address, 'recover-everything');
+                  },
+                },
+              ]
+            : []),
           {
             text: 'Start exit',
             style: 'destructive',

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -31,10 +31,12 @@ import styles from "./styles";
 import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods, revokeStrikeToken } from "@Cypher/api/strikeAPIs";
 import {
   AUTO_BACKUP_PATH,
+  computeArkExitPlan,
   computeExitFeeReserveSats,
   connectGoogleDrive,
   convertToExitFees,
   disconnectGoogleDrive,
+  describeExitExclusion,
   estimateExitFeeConvert,
   estimateArkOnchainRecover,
   recoverArkOnchainBoard,
@@ -58,7 +60,7 @@ import {
   writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
 } from "@Cypher/services/ark";
-import type { ExitFeeConvertEstimate } from "@Cypher/services/ark";
+import type { ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
 import Share from "react-native-share";
 import { BlueStorageContext } from "../../../../blue_modules/storage-context";
@@ -1230,19 +1232,78 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const startExitWithAddress = async (destLabel: string, address: string) => {
     setExitPickerOpen(false);
     setExitStarting(true);
-    // Re-estimate the exit-fee cost NOW: fee rates move between screen mount and
-    // this tap, so the warning must reflect the current shortfall rather than a
-    // stale mount-time number. If the on-chain fee wallet is short, advise the
-    // user to top up. It's a stall warning, not a hard block (progressExits
-    // resumes the moment fees are added).
+    // Triage NOW, not at screen mount: fee rates and the chain tip both move
+    // between mount and this tap, and both change which capsules are worth
+    // exiting. The plan decides the exit set AND sizes the reserve over that
+    // set, so the shortfall quoted below is for the capsules actually being
+    // exited rather than for every capsule in the wallet.
+    let plan: ExitTriageResult | null = null;
     let freshRecommended = recommendedReserveSats ?? 0;
     try {
-      const fresh = await computeExitFeeReserveSats();
-      freshRecommended = fresh.recommendedSats;
-      setRecommendedReserveSats(fresh.recommendedSats);
+      plan = await computeArkExitPlan();
+      if (plan) {
+        freshRecommended = plan.reserveSats;
+        setRecommendedReserveSats(plan.reserveSats);
+      }
     } catch {
       // Keep the last computed recommendation on a transient failure.
     }
+
+    // The capsule read failed, so there is no exit set to hand the SDK. Say
+    // that, rather than letting startArkEmergencyExit reject an empty list with
+    // copy that would read as "you have nothing worth exiting".
+    if (!plan) {
+      setExitStarting(false);
+      Alert.alert(
+        'Emergency Exit',
+        "Couldn't read your capsules just now, so the exit wasn't started. Try again in a moment.",
+      );
+      return;
+    }
+
+    // Nothing survived triage. Say why rather than starting an exit that would
+    // spend the reserve and return nothing.
+    if (plan.selectedIds.length === 0) {
+      setExitStarting(false);
+      Alert.alert(
+        'Emergency Exit',
+        plan.excluded.length === 0
+          ? 'There are no capsules to exit.'
+          : `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
+            plan.excluded
+              .map(
+                (e) =>
+                  `${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`,
+              )
+              .join('\n') +
+            '\n\nThey stay in your vault and stay spendable.',
+      );
+      return;
+    }
+
+    // Narrowed alias: `plan` is a let, so the null checks above do not survive
+    // into the Alert's onPress closure.
+    const exitPlan = plan;
+
+    // Principle: never silently abandon funds. Every capsule left behind is
+    // named, with its amount and the reason, BEFORE the user commits.
+    const exclusionNotice =
+      plan.excluded.length > 0
+        ? `${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} holding ${plan.excludedSats.toLocaleString()} sats will NOT be exited:\n` +
+          plan.excluded
+            .map(
+              (e) =>
+                `  ${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`,
+            )
+            .join('\n') +
+          '\n\nThey stay in your vault and stay spendable. Sending them, or combining them, recovers more than an exit would.\n\n'
+        : '';
+
+    // Principle: never silently spend more than the funds are worth. The
+    // reserve sits next to what comes back, so a reserve larger than the value
+    // is impossible to miss.
+    const costNotice = `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n`;
+
     const shortfall = Math.max(0, freshRecommended - onchainReserveSats);
     const underfunded = freshRecommended > 0 && shortfall > 0;
     const underfundedPrefix = underfunded
@@ -1251,7 +1312,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     try {
       Alert.alert(
         'Emergency Exit',
-        underfundedPrefix +
+        exclusionNotice +
+          costNotice +
+          underfundedPrefix +
           `Forces your VTXO capsules onto the Bitcoin chain. Funds arrive at your ${destLabel} after a ~24-hour wait set by Bitcoin. Once you start, this can't be cancelled.\n\n` +
           'Only start this if your soonest capsule is at least 1 day from expiry. The exit txs must confirm on-chain before then, so it is not a last-minute rescue.\n\n' +
           `${address}\n\n` +
@@ -1267,7 +1330,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             style: 'destructive',
             onPress: async () => {
               try {
-                await startArkEmergencyExit();
+                await startArkEmergencyExit(exitPlan.selectedIds);
                 setArkExitDestinationAddress(address);
                 setArkExitStartedAt(Date.now());
                 // Fresh exit: clear any stale "drained" flag from a prior exit
@@ -1278,7 +1341,10 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // txs broadcast and any live read needs an open handle, so
                 // this persisted figure is what the status panel falls back
                 // to across reloads.
-                const startedSats = Number(arkBalanceDetail?.spendableSats ?? 0);
+                // The exit set, not the wallet: triage may have left capsules
+                // behind, and quoting the whole spendable balance here would
+                // report a total the exit can never deliver.
+                const startedSats = exitPlan.selectedSats;
                 setArkExitStartedSats(startedSats > 0 ? startedSats : null);
                 setArkExitInProgress(true);
                 // Activity log: read pending sats fresh — the exit just

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -38,6 +38,7 @@ import {
   disconnectGoogleDrive,
   describeExitExclusion,
   estimateExitFeeConvert,
+  getLastExitFeeDeadlineHeight,
   estimateArkOnchainRecover,
   recoverArkOnchainBoard,
   fetchArkExitVtxos,
@@ -354,6 +355,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     arkExitStartedSats,
     setArkExitStartedSats,
     setArkExitFeeReserveSats,
+    setArkExitFeeDeadlineHeight,
   } = useAuthStore() as any;
   const arkIosBackupReminderActive = useAuthStore((s) => s.arkIosBackupReminderActive);
   const setArkIosBackupReminderActive = useAuthStore((s) => s.setArkIosBackupReminderActive);
@@ -1395,6 +1397,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             onPress: async () => {
               try {
                 await startArkEmergencyExit(exitPlan.selectedIds);
+                // Persist what the reserve was priced against, so the drive can
+                // re-derive its bid each tick as the runway shrinks.
+                setArkExitFeeDeadlineHeight(getLastExitFeeDeadlineHeight());
                 setArkExitDestinationAddress(address);
                 setArkExitStartedAt(Date.now());
                 // Fresh exit: clear any stale "drained" flag from a prior exit

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -10,8 +10,11 @@
  *
  * Phase contract (matches the Bark SDK shape):
  *
- *   1. `startArkEmergencyExit()` → `wallet.startExitForEntireWallet()`
- *      Marks every VTXO for exit. No on-chain txs broadcast yet.
+ *   1. `startArkEmergencyExit(ids)` → `wallet.startExitForVtxos(ids)`
+ *      Marks the triaged VTXO set for exit. No on-chain txs broadcast yet.
+ *      The set comes from `computeArkExitPlan` in ./exitFunding, which drops
+ *      capsules that cannot be exited, cannot clear their timelock before
+ *      expiry, or would cost more reserve than they can ever return.
  *
  *   2. `progressArkExits()` → `wallet.progressExits(onchain, feeRate?)`
  *      Builds + broadcasts the actual on-chain exit txs as inputs become
@@ -74,17 +77,35 @@ function requireWallet() {
 }
 
 /**
- * Kick off unilateral exit for ALL VTXOs in this wallet. No destination is
- * needed yet — the destination is supplied at `claimArkExitsToAddress` time
- * (we save it in zustand at start so the auto-claim loop has it).
+ * Kick off a unilateral exit for a CHOSEN set of VTXOs. No destination is
+ * needed yet: it is supplied at `claimArkExitsToAddress` time (we save it in
+ * zustand at start so the auto-claim loop has it).
+ *
+ * Takes ids rather than exiting the whole wallet. `startExitForEntireWallet()`
+ * marks every VTXO, dust included, and the on-chain reserve is then sized over
+ * all of it. Measured on the QA wallet 2026-08-20 at 1 sat/vB: two 400-sat
+ * capsules on deep exit trees were 10,656 of the 16,060 vB the exit would cost,
+ * 66% of the reserve for 16% of the value, and neither could ever return more
+ * than it consumed. The reserve that dust eats is the reserve the healthy
+ * capsules need, so it does not merely waste money, it decides which capsules
+ * get stranded when the reserve runs dry.
+ *
+ * Callers pass `computeArkExitPlan().selectedIds` (see ./exitFunding), and must
+ * have shown the user every excluded capsule by name and amount first. Refuses
+ * an empty set rather than falling back to the whole wallet: a silent fallback
+ * would reintroduce exactly the behaviour this replaces.
  */
-export async function startArkEmergencyExit(): Promise<void> {
+export async function startArkEmergencyExit(vtxoIds: readonly string[]): Promise<void> {
     const handle = requireWallet();
+    const ids = (vtxoIds ?? []).filter((id) => !!id);
+    if (ids.length === 0) {
+        throw new Error('No capsules can be exited right now.');
+    }
     // Spawn the onchain wallet eagerly — progressExits() needs it on the very
     // next tick. Catching here surfaces a clean error to the UI rather than
     // letting the first sync-cycle progress call fail with "not initialized".
     await ensureArkOnchainHandle();
-    await handle.startExitForEntireWallet();
+    await handle.startExitForVtxos([...ids]);
 }
 
 /**

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -22,8 +22,19 @@ import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
 import { assertNoActiveArkExit } from './exit';
-import type { ExitEconomicPolicy, ExitTriageResult, ExitTriageVtxo } from './exitTriage';
-import { RESERVE_FLOOR_SATS, SPIKE_MULT, triageArkExit } from './exitTriage';
+import type {
+    ExitEconomicPolicy,
+    ExitFeeUrgency,
+    ExitTriageResult,
+    ExitTriageVtxo,
+} from './exitTriage';
+import {
+    RESERVE_FLOOR_SATS,
+    SPIKE_MULT,
+    exitFeeUrgency,
+    triageArkExit,
+    urgencyFromSlackBlocks,
+} from './exitTriage';
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
 import { getArkWalletHandle } from './walletHandle';
@@ -81,6 +92,80 @@ export type ExitFeeConvertEstimate = {
  * mempool.space rather than the configured esplora (blockstream), which the
  * codebase repeatedly notes bot-blocks bark's client.
  */
+/**
+ * Which mempool.space rate each urgency band bids at. See ExitFeeUrgency for
+ * why the exit tree is not always in a hurry.
+ *
+ * `minimumFee` is deliberately absent. It is the relay floor, not a target, and
+ * an exit tx that fails to confirm does not merely arrive late, it can leave the
+ * capsule to be swept.
+ */
+const URGENCY_RATE_FIELD: Record<ExitFeeUrgency, string> = {
+    relaxed: 'economyFee',
+    moderate: 'hourFee',
+    soon: 'halfHourFee',
+    urgent: 'fastestFee',
+};
+
+/**
+ * Fee rate for the exit-tree CPFP children, at the urgency the capsules
+ * actually have.
+ *
+ * Falls back to the fastest rate present in the response, and then to the
+ * congestion-hedge constant, so a malformed or partial response bids HIGH.
+ * Under-bidding here risks the capsule; over-bidding only parks sats on-chain
+ * that stay the user's own.
+ */
+export type ExitFeeRateTable = Record<ExitFeeUrgency, number>;
+
+/**
+ * All four bands in ONE fetch.
+ *
+ * Fetched together because pricing the exit takes two passes (see
+ * computeArkExitPlan) and a second call between them would let the market move
+ * underneath the comparison, as well as costing a round trip on the exit path.
+ *
+ * Every fallback bids HIGH: a missing field falls back to the fastest rate in
+ * the response, an unusable response to the congestion hedge. Under-bidding
+ * risks the capsule, over-bidding only parks sats that stay the user's own.
+ */
+export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
+    const flat = (r: number): ExitFeeRateTable => ({
+        relaxed: r, moderate: r, soon: r, urgent: r,
+    });
+    try {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 4000);
+        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
+            signal: controller.signal,
+        });
+        clearTimeout(t);
+        if (!res.ok) return flat(RESERVE_FEE_FALLBACK_RATE);
+        const rec = await res.json();
+        const fastest = Number(rec?.fastestFee);
+        if (!isFinite(fastest) || fastest <= 0) return flat(RESERVE_FEE_FALLBACK_RATE);
+        const pick = (band: ExitFeeUrgency) => {
+            const v = Number(rec?.[URGENCY_RATE_FIELD[band]]);
+            return Math.max(1, Math.ceil(isFinite(v) && v > 0 ? v : fastest));
+        };
+        return {
+            relaxed: pick('relaxed'),
+            moderate: pick('moderate'),
+            soon: pick('soon'),
+            urgent: pick('urgent'),
+        };
+    } catch {
+        return flat(RESERVE_FEE_FALLBACK_RATE);
+    }
+}
+
+/** One band, for callers that already know their urgency (the exit drive). */
+export async function fetchExitTreeFeeRateSatPerVb(
+    urgency: ExitFeeUrgency,
+): Promise<number> {
+    return (await fetchExitFeeRates())[urgency];
+}
+
 export async function fetchFastFeeRateSatPerVb(): Promise<number> {
     try {
         const controller = new AbortController();
@@ -147,23 +232,64 @@ async function readExitCandidates(): Promise<ExitTriageVtxo[] | null> {
  *
  * Returns null only when there is no wallet handle or the VTXO read failed.
  */
+/**
+ * Deadline height from the most recent plan, for the caller to persist when it
+ * actually starts an exit. Module-level rather than on the result so the plan
+ * type stays a pure description of the exit set.
+ */
+let lastExitFeeDeadlineHeight: number | null = null;
+
+/** Deadline height the last computed plan was priced against. */
+export function getLastExitFeeDeadlineHeight(): number | null {
+    return lastExitFeeDeadlineHeight;
+}
+
 export async function computeArkExitPlan(
     opts?: { economicPolicy?: ExitEconomicPolicy },
 ): Promise<ExitTriageResult | null> {
     const vtxos = await readExitCandidates();
     if (!vtxos) return null;
 
-    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
     const s = useAuthStore.getState();
+    const chainTipHeight = s.arkChainTipHeight ?? null;
+    const vtxoExitDeltaBlocks = s.arkVtxoExitDeltaBlocks ?? null;
 
-    const plan = triageArkExit({
-        vtxos,
-        feeRateSatPerVb,
-        chainTipHeight: s.arkChainTipHeight ?? null,
-        vtxoExitDeltaBlocks: s.arkVtxoExitDeltaBlocks ?? null,
-        maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
-        economicPolicy: opts?.economicPolicy,
-    });
+    const rates = await fetchExitFeeRates();
+    const runTriage = (feeRateSatPerVb: number) =>
+        triageArkExit({
+            vtxos,
+            feeRateSatPerVb,
+            chainTipHeight,
+            vtxoExitDeltaBlocks,
+            maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
+            economicPolicy: opts?.economicPolicy,
+        });
+
+    // Pricing and selection depend on each other: the rate decides which
+    // capsules are worth exiting, and which capsules are being exited decides
+    // how urgent the rate has to be. Resolved in two passes rather than a fixed
+    // point, because the first pass IS the old behaviour and is therefore always
+    // a safe answer to fall back to.
+    //
+    // Pass 1 prices at the fastest rate, unconditionally, exactly as before. Its
+    // selection is what reveals the real urgency.
+    const urgentPlan = runTriage(rates.urgent);
+    let urgency = exitFeeUrgency(urgentPlan.selected);
+    let plan = urgentPlan;
+
+    if (rates[urgency.urgency] < rates.urgent) {
+        // Pass 2 at the rate the runway actually justifies. A cheaper rate can
+        // only ADD capsules, so re-read the urgency of that larger set: if a
+        // newcomer is tighter than anything in pass 1, the cheaper rate was not
+        // justified after all and pass 1 stands.
+        const relaxedPlan = runTriage(rates[urgency.urgency]);
+        const recheck = exitFeeUrgency(relaxedPlan.selected);
+        if (rates[recheck.urgency] <= rates[urgency.urgency]) {
+            plan = relaxedPlan;
+            urgency = recheck;
+        }
+    }
+    lastExitFeeDeadlineHeight = urgency.deadlineHeight;
 
     if (__DEV__) {
         console.log(
@@ -174,6 +300,8 @@ export async function computeArkExitPlan(
             'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
             'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
             '); policy=', plan.economicPolicy,
+            '; urgency=', urgency.urgency, 'slack=', urgency.tightestSlackBlocks, 'blocks',
+            '; rates=', JSON.stringify(rates),
             '; netLoss=', plan.netLossSats, '; overridable=', plan.overridableCount,
             plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
         );
@@ -266,6 +394,39 @@ export async function fetchArkExitParams(): Promise<void> {
     } catch (err) {
         if (__DEV__) console.warn('[Ark exit-funding] arkInfo (exit params) threw:', err);
     }
+}
+
+/**
+ * Fee rate the exit drive should bid for its CPFP children RIGHT NOW.
+ *
+ * `progressExits` used to be called with no rate at all, so bark chose one and
+ * whatever it chose had nothing to do with the reserve the user had been asked
+ * to fund. That was survivable only because the reserve was sized at the
+ * fastest rate and therefore almost always generous. Now that the reserve is
+ * priced to the runway, the bid has to be priced the same way or the two can
+ * disagree in the dangerous direction.
+ *
+ * Re-derived every tick from the persisted deadline height and the current tip,
+ * so a capsule drifting toward its expiry starts bidding harder on its own.
+ * Costs one small fee-API call and no wallet read.
+ *
+ * Returns undefined when there is no deadline to price against, which leaves
+ * the SDK's own choice in place rather than inventing one.
+ */
+export async function fetchArkExitDriveFeeRate(): Promise<bigint | undefined> {
+    const s = useAuthStore.getState();
+    const deadline = s.arkExitFeeDeadlineHeight;
+    const tip = s.arkChainTipHeight;
+    if (typeof deadline !== 'number' || typeof tip !== 'number') return undefined;
+    const urgency = urgencyFromSlackBlocks(deadline - tip);
+    const rate = await fetchExitTreeFeeRateSatPerVb(urgency);
+    if (__DEV__) {
+        console.log(
+            '[Ark exit-drive] bidding', rate, 'sat/vB;',
+            'urgency=', urgency, 'slack=', deadline - tip, 'blocks',
+        );
+    }
+    return BigInt(Math.max(1, Math.ceil(rate)));
 }
 
 /**

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -22,7 +22,7 @@ import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
 import { assertNoActiveArkExit } from './exit';
-import type { ExitTriageResult, ExitTriageVtxo } from './exitTriage';
+import type { ExitEconomicPolicy, ExitTriageResult, ExitTriageVtxo } from './exitTriage';
 import { RESERVE_FLOOR_SATS, SPIKE_MULT, triageArkExit } from './exitTriage';
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
@@ -141,9 +141,15 @@ async function readExitCandidates(): Promise<ExitTriageVtxo[] | null> {
  * axis assume the worst rather than skip (see ./exitTriage). That is the whole
  * point: the exit path has to work against a server that is gone.
  *
+ * `economicPolicy` is how far past the economics the user has chosen to go.
+ * Callers must leave it at the default until the user has been shown the loss
+ * in sats and asked (spec principle 4); it is not a retry knob.
+ *
  * Returns null only when there is no wallet handle or the VTXO read failed.
  */
-export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
+export async function computeArkExitPlan(
+    opts?: { economicPolicy?: ExitEconomicPolicy },
+): Promise<ExitTriageResult | null> {
     const vtxos = await readExitCandidates();
     if (!vtxos) return null;
 
@@ -156,6 +162,7 @@ export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
         chainTipHeight: s.arkChainTipHeight ?? null,
         vtxoExitDeltaBlocks: s.arkVtxoExitDeltaBlocks ?? null,
         maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
+        economicPolicy: opts?.economicPolicy,
     });
 
     if (__DEV__) {
@@ -166,6 +173,8 @@ export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
             'excluded', plan.excluded.length, 'holding', plan.excludedSats, 'sats;',
             'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
             'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
+            '); policy=', plan.economicPolicy,
+            '; netLoss=', plan.netLossSats, '; overridable=', plan.overridableCount,
             plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
         );
         for (const e of plan.excluded) {

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -18,48 +18,24 @@
  * of this reserve.
  */
 
+import useAuthStore from '@Cypher/stores/authStore';
+
 import { barkStateTag } from './barkState';
 import { assertNoActiveArkExit } from './exit';
+import type { ExitTriageResult, ExitTriageVtxo } from './exitTriage';
+import { RESERVE_FLOOR_SATS, SPIKE_MULT, triageArkExit } from './exitTriage';
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
 import { getArkWalletHandle } from './walletHandle';
 
 // --- Tunable sizing constants ----------------------------------------------
 //
-// The reserve is grounded in the SDK's own per-VTXO exit-cost data
-// (`Vtxo.exitTxWeightWu` = weight of the full unilateral exit tx chain, and
-// `Vtxo.exitDepth` = number of levels in that chain), so it tracks real exit
-// cost rather than a blind guess. The multipliers add headroom for the
-// multi-block window an exit spans (a fee spike mid-exit is its weak spot, and
-// per Bark's Peter you want runway to "refill the onchain wallet if you run
-// out"). All values are intentionally conservative: over-reserving is
-// harmless (the extra sats stay the user's own on-chain, and the auto-board
-// pipeline boards any excess above the reserve back into Ark later), while
-// under-reserving stalls the exit.
+// The per-capsule cost model (CPFP_CHILD_VB, FALLBACK_VB_PER_VTXO, SPIKE_MULT,
+// RESERVE_FLOOR_SATS) moved to ./exitTriage, which is the module that decides
+// which capsules the reserve is FOR. Keeping two copies would let the number
+// the user is asked to fund drift from the set it was sized over. Only the
+// fee-rate fallback, which is about fetching rather than costing, stays here.
 
-/** Per exit-tree level: the CPFP child (anchor input + funding input + change)
- *  that bumps that level. Upper-bounded; matches RECOVER_EST_VSIZE in
- *  ./recoverOnchainBoard.ts. Applied `exitDepth` times per VTXO. */
-const CPFP_CHILD_VB = 150;
-/** Headroom multiplier over the current fee rate, for a fee spike during the
- *  (multi-block) exit window. */
-const SPIKE_MULT = 2.0;
-/** Lower bound whenever there is anything to exit, so a low fee rate (or a
- *  runtime `exitTxWeightWu` of 0) still reserves enough for at least one CPFP
- *  child at a moderate rate. Kept below the 50k board minimum so it doesn't
- *  over-hoard on-chain.
- *
- *  Sized to the stated rationale (one CPFP child ~150 vB at a moderate rate
- *  with the spike buffer), not a flat 10k. The old 10k floor over-reserved
- *  small exits by 2-4x their real cost and, combined with the (soft) fee gate,
- *  made a well-funded small vault look unfundable for exit. This is guidance
- *  only now: the exit stays startable via "Start exit anyway" whenever there
- *  is any on-chain balance, so the floor no longer blocks — it just sets the
- *  auto-board hold target. */
-const RESERVE_FLOOR_SATS = 5_000;
-/** Fallback per-VTXO vsize used only if the SDK returns `exitTxWeightWu === 0`
- *  at runtime (the type says it's populated; guard anyway). */
-const FALLBACK_VB_PER_VTXO = 200;
 /** Fee-rate fallback (sat/vB) when the mempool fetch fails. Deliberately not
  *  tiny, since an emergency exit may run during congestion, but not the old
  *  20 either: on a flaky network the fee fetch fails often, and 20 sat/vB
@@ -74,12 +50,18 @@ export type ExitFeeReserve = {
     /** Recommended sats to hold on-chain to fund the exit. 0 when nothing is
      *  exitable (so a nothing-to-exit wallet is never gated). */
     recommendedSats: number;
-    /** Count of VTXOs the reserve was sized over. */
+    /** Count of VTXOs the reserve was sized over: the SELECTED set, not the
+     *  wallet. */
     vtxoCount: number;
     /** Fee rate (sat/vB) the recommendation was computed at. */
     feeRateSatPerVb: number;
-    /** Summed exit vsize across the exitable VTXOs (pre-multiplier). */
+    /** Summed exit vsize across the SELECTED VTXOs (pre-multiplier). */
     totalExitVb: number;
+    /** Capsules triage dropped from the exit set. */
+    excludedCount: number;
+    /** Face value of those capsules, which is what the user is being asked to
+     *  give up. Never allow this to be non-zero without naming them. */
+    excludedSats: number;
 };
 
 export type ExitFeeConvertEstimate = {
@@ -118,16 +100,98 @@ export async function fetchFastFeeRateSatPerVb(): Promise<number> {
 }
 
 /**
- * Compute the recommended on-chain fee reserve for a full-wallet exit.
+ * Read every capsule the exit could touch, in the flat shape ./exitTriage
+ * wants.
  *
- * Reads `handle.allVtxos()` fresh (the store's `ArkVtxoView` drops
- * `exitTxWeightWu` / `exitDepth`, so the cached VTXO list can't be reused).
- * (allVtxos is a JS-thread-blocking UniFFI call; call this off the render
- * path.) Filters to non-spent VTXOs, mirroring the wallet-exit set that
- * `startExitForEntireWallet` marks.
+ * Reads `handle.allVtxos()` fresh: the store's `ArkVtxoView` drops
+ * `exitTxWeightWu` and `exitDepth`, which are exactly the two fields the whole
+ * cost model turns on, so the cached VTXO list cannot be reused. allVtxos is a
+ * JS-thread-blocking UniFFI call, so keep this off the render path.
+ */
+async function readExitCandidates(): Promise<ExitTriageVtxo[] | null> {
+    const handle = getArkWalletHandle();
+    if (!handle) return null;
+    try {
+        const vtxos = await handle.allVtxos();
+        return (vtxos ?? []).map((v) => ({
+            id: v.id,
+            sats: Number(v.amountSats ?? 0n),
+            exitDepth: Number(v.exitDepth ?? 0),
+            exitTxWeightWu: Number(v.exitTxWeightWu ?? 0n),
+            expiryHeight: Number(v.expiryHeight ?? 0),
+            // bark 0.6.1: `state` is a tagged-enum object; flatten to its
+            // variant string so triage can compare it.
+            stateTag: barkStateTag(v.state),
+            registered: v.registered,
+        }));
+    } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] allVtxos threw:', err);
+        return null;
+    }
+}
+
+/**
+ * Decide which capsules an emergency exit should actually exit, and what that
+ * costs. This is the function the exit-start path calls: its `selectedIds` go
+ * to `startExitForVtxos`, and its `excluded` list is what the user has to be
+ * shown before they commit.
  *
- * Returns `recommendedSats: 0` when the wallet handle is unset or there is
- * nothing exitable.
+ * Takes no ASP call. `vtxoExitDelta` comes from the persisted cache written
+ * while the server was last reachable, and a missing cache makes the temporal
+ * axis assume the worst rather than skip (see ./exitTriage). That is the whole
+ * point: the exit path has to work against a server that is gone.
+ *
+ * Returns null only when there is no wallet handle or the VTXO read failed.
+ */
+export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
+    const vtxos = await readExitCandidates();
+    if (!vtxos) return null;
+
+    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
+    const s = useAuthStore.getState();
+
+    const plan = triageArkExit({
+        vtxos,
+        feeRateSatPerVb,
+        chainTipHeight: s.arkChainTipHeight ?? null,
+        vtxoExitDeltaBlocks: s.arkVtxoExitDeltaBlocks ?? null,
+        maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
+    });
+
+    if (__DEV__) {
+        console.log(
+            '[Ark exit-triage] selected', plan.selected.length, 'of',
+            plan.selected.length + plan.excluded.length, 'capsules;',
+            plan.selectedSats, 'sats in,', plan.netRecoverableSats, 'recoverable;',
+            'excluded', plan.excluded.length, 'holding', plan.excludedSats, 'sats;',
+            'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
+            'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
+            plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
+        );
+        for (const e of plan.excluded) {
+            console.log(
+                `[Ark exit-triage] excluded ${e.id} ${e.sats} sats depth=${e.exitDepth}`,
+                `perVtxoVb=${e.perVtxoVb} reason=${e.reason}`,
+            );
+        }
+    }
+
+    return plan;
+}
+
+/**
+ * Recommended on-chain fee reserve, sized over the capsules the exit will
+ * ACTUALLY exit.
+ *
+ * It used to sum every non-spent VTXO, which billed the user for two things
+ * they never get back. Measured on the QA wallet 2026-08-20: dust that triage
+ * now discards was 66% of the demanded reserve (32,120 down to 10,808), and ten
+ * already-`Exited` capsules, which bark keeps returning from `allVtxos()`
+ * forever, added another 14,504 sats of reserve for value that was already
+ * on-chain.
+ *
+ * Returns `recommendedSats: 0` when the wallet handle is unset or nothing
+ * survives triage, so a wallet with nothing worth exiting is never gated.
  */
 export async function computeExitFeeReserveSats(): Promise<ExitFeeReserve> {
     const empty: ExitFeeReserve = {
@@ -135,55 +199,64 @@ export async function computeExitFeeReserveSats(): Promise<ExitFeeReserve> {
         vtxoCount: 0,
         feeRateSatPerVb: 0,
         totalExitVb: 0,
+        excludedCount: 0,
+        excludedSats: 0,
     };
 
-    const handle = getArkWalletHandle();
-    if (!handle) return empty;
-
-    let vtxos;
-    try {
-        vtxos = await handle.allVtxos();
-    } catch (err) {
-        if (__DEV__) console.warn('[Ark exit-funding] allVtxos threw:', err);
-        return empty;
-    }
-
-    const exitable = (vtxos ?? []).filter(
-        // bark 0.6.1: `state` is a tagged-enum object; read its variant string.
-        // Same semantics as before: exclude already-spent vtxos from the
-        // exit-fee estimate.
-        (v) => barkStateTag(v.state).toLowerCase() !== 'spent',
-    );
-    if (exitable.length === 0) return empty;
-
-    let totalExitVb = 0;
-    for (const v of exitable) {
-        const chainVb = Math.ceil(Number(v.exitTxWeightWu ?? 0n) / 4);
-        const perVtxoVb =
-            Math.max(chainVb, FALLBACK_VB_PER_VTXO) +
-            Math.max(0, Number(v.exitDepth ?? 0)) * CPFP_CHILD_VB;
-        totalExitVb += perVtxoVb;
-    }
-
-    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
-    const computed = Math.ceil(totalExitVb * feeRateSatPerVb * SPIKE_MULT);
-    const recommendedSats = Math.max(RESERVE_FLOOR_SATS, computed);
+    const plan = await computeArkExitPlan();
+    if (!plan) return empty;
 
     if (__DEV__) {
         console.log(
             '[Ark exit-funding] reserve:',
-            recommendedSats, 'sats over', exitable.length, 'vtxos;',
-            'totalExitVb=', totalExitVb,
-            'feeRate=', feeRateSatPerVb, 'sat/vB; spikeMult=', SPIKE_MULT,
+            plan.reserveSats, 'sats over', plan.selected.length, 'selected vtxos;',
+            'totalExitVb=', plan.totalExitVb,
+            'feeRate=', plan.feeRateSatPerVb, 'sat/vB; spikeMult=', SPIKE_MULT,
+            '; floor=', RESERVE_FLOOR_SATS,
         );
     }
 
     return {
-        recommendedSats,
-        vtxoCount: exitable.length,
-        feeRateSatPerVb,
-        totalExitVb,
+        recommendedSats: plan.reserveSats,
+        vtxoCount: plan.selected.length,
+        feeRateSatPerVb: plan.feeRateSatPerVb,
+        totalExitVb: plan.totalExitVb,
+        excludedCount: plan.excluded.length,
+        excludedSats: plan.excludedSats,
     };
+}
+
+/**
+ * Cache the server's exit-relevant protocol constants so the exit path never
+ * has to ask for them.
+ *
+ * `vtxoExitDelta` is the CSV a broadcast exit output sits out before it can be
+ * claimed, and it is what exit triage measures a capsule's remaining runway
+ * against. The exit path is not allowed to call the ASP (a user who pressed the
+ * trustless button must get the trustless path, and the server may simply be
+ * gone), so this has to be fetched while the server is still reachable and
+ * persisted. A missing cache is handled, not fatal: triage assumes the worst
+ * plausible delta, which errs toward disclosing an exclusion rather than
+ * committing reserve to a capsule the server can sweep mid-exit.
+ *
+ * Called once per session from the sync loop, next to the round-interval
+ * fetch. Never throws.
+ */
+export async function fetchArkExitParams(): Promise<void> {
+    const handle = getArkWalletHandle();
+    if (!handle) return;
+    try {
+        const info = await handle.arkInfo();
+        if (!info) return;
+        const delta = Number(info.vtxoExitDelta);
+        const maxDepth = Number(info.maxVtxoExitDepth);
+        useAuthStore.getState().setArkExitParams({
+            vtxoExitDeltaBlocks: Number.isFinite(delta) && delta > 0 ? delta : null,
+            maxVtxoExitDepth: Number.isFinite(maxDepth) && maxDepth > 0 ? maxDepth : null,
+        });
+    } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] arkInfo (exit params) threw:', err);
+    }
 }
 
 /**

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -21,17 +21,22 @@
 import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
+import { ESPLORA_URLS } from './config';
 import { assertNoActiveArkExit } from './exit';
 import type {
     ExitEconomicPolicy,
+    ExitFeeRateTable,
     ExitFeeUrgency,
     ExitTriageResult,
     ExitTriageVtxo,
 } from './exitTriage';
 import {
+    EXIT_FEE_FALLBACK_RATES,
     RESERVE_FLOOR_SATS,
     SPIKE_MULT,
     exitFeeUrgency,
+    ratesFromEsploraEstimates,
+    ratesFromMempoolRecommended,
     triageArkExit,
     urgencyFromSlackBlocks,
 } from './exitTriage';
@@ -93,21 +98,6 @@ export type ExitFeeConvertEstimate = {
  * codebase repeatedly notes bot-blocks bark's client.
  */
 /**
- * Which mempool.space rate each urgency band bids at. See ExitFeeUrgency for
- * why the exit tree is not always in a hurry.
- *
- * `minimumFee` is deliberately absent. It is the relay floor, not a target, and
- * an exit tx that fails to confirm does not merely arrive late, it can leave the
- * capsule to be swept.
- */
-const URGENCY_RATE_FIELD: Record<ExitFeeUrgency, string> = {
-    relaxed: 'economyFee',
-    moderate: 'hourFee',
-    soon: 'halfHourFee',
-    urgent: 'fastestFee',
-};
-
-/**
  * Fee rate for the exit-tree CPFP children, at the urgency the capsules
  * actually have.
  *
@@ -116,50 +106,60 @@ const URGENCY_RATE_FIELD: Record<ExitFeeUrgency, string> = {
  * Under-bidding here risks the capsule; over-bidding only parks sats on-chain
  * that stay the user's own.
  */
-export type ExitFeeRateTable = Record<ExitFeeUrgency, number>;
-
 /**
- * All four bands in ONE fetch.
+ * All four bands, from the best source that answers.
  *
- * Fetched together because pricing the exit takes two passes (see
- * computeArkExitPlan) and a second call between them would let the market move
- * underneath the comparison, as well as costing a round trip on the exit path.
+ * Three sources, in order, because a single fee API is a single point of
+ * failure and it fired on the first day: mempool.space was unreachable from
+ * both the device and the dev machine on 2026-08-20, which collapsed every band
+ * to one constant and undid the runway pricing entirely.
  *
- * Every fallback bids HIGH: a missing field falls back to the fastest rate in
- * the response, an unusable response to the congestion hedge. Under-bidding
- * risks the capsule, over-bidding only parks sats that stay the user's own.
+ *   1. mempool.space named tiers, the richest signal
+ *   2. esplora /fee-estimates, keyed by confirmation target, across the same
+ *      providers the wallet already rotates (blockstream answered when
+ *      mempool.space did not)
+ *   3. band-aware constants, which still respect urgency rather than flattening
+ *
+ * Fetched as a table rather than one band at a time because pricing the exit
+ * takes more than one pass (see computeArkExitPlan) and refetching between them
+ * would let the market move underneath the comparison.
  */
 export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
-    const flat = (r: number): ExitFeeRateTable => ({
-        relaxed: r, moderate: r, soon: r, urgent: r,
-    });
-    try {
-        const controller = new AbortController();
-        const t = setTimeout(() => controller.abort(), 4000);
-        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
-            signal: controller.signal,
-        });
-        clearTimeout(t);
-        if (!res.ok) return flat(RESERVE_FEE_FALLBACK_RATE);
-        const rec = await res.json();
-        const fastest = Number(rec?.fastestFee);
-        if (!isFinite(fastest) || fastest <= 0) return flat(RESERVE_FEE_FALLBACK_RATE);
-        const pick = (band: ExitFeeUrgency) => {
-            const v = Number(rec?.[URGENCY_RATE_FIELD[band]]);
-            return Math.max(1, Math.ceil(isFinite(v) && v > 0 ? v : fastest));
-        };
-        return {
-            relaxed: pick('relaxed'),
-            moderate: pick('moderate'),
-            soon: pick('soon'),
-            urgent: pick('urgent'),
-        };
-    } catch {
-        return flat(RESERVE_FEE_FALLBACK_RATE);
+    const get = async (url: string): Promise<unknown | null> => {
+        try {
+            const controller = new AbortController();
+            const t = setTimeout(() => controller.abort(), 4000);
+            const res = await fetch(url, { signal: controller.signal });
+            clearTimeout(t);
+            if (!res.ok) return null;
+            return await res.json();
+        } catch {
+            return null;
+        }
+    };
+
+    const recommended = await get('https://mempool.space/api/v1/fees/recommended');
+    const fromMempool = ratesFromMempoolRecommended(recommended);
+    if (fromMempool) return fromMempool;
+
+    for (const base of ESPLORA_URLS) {
+        const est = await get(`${base}/fee-estimates`);
+        const fromEsplora = ratesFromEsploraEstimates(est);
+        if (fromEsplora) {
+            if (__DEV__) console.log('[Ark exit-funding] fee rates via esplora', base, fromEsplora);
+            return fromEsplora;
+        }
     }
+
+    if (__DEV__) {
+        console.warn(
+            '[Ark exit-funding] every fee source unreachable; using band-aware fallback',
+            EXIT_FEE_FALLBACK_RATES,
+        );
+    }
+    return EXIT_FEE_FALLBACK_RATES;
 }
 
-/** One band, for callers that already know their urgency (the exit drive). */
 export async function fetchExitTreeFeeRateSatPerVb(
     urgency: ExitFeeUrgency,
 ): Promise<number> {
@@ -267,25 +267,32 @@ export async function computeArkExitPlan(
 
     // Pricing and selection depend on each other: the rate decides which
     // capsules are worth exiting, and which capsules are being exited decides
-    // how urgent the rate has to be. Resolved in two passes rather than a fixed
-    // point, because the first pass IS the old behaviour and is therefore always
-    // a safe answer to fall back to.
-    //
-    // Pass 1 prices at the fastest rate, unconditionally, exactly as before. Its
-    // selection is what reveals the real urgency.
+    // how urgent the rate has to be. Resolved by probing rather than iterating
+    // to a fixed point, because the dearest pass IS the old behaviour and is
+    // therefore always a safe answer to fall back to.
     const urgentPlan = runTriage(rates.urgent);
-    let urgency = exitFeeUrgency(urgentPlan.selected);
     let plan = urgentPlan;
+    let urgency = exitFeeUrgency(urgentPlan.selected);
+
+    if (urgentPlan.selected.length === 0 && rates.relaxed < rates.urgent) {
+        // Nothing survives at the dearest rate, so there is no selection to read
+        // an urgency off, and taking the empty set's 'urgent' at face value
+        // pins the rate high and keeps the answer permanently empty. Probe the
+        // cheapest band: if anything IS exitable down there, its own runway
+        // decides the real rate below.
+        const cheapest = runTriage(rates.relaxed);
+        if (cheapest.selected.length > 0) urgency = exitFeeUrgency(cheapest.selected);
+    }
 
     if (rates[urgency.urgency] < rates.urgent) {
-        // Pass 2 at the rate the runway actually justifies. A cheaper rate can
-        // only ADD capsules, so re-read the urgency of that larger set: if a
-        // newcomer is tighter than anything in pass 1, the cheaper rate was not
-        // justified after all and pass 1 stands.
-        const relaxedPlan = runTriage(rates[urgency.urgency]);
-        const recheck = exitFeeUrgency(relaxedPlan.selected);
-        if (rates[recheck.urgency] <= rates[urgency.urgency]) {
-            plan = relaxedPlan;
+        // Price at what the runway justifies. A cheaper rate can only ADD
+        // capsules, so re-read the urgency of that larger set: if a newcomer is
+        // tighter than anything already counted, the cheaper rate was not
+        // justified after all and the dearest pass stands.
+        const cheaperPlan = runTriage(rates[urgency.urgency]);
+        const recheck = exitFeeUrgency(cheaperPlan.selected);
+        if (cheaperPlan.selected.length > 0 && rates[recheck.urgency] <= rates[urgency.urgency]) {
+            plan = cheaperPlan;
             urgency = recheck;
         }
     }

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -1,0 +1,483 @@
+/**
+ * Which capsules a unilateral exit should actually exit, and what that costs.
+ *
+ * Pure and import-free on purpose, so it stays unit-testable without the native
+ * bark module, matching exitFundingPlan.ts, refreshBatch.ts, exitReserveTarget.ts
+ * and autoBoardDecision.ts.
+ *
+ * WHY THIS EXISTS
+ *
+ * `startExitForEntireWallet()` marks every VTXO and `computeExitFeeReserveSats`
+ * sums every non-spent VTXO, so an exit chases capsules it can never recover and
+ * bills the user for the privilege. Measured 2026-08-20 on the QA wallet at
+ * 1 sat/vB: exiting all 8 live capsules costs 16,060 sats of exit-tree fees to
+ * rescue 4,990 sats of value, and two 400-sat capsules are 10,656 of that (66%)
+ * while holding 16% of the value. Excluding those two takes the demanded reserve
+ * from 32,120 to 10,808.
+ *
+ * The failure mode is not the claim. `drainExits` batches, so a small capsule
+ * adds roughly one input (~76 vB) and returns its value; it pays for itself at
+ * claim time. The damage is that dust silently consumes the CPFP reserve the
+ * healthy capsules need, and with no ordering policy, which capsules get
+ * stranded when the reserve runs dry is undefined.
+ *
+ * THE THRESHOLD IS NOT A SAT AMOUNT
+ *
+ * A 400-sat capsule at exitDepth 17 costs 5,645 vB and is hopeless. A 400 at
+ * depth 2 costs 632 vB and is merely marginal. The rule is computed per capsule
+ * from `exitDepth` and `exitTxWeightWu`. ARK_REFRESH_MIN_SATS (500) is the
+ * REFRESH floor and is the wrong tool here.
+ *
+ * TWO POTS, NEVER ONE THRESHOLD
+ *
+ * The exit-tree cost is charged to the on-chain reserve the user funds
+ * separately. The claim cost comes out of the capsule itself. Summing them into
+ * a single number would misprice both, so they are tracked separately all the
+ * way through.
+ */
+
+// --- Cost model ------------------------------------------------------------
+//
+// Single source of truth for per-capsule exit cost. exitFunding.ts imports
+// these rather than keeping its own copy, so the reserve the user is asked to
+// fund and the triage that decides what the reserve is for can never disagree.
+
+/** Per exit-tree level: the CPFP child (anchor input + funding input + change)
+ *  that bumps that level. Upper-bounded; matches RECOVER_EST_VSIZE in
+ *  ./recoverOnchainBoard.ts. Applied `exitDepth` times per capsule. */
+export const CPFP_CHILD_VB = 150;
+
+/** Fallback per-capsule vsize used only when the SDK reports
+ *  `exitTxWeightWu === 0`. Measured across 196 capsules on 2026-08-19: zero
+ *  report 0, including all 117 unregistered ones. Guard anyway. */
+export const FALLBACK_VB_PER_VTXO = 200;
+
+/** Headroom multiplier over the current fee rate, for a fee spike during the
+ *  multi-block exit window. */
+export const SPIKE_MULT = 2.0;
+
+/** Lower bound whenever there is anything to exit, so a low fee rate still
+ *  reserves enough for at least one CPFP child at a moderate rate. Kept below
+ *  the 50k board minimum so it does not over-hoard on-chain. */
+export const RESERVE_FLOOR_SATS = 5_000;
+
+/** Marginal vsize one more capsule adds to a batched `drainExits` claim.
+ *  Measured 2026-08-19/20: a standalone 1-in-1-out claim is 117.5 vB
+ *  (224 bytes, 470 wu) and each extra input adds ~76. The marginal figure is
+ *  the right one because the app always claims through one batched
+ *  `drainExits`, so the transaction overhead is paid once for the whole exit,
+ *  not once per capsule. */
+export const CLAIM_INPUT_VB = 76;
+
+/** Blocks of confirmation runway assumed per exit-tree level.
+ *
+ *  MODELLED, not measured. Each level spends the level above it, so a level
+ *  cannot be broadcast until its parent confirms, and the drive that broadcasts
+ *  them is foreground-only and rate-limited by the chain source. One block per
+ *  level would assume every CPFP child lands in the next block with the app
+ *  open throughout, which the 2026-08-17/20 exit did not manage. Six blocks
+ *  (about an hour) per level keeps the temporal axis conservative in the safe
+ *  direction: it excludes a capsule slightly too early rather than committing
+ *  reserve to one the server can sweep mid-exit. */
+export const BLOCKS_PER_EXIT_LEVEL = 6;
+
+/** Floor on the confirmation budget, so a shallow tree still gets real runway. */
+export const MIN_CONFIRMATION_BUDGET_BLOCKS = 6;
+
+/** CSV delta assumed when `ArkInfo.vtxoExitDelta` was never cached.
+ *
+ *  The exit path must not call the ASP (spec principle 2), so a missing cache
+ *  cannot be resolved at exit time. Observed mainnet value is 144. Assuming the
+ *  worst plausible delta rather than skipping the check means doubling it, the
+ *  same 2x posture SPIKE_MULT takes toward fee rates. A capsule excluded on the
+ *  assumed delta is named to the user, so the cost of being wrong here is a
+ *  disclosed exclusion, not a silent loss. */
+export const ASSUMED_EXIT_DELTA_BLOCKS = 288;
+
+/** How far under water a capsule may be and still be worth exiting.
+ *
+ *  A capsule is worth exiting outright when the reserve it consumes is less
+ *  than what it returns. Almost nothing clears that bar: at 1 sat/vB, in the
+ *  cheapest fee market in years, the BEST capsule in the measured wallet (698
+ *  sats, depth 2) spends 632 of reserve to return 622. So a strict
+ *  cost-under-value rule would exclude the entire wallet and the emergency exit
+ *  would do nothing.
+ *
+ *  The honest line is degree, not sign. Refusing to exit a capsule that spends
+ *  632 to return 622 abandons 622 sats to the server to save 10 sats of
+ *  reserve, which is worse for the user in every direction. Refusing one that
+ *  spends 5,645 to return 324 saves seventeen times what it costs. This
+ *  multiple is where those two cases separate: spend up to twice what comes
+ *  back, never seventeen times.
+ *
+ *  It is scale-aware without being fee-rate-blind, because both sides move with
+ *  the fee rate and the claim side eats the value: the same 698 at depth 2 is
+ *  1.0x under water at 1 sat/vB, 9.9x at 5, and returns nothing at all at 20. */
+export const MAX_RESERVE_MULTIPLE = 2;
+
+/** VTXO states that hold nothing to exit. `Exited` matters as much as `Spent`
+ *  here: bark keeps returning a completed exit's VTXO from `allVtxos()` as
+ *  `Exited` forever, and the reserve calc used to filter only `spent`, so ten
+ *  finished exits on the measured wallet added 7,252 vB (14,504 sats of
+ *  demanded reserve, 31% of the total) for capsules whose value is already
+ *  on-chain. */
+const TERMINAL_STATE_TAGS = new Set(['spent', 'exited']);
+
+// --- Types -----------------------------------------------------------------
+
+/** One capsule, flattened from the SDK's `Vtxo` at the call boundary so this
+ *  module never touches bigint or the native module. */
+export type ExitTriageVtxo = {
+    id: string;
+    sats: number;
+    /** Genesis chain length. Dominates cost: measured min 2, median 9, max 49. */
+    exitDepth: number;
+    /** Weight units of the unilateral exit transaction chain. */
+    exitTxWeightWu: number;
+    /** Absolute block height the capsule expires at. 0 when unknown. */
+    expiryHeight: number;
+    /** `Vtxo.state` flattened to its variant name (see ./barkState). */
+    stateTag: string;
+    /** Server recovery-mailbox flag. Does NOT affect exitability: measured
+     *  2026-08-19, all 117 unregistered capsules carry a full exit chain. */
+    registered?: boolean;
+};
+
+/** Why a capsule holding value is not in the exit set. Every one of these is
+ *  surfaced to the user by name and amount before they commit (spec principle
+ *  3). Terminal capsules are deliberately NOT in this union: they hold nothing,
+ *  the user has never seen them, and listing them would bury the exclusions
+ *  that matter. The measured wallet carries 188 of them against 8 live ones. */
+export type ExitExclusionReason =
+    /** Structural: the SDK reports no exit chain for this capsule. */
+    | 'no-exit-chain'
+    /** Temporal: the server can sweep it before the exit clears its CSV. */
+    | 'too-close-to-expiry'
+    /** Economic: its own claim fee is at least its whole value. */
+    | 'returns-nothing'
+    /** Economic: the reserve it consumes dwarfs what it returns. */
+    | 'reserve-dwarfs-value';
+
+/** Disclosures that do not change the decision but the user should still see. */
+export type ExitTriageNote =
+    /** Chain tip or expiry height unknown, so runway could not be checked. */
+    | 'expiry-unknown'
+    /** Past `ArkInfo.maxVtxoExitDepth`: the server will not cosign further
+     *  arkoor spends, so exit or refresh are the only remaining moves. */
+    | 'beyond-server-depth-cap'
+    /** Included despite costing more reserve than it returns. */
+    | 'under-water';
+
+export type ExitEconomicVerdict = 'profitable' | 'marginal' | 'uneconomic';
+
+export type ExitTriageEntry = {
+    id: string;
+    sats: number;
+    exitDepth: number;
+    /** Exit-tree vsize for this capsule alone. */
+    perVtxoVb: number;
+    /** Reserve this capsule consumes at the given fee rate, priced at the bare
+     *  rate. The SPIKE_MULT headroom is deliberately NOT applied here: it is
+     *  volatility cover for the exit as a whole, and charging it per capsule
+     *  inside the profitability test would double-penalise every capsule and
+     *  exclude a wallet that is merely fee-sensitive. Sum over the selected set
+     *  times SPIKE_MULT is `reserveSats`. */
+    exitTreeCostSats: number;
+    /** Fee this capsule adds to the batched claim, paid out of its own value. */
+    marginalClaimSats: number;
+    /** What actually reaches the user's address: value minus its claim fee. */
+    netRecoveredSats: number;
+    economic: ExitEconomicVerdict;
+    /** Blocks until expiry, or null when the tip or expiry height is unknown. */
+    blocksUntilExpiry: number | null;
+    /** Blocks of runway this capsule needs: confirmation budget + CSV delta. */
+    requiredRunwayBlocks: number;
+    included: boolean;
+    reason?: ExitExclusionReason;
+    notes: ExitTriageNote[];
+};
+
+export type TriageArkExitInput = {
+    vtxos: readonly ExitTriageVtxo[];
+    /** Rate the exit-tree CPFP children are priced at (the fast rate). */
+    feeRateSatPerVb: number;
+    /** Rate the claim is priced at. A claim races nothing and its fee comes out
+     *  of the claimed value, so it is a genuinely different rate from the
+     *  time-critical CPFP one. Defaults to `claimRateFromExitRate`, which is
+     *  what the app actually pays; a default of the raw fast rate would have
+     *  triage condemn capsules the claim path would have recovered fine. */
+    claimFeeRateSatPerVb?: number;
+    /** Current tip. null when every chain-source provider failed. */
+    chainTipHeight: number | null;
+    /** Cached `ArkInfo.vtxoExitDelta`. null falls back to
+     *  ASSUMED_EXIT_DELTA_BLOCKS rather than skipping the temporal axis. */
+    vtxoExitDeltaBlocks: number | null;
+    /** Cached `ArkInfo.maxVtxoExitDepth`, for the disclosure note only. */
+    maxVtxoExitDepth?: number | null;
+    /** Whether capsules that cost more reserve than they return, but by less
+     *  than MAX_RESERVE_MULTIPLE, are exited. Default true: excluding them
+     *  abandons real value to save a trivial amount of reserve. Exposed so the
+     *  UI can offer the opt-out spec principle 4 calls for. */
+    includeMarginal?: boolean;
+};
+
+export type ExitTriageResult = {
+    /** Ids to hand `startExitForVtxos`, ordered most net-recoverable first so a
+     *  reserve that runs dry strands the least valuable capsules (spec 4.4). */
+    selectedIds: string[];
+    selected: ExitTriageEntry[];
+    /** Capsules that hold value and are being left behind, largest first, so
+     *  disclosure leads with the biggest amount the user is giving up. */
+    excluded: ExitTriageEntry[];
+    /** Spent / already-Exited capsules skipped before triage. Counted rather
+     *  than listed: they hold nothing, so they are a reserve-sizing concern,
+     *  not a disclosure one. */
+    skippedTerminalCount: number;
+    /** Face value of the selected capsules. */
+    selectedSats: number;
+    /** What the selected capsules actually deliver, after their claim fees. */
+    netRecoverableSats: number;
+    /** Face value the user is being asked to abandon. */
+    excludedSats: number;
+    /** Summed exit vsize over the SELECTED capsules only (spec 4.3). */
+    totalExitVb: number;
+    /** Recommended on-chain reserve for the selected set. 0 when nothing is
+     *  selected, so a nothing-to-exit wallet is never gated. */
+    reserveSats: number;
+    /** Selected capsules that cost more reserve than they return. */
+    underWaterCount: number;
+    feeRateSatPerVb: number;
+    claimFeeRateSatPerVb: number;
+    /** True when the temporal axis ran on ASSUMED_EXIT_DELTA_BLOCKS. */
+    usedAssumedExitDelta: boolean;
+};
+
+// --- Cost model helpers ----------------------------------------------------
+
+/**
+ * Exit-tree vsize for one capsule: the chain itself plus a CPFP child per
+ * level. This is the term that varies 25x inside a single wallet, and it is why
+ * a sat-denominated dust threshold cannot express the rule.
+ */
+export function perVtxoExitVb(v: Pick<ExitTriageVtxo, 'exitDepth' | 'exitTxWeightWu'>): number {
+    const chainVb = Math.ceil(Math.max(0, Number(v.exitTxWeightWu) || 0) / 4);
+    const depth = Math.max(0, Math.floor(Number(v.exitDepth) || 0));
+    return Math.max(chainVb, FALLBACK_VB_PER_VTXO) + depth * CPFP_CHILD_VB;
+}
+
+/**
+ * Reserve for a given total exit vsize. Zero vsize means nothing to exit and
+ * must return 0, NOT the floor, or a wallet with nothing exitable would be
+ * gated on a 5,000 sat reserve it has no use for.
+ */
+export function reserveSatsForExitVb(totalExitVb: number, feeRateSatPerVb: number): number {
+    if (totalExitVb <= 0) return 0;
+    const rate = Math.max(0, Number(feeRateSatPerVb) || 0);
+    return Math.max(RESERVE_FLOOR_SATS, Math.ceil(totalExitVb * rate * SPIKE_MULT));
+}
+
+/**
+ * Blocks a capsule needs between now and its expiry for an exit to be safe:
+ * long enough for its tree to confirm, and then to sit out the CSV delta. Below
+ * this the server can sweep the capsule while the exit is still timelocked, so
+ * the user loses both the capsule and the reserve spent chasing it.
+ */
+export function requiredRunwayBlocks(exitDepth: number, exitDeltaBlocks: number): number {
+    const depth = Math.max(0, Math.floor(Number(exitDepth) || 0));
+    const confirmationBudget = Math.max(
+        MIN_CONFIRMATION_BUDGET_BLOCKS,
+        depth * BLOCKS_PER_EXIT_LEVEL,
+    );
+    return confirmationBudget + Math.max(0, Math.floor(exitDeltaBlocks));
+}
+
+/** Bounds on the CLAIM fee rate, which is a different problem from the exit-tree
+ *  CPFP rate the reserve is sized at.
+ *
+ *  The CPFP children are time-critical: the tree has to confirm before the
+ *  capsule expires, so paying for speed there buys something real, out of the
+ *  reserve. A claim is the opposite. It spends an output whose CSV has already
+ *  matured, it races nothing, and its fee comes out of the claimed value. Worse,
+ *  an over-priced claim does not fail slowly, it fails permanently: bark refuses
+ *  to build a claim whose fee exceeds its output, and the drive rebuilds the
+ *  same doomed claim forever. Observed live 2026-08-19 at 779 sats against a
+ *  698 sat output, at a moment when the mempool wanted 1. */
+const CLAIM_RATE_MIN = 1;
+const CLAIM_RATE_MAX = 5;
+
+/**
+ * Claim rate to price the economic axis at, derived from the exit-tree rate.
+ * Clamped, because triage that prices claims at the fastest rate would call a
+ * healthy capsule unrecoverable during any fee spike.
+ */
+export function claimRateFromExitRate(feeRateSatPerVb: number): number {
+    const rate = Math.ceil(Math.max(0, Number(feeRateSatPerVb) || 0));
+    return Math.min(CLAIM_RATE_MAX, Math.max(CLAIM_RATE_MIN, rate));
+}
+
+// --- Triage ----------------------------------------------------------------
+
+/**
+ * Partition every capsule on the three axes of spec 4.2 and size the reserve to
+ * what survives. Pure: no IO, no store reads, no SDK calls. The caller reads
+ * `allVtxos()`, flattens, and threads through the cached chain tip and ArkInfo
+ * deltas.
+ */
+export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
+    const feeRate = Math.max(0, Number(input.feeRateSatPerVb) || 0);
+    const claimRate =
+        input.claimFeeRateSatPerVb == null
+            ? claimRateFromExitRate(feeRate)
+            : Math.max(0, Number(input.claimFeeRateSatPerVb) || 0);
+    const includeMarginal = input.includeMarginal !== false;
+
+    const usedAssumedExitDelta =
+        input.vtxoExitDeltaBlocks == null || !Number.isFinite(input.vtxoExitDeltaBlocks);
+    const exitDelta = usedAssumedExitDelta
+        ? ASSUMED_EXIT_DELTA_BLOCKS
+        : Math.max(0, Math.floor(input.vtxoExitDeltaBlocks as number));
+
+    const tip =
+        typeof input.chainTipHeight === 'number' && Number.isFinite(input.chainTipHeight)
+            ? Math.floor(input.chainTipHeight)
+            : null;
+
+    const maxDepth =
+        typeof input.maxVtxoExitDepth === 'number' && input.maxVtxoExitDepth > 0
+            ? input.maxVtxoExitDepth
+            : null;
+
+    const selected: ExitTriageEntry[] = [];
+    const excluded: ExitTriageEntry[] = [];
+    let skippedTerminalCount = 0;
+
+    for (const v of input.vtxos ?? []) {
+        const sats = Math.max(0, Math.floor(Number(v.sats) || 0));
+        const perVb = perVtxoExitVb(v);
+        const marginalClaimSats = Math.ceil(CLAIM_INPUT_VB * claimRate);
+        const netRecoveredSats = sats - marginalClaimSats;
+        const exitTreeCostSats = Math.ceil(perVb * feeRate);
+
+        const notes: ExitTriageNote[] = [];
+        if (maxDepth != null && v.exitDepth > maxDepth) notes.push('beyond-server-depth-cap');
+
+        const blocksUntilExpiry =
+            tip != null && v.expiryHeight > 0 ? v.expiryHeight - tip : null;
+        const runway = requiredRunwayBlocks(v.exitDepth, exitDelta);
+
+        const economic: ExitEconomicVerdict =
+            netRecoveredSats <= 0
+                ? 'uneconomic'
+                : exitTreeCostSats <= netRecoveredSats
+                  ? 'profitable'
+                  : exitTreeCostSats <= netRecoveredSats * MAX_RESERVE_MULTIPLE
+                    ? 'marginal'
+                    : 'uneconomic';
+
+        const base = {
+            id: v.id,
+            sats,
+            exitDepth: Math.max(0, Math.floor(Number(v.exitDepth) || 0)),
+            perVtxoVb: perVb,
+            exitTreeCostSats,
+            marginalClaimSats,
+            netRecoveredSats,
+            economic,
+            blocksUntilExpiry,
+            requiredRunwayBlocks: runway,
+        };
+
+        const exclude = (reason: ExitExclusionReason) => {
+            excluded.push({ ...base, included: false, reason, notes });
+        };
+
+        // Structural. A terminal capsule holds nothing, so it is dropped before
+        // triage rather than reported as an exclusion. It still matters: the
+        // old reserve calc filtered only `spent`, so ten finished exits on the
+        // measured wallet added 7,252 vB of demanded reserve for value already
+        // sitting on-chain.
+        if (TERMINAL_STATE_TAGS.has(String(v.stateTag ?? '').toLowerCase())) {
+            skippedTerminalCount++;
+            continue;
+        }
+        if (perVb <= 0 || (Number(v.exitTxWeightWu) <= 0 && Number(v.exitDepth) <= 0)) {
+            exclude('no-exit-chain');
+            continue;
+        }
+
+        // Temporal. A hard exclusion, not a warning: an exit that does not clear
+        // its CSV before expiry loses the capsule AND the reserve spent on it.
+        if (blocksUntilExpiry != null) {
+            if (blocksUntilExpiry <= runway) {
+                exclude('too-close-to-expiry');
+                continue;
+            }
+        } else {
+            // Unknown runway is not evidence of a problem, and refusing to exit
+            // on a failed tip read would disarm the emergency button for a
+            // network fault. Include and disclose.
+            notes.push('expiry-unknown');
+        }
+
+        // Economic.
+        if (economic === 'uneconomic') {
+            exclude(
+                netRecoveredSats <= 0 ? 'returns-nothing' : 'reserve-dwarfs-value',
+            );
+            continue;
+        }
+        if (economic === 'marginal') {
+            if (!includeMarginal) {
+                exclude('reserve-dwarfs-value');
+                continue;
+            }
+            notes.push('under-water');
+        }
+
+        selected.push({ ...base, included: true, notes });
+    }
+
+    // Most net-recoverable first. If the reserve runs dry mid-exit the capsules
+    // that got furthest are the ones worth the most, rather than whichever the
+    // iterator happened to reach first.
+    selected.sort((a, b) => b.netRecoveredSats - a.netRecoveredSats || a.id.localeCompare(b.id));
+    excluded.sort((a, b) => b.sats - a.sats || a.id.localeCompare(b.id));
+
+    const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
+
+    return {
+        selectedIds: selected.map((e) => e.id),
+        selected,
+        excluded,
+        skippedTerminalCount,
+        selectedSats: selected.reduce((acc, e) => acc + e.sats, 0),
+        netRecoverableSats: selected.reduce((acc, e) => acc + e.netRecoveredSats, 0),
+        excludedSats: excluded.reduce((acc, e) => acc + e.sats, 0),
+        totalExitVb,
+        reserveSats: reserveSatsForExitVb(totalExitVb, feeRate),
+        underWaterCount: selected.filter((e) => e.economic === 'marginal').length,
+        feeRateSatPerVb: feeRate,
+        claimFeeRateSatPerVb: claimRate,
+        usedAssumedExitDelta,
+    };
+}
+
+/**
+ * One-line reason text per exclusion, for the confirm dialog. Wording is the
+ * product owner's to change; the contract this satisfies is that no capsule is
+ * ever dropped without the user being told which one and why.
+ */
+export function describeExitExclusion(reason: ExitExclusionReason | undefined): string {
+    switch (reason) {
+        case 'no-exit-chain':
+            return 'no exit chain available';
+        case 'too-close-to-expiry':
+            return 'too close to expiry to exit safely';
+        case 'returns-nothing':
+            return 'network fee is more than it holds';
+        case 'reserve-dwarfs-value':
+            return 'costs far more in fees than it holds';
+        default:
+            return 'cannot be exited';
+    }
+}

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -220,6 +220,9 @@ export type ExitTriageEntry = {
     blocksUntilExpiry: number | null;
     /** Blocks of runway this capsule needs: confirmation budget + CSV delta. */
     requiredRunwayBlocks: number;
+    /** Absolute height the capsule expires at, so callers can turn slack back
+     *  into a fixed deadline that stays valid as the chain advances. */
+    expiryHeight: number;
     included: boolean;
     reason?: ExitExclusionReason;
     notes: ExitTriageNote[];
@@ -356,6 +359,115 @@ export function claimRateFromExitRate(feeRateSatPerVb: number): number {
     return Math.min(CLAIM_RATE_MAX, Math.max(CLAIM_RATE_MIN, rate));
 }
 
+/**
+ * How much of a hurry the exit tree is actually in.
+ *
+ * The reserve used to be priced at the mempool's "fastest" rate unconditionally.
+ * That is the wrong question. The exit tree is not racing the next block, it is
+ * racing the capsule's EXPIRY, because a capsule the server sweeps before its
+ * exit clears the CSV is lost. A capsule with weeks of runway has no reason to
+ * bid for next-block confirmation, and paying for it inflates the reserve the
+ * user is asked to fund by several times.
+ *
+ * Measured 2026-08-20: the live wallet's capsules sat about 3,700 blocks clear
+ * of the runway they needed, roughly 26 days, while the app priced their exit at
+ * a fastestFee of 7 against an economyFee of 2. That is a 3.5x over-demand for
+ * urgency that did not exist.
+ *
+ * This is the same mistake #187 fixed for the claim, in the other direction:
+ * there, a rate chosen for speed made a claim impossible to build. Here it makes
+ * a reserve impossible to fund.
+ *
+ * Bands are deliberately conservative and the drive re-evaluates on every tick,
+ * so a capsule that drifts toward its expiry climbs the bands and starts bidding
+ * harder well before it is in trouble.
+ */
+export type ExitFeeUrgency = 'relaxed' | 'moderate' | 'soon' | 'urgent';
+
+/** Spare blocks ABOVE the runway a capsule needs, per band. */
+export const URGENCY_RELAXED_BLOCKS = 1008; // ~1 week
+export const URGENCY_MODERATE_BLOCKS = 288; // ~2 days
+export const URGENCY_SOON_BLOCKS = 144; // ~1 day
+
+export type ExitFeeUrgencyResult = {
+    urgency: ExitFeeUrgency;
+    /** Spare blocks the tightest exitable capsule has, null when unknowable. */
+    tightestSlackBlocks: number | null;
+    /**
+     * Block height by which the tightest capsule's exit must have cleared.
+     * Fixed, unlike the slack, so persisting THIS lets the drive re-derive
+     * urgency each tick against the current tip without another wallet read,
+     * and without the band going stale as the exit runs for days.
+     */
+    deadlineHeight: number | null;
+    /** Capsules the band was derived from. */
+    consideredCount: number;
+};
+
+/**
+ * Band for a given slack. Split out so the exit drive can re-derive urgency
+ * from a persisted deadline height and the current tip, using the same
+ * thresholds the reserve was sized with.
+ */
+export function urgencyFromSlackBlocks(slackBlocks: number | null): ExitFeeUrgency {
+    if (slackBlocks == null || !Number.isFinite(slackBlocks)) return 'urgent';
+    if (slackBlocks >= URGENCY_RELAXED_BLOCKS) return 'relaxed';
+    if (slackBlocks >= URGENCY_MODERATE_BLOCKS) return 'moderate';
+    if (slackBlocks >= URGENCY_SOON_BLOCKS) return 'soon';
+    return 'urgent';
+}
+
+/**
+ * Urgency for an exit set, from the tightest slack in it.
+ *
+ * Takes triaged ENTRIES, not raw capsules, and that is the whole point. An
+ * earlier version read the candidate list and got it backwards on the first
+ * real wallet it saw: two dust capsules 22 blocks from their runway priced the
+ * entire exit as urgent, when neither was going to be exited at all. Pricing
+ * has to follow selection, or capsules the exit is abandoning still get to
+ * decide what it pays.
+ *
+ * Entries already carry `blocksUntilExpiry` and `requiredRunwayBlocks`, so this
+ * is a min over their difference and nothing more.
+ *
+ * An empty set, or one whose runway cannot be read, yields 'urgent'.
+ * Over-reserving parks sats the user still owns; under-reserving stalls the
+ * exit and can cost the capsule, so unknown resolves toward paying more.
+ */
+export function exitFeeUrgency(
+    entries: readonly ExitTriageEntry[],
+): ExitFeeUrgencyResult {
+    let tightest: number | null = null;
+    let deadlineHeight: number | null = null;
+    let consideredCount = 0;
+
+    for (const e of entries ?? []) {
+        if (e.blocksUntilExpiry == null) continue;
+        const slack = e.blocksUntilExpiry - e.requiredRunwayBlocks;
+        consideredCount++;
+        if (tightest == null || slack < tightest) tightest = slack;
+    }
+
+    if (tightest != null && entries.length > 0) {
+        // Recover the absolute height the tightest capsule must clear by, so
+        // the drive can re-derive urgency later against a fresh tip.
+        for (const e of entries) {
+            if (e.blocksUntilExpiry == null) continue;
+            if (e.blocksUntilExpiry - e.requiredRunwayBlocks === tightest) {
+                deadlineHeight = e.expiryHeight - e.requiredRunwayBlocks;
+                break;
+            }
+        }
+    }
+
+    return {
+        urgency: urgencyFromSlackBlocks(tightest),
+        tightestSlackBlocks: tightest,
+        deadlineHeight,
+        consideredCount,
+    };
+}
+
 // --- Triage ----------------------------------------------------------------
 
 /**
@@ -426,6 +538,7 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
             economic,
             blocksUntilExpiry,
             requiredRunwayBlocks: runway,
+            expiryHeight: Math.max(0, Math.floor(Number(v.expiryHeight) || 0)),
         };
 
         const exclude = (reason: ExitExclusionReason) => {

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -417,6 +417,131 @@ export function urgencyFromSlackBlocks(slackBlocks: number | null): ExitFeeUrgen
     return 'urgent';
 }
 
+export type ExitFeeRateTable = Record<ExitFeeUrgency, number>;
+
+/**
+ * Last-resort rate per band, used only when every fee source is unreachable.
+ *
+ * NOT a flat constant, and that distinction is the whole point. The first
+ * version of this fell back to a single congestion hedge for every band, which
+ * quietly undid the runway pricing at exactly the moment it could not be
+ * checked: observed live 2026-08-20 with mempool.space down, a wallet with 26
+ * days of runway was priced at 10 sat/vB and its forced exit demanded 120,720
+ * sats instead of about 24,000.
+ *
+ * The hedge exists because we cannot see the market, so it should scale with
+ * how little time we have to correct a bad guess. With weeks of runway an
+ * under-bid is recoverable, since the drive re-prices every tick and the band
+ * climbs as the runway shrinks. An over-bid is not recoverable in the same way:
+ * it is charged immediately, as a reserve the user has to go and fund.
+ */
+export const EXIT_FEE_FALLBACK_RATES: ExitFeeRateTable = {
+    relaxed: 2,
+    moderate: 5,
+    soon: 8,
+    urgent: 10,
+};
+
+/**
+ * Confirmation target, in blocks, that each band asks an esplora
+ * `/fee-estimates` map for. Esplora keys targets directly, which fits the bands
+ * better than a provider's named tiers do.
+ */
+export const ESPLORA_TARGET_FOR_BAND: Record<ExitFeeUrgency, number> = {
+    urgent: 1,
+    soon: 3,
+    moderate: 6,
+    relaxed: 144,
+};
+
+const BANDS: ExitFeeUrgency[] = ['relaxed', 'moderate', 'soon', 'urgent'];
+
+/**
+ * Fill gaps and force the table to be non-decreasing from relaxed to urgent.
+ *
+ * A fee source is not obliged to be sane. Providers have been seen returning
+ * equal tiers, missing fields, and occasionally an inverted pair, and an
+ * inverted table would have a RELAXED exit bidding more than an urgent one,
+ * which is the exact failure this whole path exists to prevent. Missing entries
+ * inherit the next band up, so a gap always resolves toward paying more.
+ */
+export function normaliseExitFeeRates(
+    partial: Partial<Record<ExitFeeUrgency, number>>,
+): ExitFeeRateTable | null {
+    const clean = (n: unknown): number | null => {
+        const v = Number(n);
+        return Number.isFinite(v) && v > 0 ? Math.max(1, Math.ceil(v)) : null;
+    };
+    const out: Partial<ExitFeeRateTable> = {};
+    for (const b of BANDS) {
+        const v = clean(partial[b]);
+        if (v != null) out[b] = v;
+    }
+    if (Object.keys(out).length === 0) return null;
+
+    // Fill downward from urgent so a missing band inherits the dearer neighbour.
+    let carry: number | null = null;
+    for (let i = BANDS.length - 1; i >= 0; i--) {
+        const b = BANDS[i];
+        if (out[b] == null) out[b] = carry ?? undefined;
+        else carry = out[b] as number;
+    }
+    // Anything still unset sits below every known band; take the cheapest known.
+    const known = BANDS.map((b) => out[b]).filter((v): v is number => v != null);
+    const cheapest = Math.min(...known);
+    for (const b of BANDS) if (out[b] == null) out[b] = cheapest;
+
+    // Monotonic: a cheaper band may never exceed a dearer one.
+    for (let i = BANDS.length - 2; i >= 0; i--) {
+        const b = BANDS[i];
+        const next = BANDS[i + 1];
+        if ((out[b] as number) > (out[next] as number)) out[b] = out[next];
+    }
+    return out as ExitFeeRateTable;
+}
+
+/** Bands from mempool.space's named tiers. Null when the shape is unusable. */
+export function ratesFromMempoolRecommended(rec: unknown): ExitFeeRateTable | null {
+    const r = rec as Record<string, unknown> | null | undefined;
+    if (!r) return null;
+    return normaliseExitFeeRates({
+        relaxed: r.economyFee as number,
+        moderate: r.hourFee as number,
+        soon: r.halfHourFee as number,
+        urgent: r.fastestFee as number,
+    });
+}
+
+/**
+ * Bands from an esplora `/fee-estimates` map of confirmation target to sat/vB.
+ *
+ * For a band's target, take the largest available target at or below it. Longer
+ * targets carry lower fees, so rounding DOWN the target rounds the fee up,
+ * which is the safe direction when the exact target is missing.
+ */
+export function ratesFromEsploraEstimates(estimates: unknown): ExitFeeRateTable | null {
+    const m = estimates as Record<string, unknown> | null | undefined;
+    if (!m || typeof m !== 'object') return null;
+    const targets = Object.keys(m)
+        .map((k) => ({ blocks: Number(k), rate: Number(m[k]) }))
+        .filter((t) => Number.isFinite(t.blocks) && t.blocks > 0 && Number.isFinite(t.rate) && t.rate > 0)
+        .sort((a, b) => a.blocks - b.blocks);
+    if (targets.length === 0) return null;
+
+    const pick = (band: ExitFeeUrgency) => {
+        const want = ESPLORA_TARGET_FOR_BAND[band];
+        let best = targets[0];
+        for (const t of targets) if (t.blocks <= want) best = t;
+        return best.rate;
+    };
+    return normaliseExitFeeRates({
+        relaxed: pick('relaxed'),
+        moderate: pick('moderate'),
+        soon: pick('soon'),
+        urgent: pick('urgent'),
+    });
+}
+
 /**
  * Urgency for an exit set, from the tightest slack in it.
  *

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -84,6 +84,38 @@ export const BLOCKS_PER_EXIT_LEVEL = 6;
 /** Floor on the confirmation budget, so a shallow tree still gets real runway. */
 export const MIN_CONFIRMATION_BUDGET_BLOCKS = 6;
 
+/**
+ * Minimum remaining life, in blocks, for a capsule to be worth exiting.
+ * 4 days at 10 minute blocks.
+ *
+ * This is an ECONOMIC floor, not a safety one. The temporal axis above already
+ * refuses capsules that cannot clear their timelock in time; those are unsafe.
+ * A capsule with three days left is perfectly safe to exit, and still a bad
+ * idea, because of what a short remaining life usually means about how it got
+ * there.
+ *
+ * Capsules do not arrive near expiry in good condition. They get there by
+ * failing to refresh, repeatedly: a cancelled round, a server that would not
+ * cosign, an app that was never opened. Every one of those failures leaves the
+ * capsule where it was and lets the clock run, and the ones that involve
+ * out-of-round spending push `exitDepth` up as well. So the population of
+ * nearly-expired capsules is disproportionately the deep, expensive ones, which
+ * is exactly the population an exit handles worst: cost is linear in depth and
+ * the value is unchanged.
+ *
+ * Refreshing one resets BOTH the depth and the expiry clock, for about a sat.
+ * That is worth an order of magnitude more than exiting it, so the honest
+ * advice is to refresh first and exit later.
+ *
+ * The obvious objection is that refreshing needs the ASP, and a user reaching
+ * for a unilateral exit may have no ASP to reach. That is real, and it is why
+ * this is a default rather than a law: 'recover-everything' includes these
+ * capsules, so a user facing a genuinely dead server can still take them, with
+ * the cost stated. What this stops is the common case, where an exit quietly
+ * spends a fortune dragging out stragglers the user could have refreshed.
+ */
+export const MIN_FRESHNESS_BLOCKS = 4 * 24 * 6;
+
 /** CSV delta assumed when `ArkInfo.vtxoExitDelta` was never cached.
  *
  *  The exit path must not call the ASP (spec principle 2), so a missing cache
@@ -153,6 +185,9 @@ export type ExitExclusionReason =
     | 'no-exit-chain'
     /** Temporal: the server can sweep it before the exit clears its CSV. */
     | 'too-close-to-expiry'
+    /** Temporal/economic: safe to exit, but too near expiry to be worth it.
+     *  Refreshing resets its depth and its clock for a fraction of the cost. */
+    | 'refresh-before-exiting'
     /** Economic: its own claim fee is at least its whole value. */
     | 'returns-nothing'
     /** Economic: the reserve it consumes dwarfs what it returns. */
@@ -718,6 +753,22 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
             notes.push('under-water');
         }
 
+        // Freshness, last, so a capsule that is ALSO uneconomic is reported as
+        // uneconomic. Ordering here is not cosmetic, it is the advice: telling
+        // someone to refresh a 400-sat capsule is useless, because it is below
+        // the per-input round minimum and cannot be refreshed alone. "Costs
+        // more than it holds" is the true and actionable reason for that one.
+        // This exclusion is for capsules that are worth exiting on the numbers
+        // and are merely stale, where refreshing genuinely is the better move.
+        if (
+            blocksUntilExpiry != null &&
+            blocksUntilExpiry < MIN_FRESHNESS_BLOCKS &&
+            policy !== 'recover-everything'
+        ) {
+            exclude('refresh-before-exiting');
+            continue;
+        }
+
         selected.push({ ...base, included: true, notes });
     }
 
@@ -730,7 +781,9 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
     const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
     const reserveSats = reserveSatsForExitVb(totalExitVb, feeRate);
     const netRecoverableSats = selected.reduce((acc, e) => acc + e.netRecoveredSats, 0);
-    const overridable = excluded.filter((e) => e.reason === 'reserve-dwarfs-value');
+    const overridable = excluded.filter(
+        (e) => e.reason === 'reserve-dwarfs-value' || e.reason === 'refresh-before-exiting',
+    );
 
     return {
         selectedIds: selected.map((e) => e.id),
@@ -764,6 +817,8 @@ export function describeExitExclusion(reason: ExitExclusionReason | undefined): 
             return 'no exit chain available';
         case 'too-close-to-expiry':
             return 'too close to expiry to exit safely';
+        case 'refresh-before-exiting':
+            return 'expiring soon, refresh it instead of exiting it';
         case 'returns-nothing':
             return 'network fee is more than it holds';
         case 'reserve-dwarfs-value':

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -170,6 +170,34 @@ export type ExitTriageNote =
 
 export type ExitEconomicVerdict = 'profitable' | 'marginal' | 'uneconomic';
 
+/**
+ * How far past the economics the user has chosen to go.
+ *
+ * The economic axis is the only one with an override, and that is deliberate.
+ * The other two exclusions are not judgement calls the user can overrule:
+ * a structurally unexitable capsule has nothing to broadcast, and a capsule
+ * inside its expiry runway loses BOTH itself and the reserve spent on it when
+ * the server sweeps it mid-exit. Neither is a trade the user could want.
+ *
+ * Within the economic axis there is still one hard floor. A capsule whose own
+ * claim fee is at least its whole value ('returns-nothing') cannot deliver
+ * anything at any price: bark refuses to build a claim whose fee exceeds its
+ * output, and the drive then rebuilds that same doomed claim forever. Forcing
+ * one in does not cost the user money to rescue funds, it wedges the batch and
+ * rescues nothing. So no policy includes it.
+ *
+ *   'profitable-only'     only capsules whose reserve cost comes back
+ *   'default'             the above, plus capsules under water by less than
+ *                         MAX_RESERVE_MULTIPLE
+ *   'recover-everything'  the above, plus capsules whose reserve cost dwarfs
+ *                         what they return. This is spec principle 4: the user
+ *                         may knowingly spend more than the funds are worth,
+ *                         for instance to deny a hostile server a hostage.
+ *                         Callers MUST state the loss in sats before applying
+ *                         it, or the "knowingly" is a fiction.
+ */
+export type ExitEconomicPolicy = 'profitable-only' | 'default' | 'recover-everything';
+
 export type ExitTriageEntry = {
     id: string;
     sats: number;
@@ -214,11 +242,9 @@ export type TriageArkExitInput = {
     vtxoExitDeltaBlocks: number | null;
     /** Cached `ArkInfo.maxVtxoExitDepth`, for the disclosure note only. */
     maxVtxoExitDepth?: number | null;
-    /** Whether capsules that cost more reserve than they return, but by less
-     *  than MAX_RESERVE_MULTIPLE, are exited. Default true: excluding them
-     *  abandons real value to save a trivial amount of reserve. Exposed so the
-     *  UI can offer the opt-out spec principle 4 calls for. */
-    includeMarginal?: boolean;
+    /** How far past the economics the user has chosen to go. Defaults to
+     *  'default'. See ExitEconomicPolicy. */
+    economicPolicy?: ExitEconomicPolicy;
 };
 
 export type ExitTriageResult = {
@@ -246,6 +272,21 @@ export type ExitTriageResult = {
     reserveSats: number;
     /** Selected capsules that cost more reserve than they return. */
     underWaterCount: number;
+    /**
+     * Sats the selected set spends beyond what it recovers, 0 when it is not
+     * under water. This is the number the user has to be shown before a
+     * 'recover-everything' exit, since it IS the loss they are accepting.
+     */
+    netLossSats: number;
+    /**
+     * Capsules excluded purely on the economic ratio, which a
+     * 'recover-everything' policy would bring back. Lets the UI offer the
+     * override only when it would actually change something.
+     */
+    overridableCount: number;
+    /** Face value of those capsules. */
+    overridableSats: number;
+    economicPolicy: ExitEconomicPolicy;
     feeRateSatPerVb: number;
     claimFeeRateSatPerVb: number;
     /** True when the temporal axis ran on ASSUMED_EXIT_DELTA_BLOCKS. */
@@ -329,7 +370,7 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         input.claimFeeRateSatPerVb == null
             ? claimRateFromExitRate(feeRate)
             : Math.max(0, Number(input.claimFeeRateSatPerVb) || 0);
-    const includeMarginal = input.includeMarginal !== false;
+    const policy: ExitEconomicPolicy = input.economicPolicy ?? 'default';
 
     const usedAssumedExitDelta =
         input.vtxoExitDeltaBlocks == null || !Number.isFinite(input.vtxoExitDeltaBlocks);
@@ -419,15 +460,20 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
             notes.push('expiry-unknown');
         }
 
-        // Economic.
-        if (economic === 'uneconomic') {
-            exclude(
-                netRecoveredSats <= 0 ? 'returns-nothing' : 'reserve-dwarfs-value',
-            );
+        // Economic. The only axis the user can overrule, and even here a
+        // capsule that cannot return anything at all is never included.
+        if (netRecoveredSats <= 0) {
+            exclude('returns-nothing');
             continue;
         }
-        if (economic === 'marginal') {
-            if (!includeMarginal) {
+        if (economic === 'uneconomic') {
+            if (policy !== 'recover-everything') {
+                exclude('reserve-dwarfs-value');
+                continue;
+            }
+            notes.push('under-water');
+        } else if (economic === 'marginal') {
+            if (policy === 'profitable-only') {
                 exclude('reserve-dwarfs-value');
                 continue;
             }
@@ -444,6 +490,9 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
     excluded.sort((a, b) => b.sats - a.sats || a.id.localeCompare(b.id));
 
     const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
+    const reserveSats = reserveSatsForExitVb(totalExitVb, feeRate);
+    const netRecoverableSats = selected.reduce((acc, e) => acc + e.netRecoveredSats, 0);
+    const overridable = excluded.filter((e) => e.reason === 'reserve-dwarfs-value');
 
     return {
         selectedIds: selected.map((e) => e.id),
@@ -451,11 +500,15 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         excluded,
         skippedTerminalCount,
         selectedSats: selected.reduce((acc, e) => acc + e.sats, 0),
-        netRecoverableSats: selected.reduce((acc, e) => acc + e.netRecoveredSats, 0),
+        netRecoverableSats,
         excludedSats: excluded.reduce((acc, e) => acc + e.sats, 0),
         totalExitVb,
-        reserveSats: reserveSatsForExitVb(totalExitVb, feeRate),
-        underWaterCount: selected.filter((e) => e.economic === 'marginal').length,
+        reserveSats,
+        underWaterCount: selected.filter((e) => e.economic !== 'profitable').length,
+        netLossSats: Math.max(0, reserveSats - netRecoverableSats),
+        overridableCount: overridable.length,
+        overridableSats: overridable.reduce((acc, e) => acc + e.sats, 0),
+        economicPolicy: policy,
         feeRateSatPerVb: feeRate,
         claimFeeRateSatPerVb: claimRate,
         usedAssumedExitDelta,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -172,6 +172,7 @@ export {
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
 export { describeExitExclusion, triageArkExit } from './exitTriage';
 export type {
+    ExitEconomicPolicy,
     ExitExclusionReason,
     ExitTriageEntry,
     ExitTriageResult,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -161,13 +161,22 @@ export {
 export { estimateArkOffboardFee, offboardArkVtxos } from './offboard';
 export type { ArkOffboardFeeView } from './offboard';
 export {
+    computeArkExitPlan,
     computeExitFeeReserveSats,
     convertToExitFees,
     estimateExitFeeConvert,
+    fetchArkExitParams,
     fetchFastFeeRateSatPerVb,
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
+export { describeExitExclusion, triageArkExit } from './exitTriage';
+export type {
+    ExitExclusionReason,
+    ExitTriageEntry,
+    ExitTriageResult,
+    ExitTriageVtxo,
+} from './exitTriage';
 export type { ArkRefreshFeeView, ArkRefreshResult, ArkDelegatedRefreshResult } from './refresh';
 
 export { setArkBackgroundRefreshEnabled } from './backgroundRefresh';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -165,15 +165,20 @@ export {
     computeExitFeeReserveSats,
     convertToExitFees,
     estimateExitFeeConvert,
+    fetchArkExitDriveFeeRate,
     fetchArkExitParams,
+    fetchExitFeeRates,
+    fetchExitTreeFeeRateSatPerVb,
     fetchFastFeeRateSatPerVb,
+    getLastExitFeeDeadlineHeight,
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
-export { describeExitExclusion, triageArkExit } from './exitTriage';
+export { describeExitExclusion, exitFeeUrgency, triageArkExit, urgencyFromSlackBlocks } from './exitTriage';
 export type {
     ExitEconomicPolicy,
     ExitExclusionReason,
+    ExitFeeUrgency,
     ExitTriageEntry,
     ExitTriageResult,
     ExitTriageVtxo,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -174,10 +174,19 @@ export {
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
-export { describeExitExclusion, exitFeeUrgency, triageArkExit, urgencyFromSlackBlocks } from './exitTriage';
+export {
+    describeExitExclusion,
+    exitFeeUrgency,
+    normaliseExitFeeRates,
+    ratesFromEsploraEstimates,
+    ratesFromMempoolRecommended,
+    triageArkExit,
+    urgencyFromSlackBlocks,
+} from './exitTriage';
 export type {
     ExitEconomicPolicy,
     ExitExclusionReason,
+    ExitFeeRateTable,
     ExitFeeUrgency,
     ExitTriageEntry,
     ExitTriageResult,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -220,6 +220,26 @@ export type AuthStateType = {
      */
     arkRoundIntervalSecs: number | null;
     /**
+     * CSV delay in blocks a unilateral exit output must sit out before it can
+     * be claimed (`ArkInfo.vtxoExitDelta`, observed 144 on mainnet). Cached
+     * from the same one-shot arkInfo fetch as `arkRoundIntervalSecs`.
+     *
+     * Cached rather than fetched on demand because the exit path must never
+     * call the ASP: the user pressed the trustless button precisely because the
+     * server may be gone. Exit triage needs this to work out whether a capsule
+     * has the runway to clear its timelock before it expires, and a null makes
+     * it assume the worst plausible delta rather than skip the check.
+     */
+    arkVtxoExitDeltaBlocks: number | null;
+    /**
+     * `ArkInfo.maxVtxoExitDepth` (observed 100). Past this the server refuses
+     * to cosign further out-of-round spends of a capsule, so exit or refresh
+     * are the only moves left with it. Surfaced as a disclosure during exit
+     * triage; it never excludes a capsule, since being un-spendable through the
+     * server is an argument FOR exiting it.
+     */
+    arkMaxVtxoExitDepth: number | null;
+    /**
      * Unilateral-exit state — set when user taps "Emergency Exit" in
      * Settings. While true, `useArkSync` switches modes: it stops issuing
      * normal sync/refresh calls (they'd race the exit machinery) and instead
@@ -288,6 +308,10 @@ export type AuthStateType = {
     setArkLastSyncedAt: (state: number | null) => void;
     setArkLastBackupAt: (state: number | null) => void;
     setArkRoundIntervalSecs: (state: number | null) => void;
+    setArkExitParams: (state: {
+        vtxoExitDeltaBlocks: number | null;
+        maxVtxoExitDepth: number | null;
+    }) => void;
     setArkExitInProgress: (state: boolean) => void;
     setArkExitDestinationAddress: (state: string | null) => void;
     setArkExitStartedAt: (state: number | null) => void;
@@ -509,6 +533,8 @@ const createAuthStore = (
     arkLastSyncedAt: null,
     arkLastBackupAt: null,
     arkRoundIntervalSecs: null,
+    arkVtxoExitDeltaBlocks: null,
+    arkMaxVtxoExitDepth: null,
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
@@ -585,6 +611,10 @@ const createAuthStore = (
     setArkLastSyncedAt: (state: number | null) => set({ arkLastSyncedAt: state }),
     setArkLastBackupAt: (state: number | null) => set({ arkLastBackupAt: state }),
     setArkRoundIntervalSecs: (state: number | null) => set({ arkRoundIntervalSecs: state }),
+    setArkExitParams: (state) => set({
+        arkVtxoExitDeltaBlocks: state.vtxoExitDeltaBlocks,
+        arkMaxVtxoExitDepth: state.maxVtxoExitDepth,
+    }),
     setArkExitInProgress: (state: boolean) => set({ arkExitInProgress: state }),
     setArkExitDestinationAddress: (state: string | null) => set({ arkExitDestinationAddress: state }),
     setArkExitStartedAt: (state: number | null) => set({ arkExitStartedAt: state }),
@@ -628,6 +658,13 @@ const createAuthStore = (
             arkLastSyncedAt: null,
             arkLastBackupAt: null,
             arkRoundIntervalSecs: null,
+            // arkVtxoExitDeltaBlocks / arkMaxVtxoExitDepth are deliberately NOT
+            // reset. They are the server's protocol constants, not wallet
+            // state, and exit triage falls back to a worst-case delta whenever
+            // they are null. Clearing them here would leave a freshly recovered
+            // wallet triaging against that worst case until the next arkInfo
+            // fetch lands, which excludes capsules that had the runway all
+            // along. Same reasoning as arkBgRefreshEnabled below.
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -240,6 +240,17 @@ export type AuthStateType = {
      */
     arkMaxVtxoExitDepth: number | null;
     /**
+     * Block height by which the tightest capsule in an in-flight exit must have
+     * cleared its timelock. Written when the exit starts.
+     *
+     * The exit drive prices its CPFP bids from how much runway is left, and the
+     * runway shrinks every block over an exit that runs for days. Persisting the
+     * DEADLINE rather than the urgency band lets the drive re-derive the band
+     * each tick against the current tip, with no extra wallet read and no stale
+     * band. Null means unknown, which the pricing treats as most urgent.
+     */
+    arkExitFeeDeadlineHeight: number | null;
+    /**
      * Unilateral-exit state — set when user taps "Emergency Exit" in
      * Settings. While true, `useArkSync` switches modes: it stops issuing
      * normal sync/refresh calls (they'd race the exit machinery) and instead
@@ -308,6 +319,7 @@ export type AuthStateType = {
     setArkLastSyncedAt: (state: number | null) => void;
     setArkLastBackupAt: (state: number | null) => void;
     setArkRoundIntervalSecs: (state: number | null) => void;
+    setArkExitFeeDeadlineHeight: (state: number | null) => void;
     setArkExitParams: (state: {
         vtxoExitDeltaBlocks: number | null;
         maxVtxoExitDepth: number | null;
@@ -535,6 +547,7 @@ const createAuthStore = (
     arkRoundIntervalSecs: null,
     arkVtxoExitDeltaBlocks: null,
     arkMaxVtxoExitDepth: null,
+    arkExitFeeDeadlineHeight: null,
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
@@ -611,6 +624,7 @@ const createAuthStore = (
     setArkLastSyncedAt: (state: number | null) => set({ arkLastSyncedAt: state }),
     setArkLastBackupAt: (state: number | null) => set({ arkLastBackupAt: state }),
     setArkRoundIntervalSecs: (state: number | null) => set({ arkRoundIntervalSecs: state }),
+    setArkExitFeeDeadlineHeight: (state: number | null) => set({ arkExitFeeDeadlineHeight: state }),
     setArkExitParams: (state) => set({
         arkVtxoExitDeltaBlocks: state.vtxoExitDeltaBlocks,
         arkMaxVtxoExitDepth: state.maxVtxoExitDepth,
@@ -665,6 +679,7 @@ const createAuthStore = (
             // wallet triaging against that worst case until the next arkInfo
             // fetch lands, which excludes capsules that had the runway all
             // along. Same reasoning as arkBgRefreshEnabled below.
+            arkExitFeeDeadlineHeight: null,
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,6 +1,7 @@
 import {
   ASSUMED_EXIT_DELTA_BLOCKS,
   EXIT_FEE_FALLBACK_RATES,
+  MIN_FRESHNESS_BLOCKS,
   claimRateFromExitRate,
   exitFeeUrgency,
   normaliseExitFeeRates,
@@ -286,6 +287,9 @@ describe('temporal axis', () => {
   it('scales the confirmation budget with tree depth', () => {
     // Same expiry, same value; only the depth differs.
     const runway = TIP + 160;
+    // recover-everything to get past the 4-day freshness floor: what is under
+    // test here is the runway, and a capsule this close to expiry only reaches
+    // the exit set when the user has explicitly forced it.
     const r = triageArkExit({
       vtxos: [
         v({ id: 'shallow', sats: 20_000, exitDepth: 2, expiryHeight: runway }),
@@ -294,6 +298,7 @@ describe('temporal axis', () => {
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
     });
     expect(requiredRunwayBlocks(2, EXIT_DELTA)).toBe(156);
     expect(requiredRunwayBlocks(3, EXIT_DELTA)).toBe(162);
@@ -308,12 +313,14 @@ describe('temporal axis', () => {
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+     economicPolicy: 'recover-everything',
     });
     const uncached = triageArkExit({
       vtxos: [near],
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: null,
+     economicPolicy: 'recover-everything',
     });
     expect(cached.selectedIds).toEqual(['near']);
     expect(cached.usedAssumedExitDelta).toBe(false);
@@ -646,6 +653,7 @@ describe('exit-tree pricing: how much of a hurry the tree is actually in', () =>
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
     });
     expect(r.selectedIds).toEqual(['x']);
     expect(exitFeeUrgency(r.selected).urgency).toBe(band);
@@ -676,6 +684,7 @@ describe('exit-tree pricing: how much of a hurry the tree is actually in', () =>
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
     });
     expect(r.selectedIds).toHaveLength(2);
     expect(exitFeeUrgency(r.selected).urgency).toBe('soon');
@@ -790,5 +799,163 @@ describe('fee sources: what happens when the market cannot be read', () => {
       vtxoExitDeltaBlocks: EXIT_DELTA,
     });
     expect(exitFeeUrgency(urgentSet.selected).urgency).toBe('urgent');
+  });
+});
+
+describe('freshness floor: refresh a stale capsule, do not exit it', () => {
+  const fresh = (id: string, daysLeft: number, over: Partial<ExitTriageVtxo> = {}) =>
+    v({ id, sats: 20_000, expiryHeight: TIP + Math.round(daysLeft * 144), ...over });
+
+  it('excludes a capsule with under 4 days left even though it is safe to exit', () => {
+    // 3 days clears the runway easily (156 blocks for depth 2), so the temporal
+    // axis is happy. This is an economic call, not a safety one.
+    const r = triageArkExit({
+      vtxos: [fresh('stale', 3)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('refresh-before-exiting');
+    expect(r.excluded[0].blocksUntilExpiry).toBeGreaterThan(r.excluded[0].requiredRunwayBlocks);
+  });
+
+  it.each([
+    [0.5, false],
+    [3, false],
+    [3.9, false],
+    [4, true],
+    [10, true],
+    [27, true],
+  ])('%s days left -> exited=%s', (days, kept) => {
+    const r = triageArkExit({
+      vtxos: [fresh('c', days as number)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds.length === 1).toBe(kept);
+  });
+
+  it('applies to every capsule kind, not just arkoor', () => {
+    // Freshness decides, not provenance. A stale round output is just as deep
+    // and just as expensive as a stale arkoor one.
+    const r = triageArkExit({
+      vtxos: [
+        fresh('stale-registered', 2, { registered: true }),
+        fresh('stale-unregistered', 2, { registered: false }),
+        fresh('healthy', 20),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['healthy']);
+    expect(r.excluded.map((e) => e.reason)).toEqual([
+      'refresh-before-exiting',
+      'refresh-before-exiting',
+    ]);
+  });
+
+  it('still hard-excludes a capsule inside its runway, which is a different fault', () => {
+    // Under 4 days AND inside the runway. The safety exclusion has to win, or
+    // the override would let a user take a capsule the server can sweep
+    // out from under the exit.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'doomed', sats: 20_000, expiryHeight: TIP + 40 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('too-close-to-expiry');
+  });
+
+  it('lets a user with no server left take them anyway', () => {
+    // Refreshing needs the ASP. A user reaching for a unilateral exit may have
+    // no ASP to reach, so this default must not become a law.
+    const r = triageArkExit({
+      vtxos: [fresh('stale', 3)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual(['stale']);
+  });
+
+  it('offers the override when freshness is the only thing holding a capsule back', () => {
+    const r = triageArkExit({
+      vtxos: [fresh('stale', 3), fresh('healthy', 20)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['healthy']);
+    expect(r.overridableCount).toBe(1);
+    expect(r.overridableSats).toBe(20_000);
+  });
+
+  it('does not fire when the chain tip is unreadable', () => {
+    // No tip means no idea how fresh anything is. Guessing "stale" would
+    // abandon a healthy wallet on a failed network read.
+    const r = triageArkExit({
+      vtxos: [fresh('c', 3)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: null,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['c']);
+    expect(r.selected[0].notes).toContain('expiry-unknown');
+  });
+
+  it('leaves tonight\'s live wallet untouched', () => {
+    // All seven sit ~27 days out, so the floor is inert here. Recorded so a
+    // future change to the threshold shows up against real capsules.
+    const r = triage();
+    expect(r.selectedIds).toHaveLength(6);
+    // The two 400s ARE under 4 days, but they are reported as uneconomic,
+    // which is the reason a user can act on: below the per-input round
+    // minimum, they cannot be refreshed alone anyway.
+    expect(r.excluded.map((e) => e.reason)).toEqual([
+      'reserve-dwarfs-value',
+      'reserve-dwarfs-value',
+    ]);
+  });
+});
+
+describe('how the freshness floor and the fee bands interact', () => {
+  it('makes the urgent bands unreachable by default, which is coherent', () => {
+    // Not a coincidence worth leaving undocumented. The floor keeps anything
+    // under 576 blocks out of the exit set, and the runway is ~156, so a
+    // selected capsule always has 420+ blocks of slack and can never read
+    // 'soon' or 'urgent'. Exit only fresh capsules, and fresh capsules are
+    // never in a hurry, so the exit never bids for speed.
+    const justFresh = v({ id: 'edge', sats: 200_000, expiryHeight: TIP + MIN_FRESHNESS_BLOCKS });
+    const r = triageArkExit({
+      vtxos: [justFresh],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['edge']);
+    const u = exitFeeUrgency(r.selected);
+    expect(u.tightestSlackBlocks).toBe(MIN_FRESHNESS_BLOCKS - 156);
+    expect(['relaxed', 'moderate']).toContain(u.urgency);
+  });
+
+  it('still bids urgently when the user forces a stale capsule in', () => {
+    // Which is exactly when bidding high is right: the capsule the user
+    // overrode the floor for is the one actually racing its expiry.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'forced', sats: 200_000, expiryHeight: TIP + 200 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual(['forced']);
+    expect(exitFeeUrgency(r.selected).urgency).toBe('urgent');
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,12 +1,15 @@
 import {
   ASSUMED_EXIT_DELTA_BLOCKS,
   claimRateFromExitRate,
+  exitFeeUrgency,
+  URGENCY_SOON_BLOCKS,
   ExitTriageVtxo,
   RESERVE_FLOOR_SATS,
   perVtxoExitVb,
   requiredRunwayBlocks,
   reserveSatsForExitVb,
   triageArkExit,
+  urgencyFromSlackBlocks,
 } from '../../src/services/ark/exitTriage';
 
 // Every capsule below is a real one, read off the QA wallet on 2026-08-20.
@@ -594,5 +597,103 @@ describe('economic policy: how far past the economics the user may go', () => {
     // 84,504 sats of reserve to recover 2,330. The user has to see that.
     expect(forced.netRecoverableSats).toBe(2330);
     expect(forced.netLossSats).toBe(82174);
+  });
+});
+
+describe('exit-tree pricing: how much of a hurry the tree is actually in', () => {
+  it('reads the live wallet as relaxed, not urgent', () => {
+    // The mistake this replaces: the app priced these at a fastestFee of 7 when
+    // the exit set sat ~3,800 blocks clear of the runway it needed, about 26
+    // days. That is a 3.5x over-demand for urgency that did not exist.
+    const u = exitFeeUrgency(triage().selected);
+    expect(u.urgency).toBe('relaxed');
+    // Tightest of the six selected is a depth-3 at 967241: 4007 - 162 = 3845.
+    expect(u.tightestSlackBlocks).toBe(3845);
+    expect(u.deadlineHeight).toBe(967241 - 162);
+    expect(u.consideredCount).toBe(6);
+  });
+
+  it('does not let capsules the exit is abandoning decide what it pays', () => {
+    // This is why urgency reads the SELECTED set and not the candidates. The
+    // two 400s are 22 and 34 blocks off their runway, so pricing the candidate
+    // list called the whole exit urgent on behalf of two capsules that were
+    // never going to be exited.
+    const plan = triage();
+    const dust = plan.excluded.map((e) => e.blocksUntilExpiry! - e.requiredRunwayBlocks);
+    expect(Math.min(...dust)).toBeLessThan(URGENCY_SOON_BLOCKS);
+    expect(exitFeeUrgency([...plan.selected, ...plan.excluded]).urgency).toBe('urgent');
+    expect(exitFeeUrgency(plan.selected).urgency).toBe('relaxed');
+  });
+
+  it.each([
+    [5000, 'relaxed'],
+    [1008, 'relaxed'],
+    [1007, 'moderate'],
+    [288, 'moderate'],
+    [287, 'soon'],
+    [144, 'soon'],
+    [143, 'urgent'],
+    [1, 'urgent'],
+  ])('%s blocks of slack is %s', (slack, band) => {
+    expect(urgencyFromSlackBlocks(slack as number)).toBe(band);
+    // And end to end, through a real triage at a rate that keeps it selected.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'x', sats: 200_000, expiryHeight: TIP + 156 + (slack as number) })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['x']);
+    expect(exitFeeUrgency(r.selected).urgency).toBe(band);
+  });
+
+  it('bids as if urgent when the chain tip is unreadable', () => {
+    // Over-reserving parks sats the user still owns. Under-reserving stalls the
+    // exit and can cost the capsule. Unknown resolves toward paying more.
+    const u = exitFeeUrgency(triage({ chainTipHeight: null }).selected);
+    expect(u.urgency).toBe('urgent');
+    expect(u.tightestSlackBlocks).toBeNull();
+    expect(u.deadlineHeight).toBeNull();
+    expect(urgencyFromSlackBlocks(null)).toBe('urgent');
+  });
+
+  it('bids as if urgent when nothing was selected', () => {
+    expect(exitFeeUrgency([]).urgency).toBe('urgent');
+    expect(exitFeeUrgency(triage({ economicPolicy: 'profitable-only' }).selected).urgency)
+      .toBe('urgent');
+  });
+
+  it('prices off the tightest member, not the average', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'roomy', sats: 200_000, expiryHeight: TIP + 9000 }),
+        v({ id: 'tight', sats: 200_000, expiryHeight: TIP + 156 + 200 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toHaveLength(2);
+    expect(exitFeeUrgency(r.selected).urgency).toBe('soon');
+  });
+
+  it('climbs the bands on its own as an exit runs and the runway shrinks', () => {
+    // The drive re-derives from the persisted deadline against the live tip, so
+    // a capsule drifting toward expiry starts bidding harder with nobody
+    // recomputing a plan.
+    const deadline = TIP + 1200;
+    expect(urgencyFromSlackBlocks(deadline - TIP)).toBe('relaxed');
+    expect(urgencyFromSlackBlocks(deadline - (TIP + 300))).toBe('moderate');
+    expect(urgencyFromSlackBlocks(deadline - (TIP + 1000))).toBe('soon');
+    expect(urgencyFromSlackBlocks(deadline - (TIP + 1100))).toBe('urgent');
+  });
+
+  it('gives the drive a deadline that stays fixed as the chain advances', () => {
+    const u = exitFeeUrgency(triage().selected);
+    // Persisting the deadline rather than the band is what keeps it honest over
+    // a multi-day exit: slack recomputed against a later tip is smaller.
+    expect(u.deadlineHeight! - TIP).toBe(u.tightestSlackBlocks);
+    expect(u.deadlineHeight! - (TIP + 3000)).toBe(845);
+    expect(urgencyFromSlackBlocks(u.deadlineHeight! - (TIP + 3000))).toBe('moderate');
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,7 +1,11 @@
 import {
   ASSUMED_EXIT_DELTA_BLOCKS,
+  EXIT_FEE_FALLBACK_RATES,
   claimRateFromExitRate,
   exitFeeUrgency,
+  normaliseExitFeeRates,
+  ratesFromEsploraEstimates,
+  ratesFromMempoolRecommended,
   URGENCY_SOON_BLOCKS,
   ExitTriageVtxo,
   RESERVE_FLOOR_SATS,
@@ -695,5 +699,96 @@ describe('exit-tree pricing: how much of a hurry the tree is actually in', () =>
     expect(u.deadlineHeight! - TIP).toBe(u.tightestSlackBlocks);
     expect(u.deadlineHeight! - (TIP + 3000)).toBe(845);
     expect(urgencyFromSlackBlocks(u.deadlineHeight! - (TIP + 3000))).toBe('moderate');
+  });
+});
+
+describe('fee sources: what happens when the market cannot be read', () => {
+  it('maps mempool.space named tiers onto the bands', () => {
+    const r = ratesFromMempoolRecommended({
+      fastestFee: 7, halfHourFee: 6, hourFee: 5, economyFee: 2, minimumFee: 1,
+    })!;
+    expect(r).toEqual({ relaxed: 2, moderate: 5, soon: 6, urgent: 7 });
+  });
+
+  it('maps an esplora fee-estimates map onto the bands', () => {
+    // Real shape, read off blockstream 2026-08-20.
+    const r = ratesFromEsploraEstimates({
+      '1': 5.2, '2': 4.586, '3': 4.3, '4': 4.178, '6': 3.9, '8': 3.285,
+      '10': 1.069, '15': 1.003, '144': 1.001, '504': 1.0,
+    })!;
+    // relaxed asks for target 144, urgent for target 1.
+    expect(r.relaxed).toBe(2);
+    expect(r.urgent).toBe(6);
+    expect(r.relaxed).toBeLessThanOrEqual(r.urgent);
+  });
+
+  it('rounds a missing esplora target DOWN, which rounds the fee up', () => {
+    // Longer targets are cheaper, so falling back to a shorter one is the safe
+    // direction when the exact target is absent.
+    const r = ratesFromEsploraEstimates({ '1': 20, '6': 9, '25': 3 })!;
+    // relaxed wants 144, the longest available is 25.
+    expect(r.relaxed).toBe(3);
+    expect(r.moderate).toBe(9);
+    expect(r.urgent).toBe(20);
+  });
+
+  it('never lets a cheaper band cost more than a dearer one', () => {
+    // An inverted table would have a RELAXED exit outbidding an urgent one,
+    // which is the exact failure this path exists to prevent.
+    const r = normaliseExitFeeRates({ relaxed: 50, moderate: 4, soon: 3, urgent: 2 })!;
+    expect(r).toEqual({ relaxed: 2, moderate: 2, soon: 2, urgent: 2 });
+    expect(r.relaxed).toBeLessThanOrEqual(r.moderate);
+    expect(r.moderate).toBeLessThanOrEqual(r.soon);
+    expect(r.soon).toBeLessThanOrEqual(r.urgent);
+  });
+
+  it('fills a missing band from the dearer neighbour, not the cheaper one', () => {
+    const r = normaliseExitFeeRates({ relaxed: 2, urgent: 9 })!;
+    expect(r).toEqual({ relaxed: 2, moderate: 9, soon: 9, urgent: 9 });
+  });
+
+  it('rejects unusable shapes rather than inventing a table', () => {
+    expect(ratesFromMempoolRecommended(null)).toBeNull();
+    expect(ratesFromMempoolRecommended({})).toBeNull();
+    expect(ratesFromEsploraEstimates(null)).toBeNull();
+    expect(ratesFromEsploraEstimates({})).toBeNull();
+    expect(ratesFromEsploraEstimates({ '1': 0, '6': -3 })).toBeNull();
+    expect(normaliseExitFeeRates({})).toBeNull();
+  });
+
+  it('keeps urgency meaningful when every fee source is unreachable', () => {
+    // The defect this replaces: a single flat congestion hedge for every band,
+    // which quietly undid the runway pricing at exactly the moment it could not
+    // be checked. Observed live with mempool.space down, a wallet with 26 days
+    // of runway was priced at 10 sat/vB.
+    const f = EXIT_FEE_FALLBACK_RATES;
+    expect(f.relaxed).toBeLessThan(f.urgent);
+    expect(f.relaxed).toBeLessThanOrEqual(f.moderate);
+    expect(f.moderate).toBeLessThanOrEqual(f.soon);
+    expect(f.soon).toBeLessThanOrEqual(f.urgent);
+
+    // 6,036 vB of exit set, the live wallet forced through.
+    const flat = reserveSatsForExitVb(6036, f.urgent);
+    const banded = reserveSatsForExitVb(6036, f.relaxed);
+    expect(flat).toBe(120_720);
+    expect(banded).toBe(24_144);
+  });
+
+  it('prices a relaxed wallet cheaply even blind, and an urgent one dearly', () => {
+    const relaxedSet = triageArkExit({
+      vtxos: [v({ id: 'roomy', sats: 200_000, expiryHeight: TIP + 9000 })],
+      feeRateSatPerVb: EXIT_FEE_FALLBACK_RATES.relaxed,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(exitFeeUrgency(relaxedSet.selected).urgency).toBe('relaxed');
+
+    const urgentSet = triageArkExit({
+      vtxos: [v({ id: 'tight', sats: 200_000, expiryHeight: TIP + 156 + 10 })],
+      feeRateSatPerVb: EXIT_FEE_FALLBACK_RATES.urgent,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(exitFeeUrgency(urgentSet.selected).urgency).toBe('urgent');
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -472,12 +472,127 @@ describe('reserve sizing', () => {
   });
 });
 
-describe('marginal opt-out', () => {
-  it('can be told to exit only capsules that pay for themselves', () => {
-    const r = triage({ includeMarginal: false });
-    // At 1 sat/vB nothing in this wallet clears its own reserve cost, which is
-    // the finding, not a bug. Default-on is what keeps the exit useful.
+describe('economic policy: how far past the economics the user may go', () => {
+  it('profitable-only exits nothing in this wallet, which is the finding, not a bug', () => {
+    const r = triage({ economicPolicy: 'profitable-only' });
+    // At 1 sat/vB nothing here clears its own reserve cost. Defaulting to
+    // 'default' rather than this is what keeps the exit useful at all.
     expect(r.selectedIds).toEqual([]);
     expect(r.excluded).toHaveLength(8);
+  });
+
+  it('recover-everything brings back the capsules excluded on the ratio', () => {
+    // Spec principle 4: the user may knowingly spend more than the funds are
+    // worth, for instance to deny a hostile server a hostage.
+    const forced = triage({ economicPolicy: 'recover-everything' });
+    expect(forced.selectedIds).toHaveLength(8);
+    expect(forced.excluded).toHaveLength(0);
+    expect(forced.totalExitVb).toBe(16060);
+    expect(forced.reserveSats).toBe(32120);
+  });
+
+  it('offers the override only when it would change something', () => {
+    const d = triage();
+    expect(d.overridableCount).toBe(2);
+    expect(d.overridableSats).toBe(800);
+    // Nothing left to force once it has been applied.
+    expect(triage({ economicPolicy: 'recover-everything' }).overridableCount).toBe(0);
+  });
+
+  it('states the loss the override accepts', () => {
+    const forced = triage({ economicPolicy: 'recover-everything' });
+    // 32,120 of reserve to recover 4,382 net. That gap is the choice.
+    expect(forced.netRecoverableSats).toBe(4990 - 8 * 76);
+    expect(forced.netLossSats).toBe(32120 - (4990 - 8 * 76));
+    expect(forced.underWaterCount).toBe(8);
+  });
+
+  it('reports no loss when the selected set actually pays for itself', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'big', sats: 500_000 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selected[0].economic).toBe('profitable');
+    expect(r.netLossSats).toBe(0);
+    expect(r.underWaterCount).toBe(0);
+  });
+
+  it('NEVER forces in a capsule that cannot return anything at any price', () => {
+    // bark refuses to build a claim whose fee exceeds its output and the drive
+    // rebuilds that same doomed claim forever, so this is not a trade the user
+    // could want: it wedges the batch and rescues nothing.
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'hopeless', sats: 200 }),
+        v({ id: 'forceable', sats: 400, exitDepth: 17, exitTxWeightWu: 12377 }),
+      ],
+      feeRateSatPerVb: 5,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual(['forceable']);
+    expect(r.excluded.map((e) => e.reason)).toEqual(['returns-nothing']);
+  });
+
+  it('NEVER forces past the expiry runway, whatever the policy', () => {
+    // Overriding this does not cost the user money to rescue funds, it loses
+    // the capsule AND the reserve when the server sweeps it mid-exit.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'fuse', sats: 20_000, expiryHeight: TIP + 40 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('too-close-to-expiry');
+  });
+
+  it('NEVER forces in a structurally unexitable capsule', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'chainless', sats: 20_000, exitDepth: 0, exitTxWeightWu: 0 }),
+        v({ id: 'gone', sats: 9000, stateTag: 'Exited' }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded.map((e) => e.reason)).toEqual(['no-exit-chain']);
+    expect(r.skippedTerminalCount).toBe(1);
+  });
+
+  it('reproduces the live 7 sat/vB wall and the way through it', () => {
+    // Measured on device 2026-08-20: mempool fastestFee 7, all seven capsules
+    // excluded, so Emergency Exit refuses. The override is what lets a user
+    // proceed anyway, with the cost stated.
+    const live = [
+      v({ id: 'aa2c257e', sats: 800, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967351 }),
+      v({ id: 'd4ec1101', sats: 700, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967253 }),
+      v({ id: '1f6627c2', sats: 698, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967241 }),
+      v({ id: '9211887d', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+      v({ id: 'a6e24d2f', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+      v({ id: 'bc672cb8', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+      v({ id: 'ec46d966', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+    ];
+    const at7 = { vtxos: live, feeRateSatPerVb: 7, chainTipHeight: 963334, vtxoExitDeltaBlocks: 144 };
+
+    const blocked = triageArkExit(at7);
+    expect(blocked.selectedIds).toEqual([]);
+    expect(blocked.excludedSats).toBe(4990);
+    expect(blocked.overridableCount).toBe(7);
+
+    const forced = triageArkExit({ ...at7, economicPolicy: 'recover-everything' });
+    expect(forced.selectedIds).toHaveLength(7);
+    expect(forced.totalExitVb).toBe(6036);
+    expect(forced.reserveSats).toBe(84504);
+    // 84,504 sats of reserve to recover 2,330. The user has to see that.
+    expect(forced.netRecoverableSats).toBe(2330);
+    expect(forced.netLossSats).toBe(82174);
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,0 +1,483 @@
+import {
+  ASSUMED_EXIT_DELTA_BLOCKS,
+  claimRateFromExitRate,
+  ExitTriageVtxo,
+  RESERVE_FLOOR_SATS,
+  perVtxoExitVb,
+  requiredRunwayBlocks,
+  reserveSatsForExitVb,
+  triageArkExit,
+} from '../../src/services/ark/exitTriage';
+
+// Every capsule below is a real one, read off the QA wallet on 2026-08-20.
+// Chain tip at the time of the snapshot was 963234 and the server reported
+// vtxoExitDelta 144 / maxVtxoExitDepth 100.
+//
+// The whole point of the module is that a capsule's fate is decided by
+// exitDepth and exitTxWeightWu, not by its sat value, so the fixtures keep the
+// measured weights rather than rounding them.
+const TIP = 963234;
+const EXIT_DELTA = 144;
+
+function v(p: Partial<ExitTriageVtxo> & { id: string; sats: number }): ExitTriageVtxo {
+  return {
+    exitDepth: 2,
+    exitTxWeightWu: 1325,
+    expiryHeight: 967241,
+    stateTag: 'Spendable',
+    registered: true,
+    ...p,
+  };
+}
+
+/** The eight live capsules, 4,990 sats total. */
+const LIVE: ExitTriageVtxo[] = [
+  v({ id: 'd4ec1101', sats: 700, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967253 }),
+  v({ id: '1f6627c2', sats: 698, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967241 }),
+  v({ id: '9211887d', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  v({ id: 'a6e24d2f', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  v({ id: 'bc672cb8', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  v({ id: 'ec46d966', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  // The two that must be discarded: unrefreshable dust on a 1.8-day fuse.
+  v({ id: '095df741', sats: 400, exitDepth: 17, exitTxWeightWu: 12377, expiryHeight: 963502 }),
+  v({ id: '54b52b50', sats: 400, exitDepth: 15, exitTxWeightWu: 11041, expiryHeight: 963502 }),
+];
+
+function triage(over: Partial<Parameters<typeof triageArkExit>[0]> = {}) {
+  return triageArkExit({
+    vtxos: LIVE,
+    feeRateSatPerVb: 1,
+    chainTipHeight: TIP,
+    vtxoExitDeltaBlocks: EXIT_DELTA,
+    maxVtxoExitDepth: 100,
+    ...over,
+  });
+}
+
+describe('perVtxoExitVb: measured cost model', () => {
+  // If this drifts, every threshold in the module moves with it.
+  it.each([
+    ['700 @ depth 2', 2, 1325, 632],
+    ['698 @ depth 3', 3, 2337, 1035],
+    ['400 @ depth 15', 15, 11041, 5011],
+    ['400 @ depth 17', 17, 12377, 5645],
+  ])('%s costs %s vB', (_label, exitDepth, exitTxWeightWu, expected) => {
+    expect(perVtxoExitVb({ exitDepth: exitDepth as number, exitTxWeightWu: exitTxWeightWu as number }))
+      .toBe(expected);
+  });
+
+  it('falls back to a floor vsize when the SDK reports no exit weight', () => {
+    expect(perVtxoExitVb({ exitDepth: 0, exitTxWeightWu: 0 })).toBe(200);
+  });
+});
+
+describe('the exit set on the live wallet', () => {
+  it('discards the two 400s and keeps the six healthy capsules', () => {
+    const r = triage();
+    expect(r.selectedIds).toHaveLength(6);
+    expect(r.excluded.map((e) => e.id).sort()).toEqual(['095df741', '54b52b50']);
+    expect(r.excludedSats).toBe(800);
+    expect(r.selectedSats).toBe(4190);
+  });
+
+  it('sizes the reserve to the selected set, not the whole wallet', () => {
+    const r = triage();
+    // 632 + 632 + 1035*4 = 5,404 vB over the six, against 16,060 over all eight.
+    expect(r.totalExitVb).toBe(5404);
+    expect(r.reserveSats).toBe(10808);
+  });
+
+  it('costs the discarded dust at two thirds of the untriaged exit', () => {
+    // The number that justifies the whole module: 10,656 of 16,060 vB, 66%,
+    // for 800 of 4,990 sats, 16%.
+    const r = triage();
+    const dust = r.excluded.reduce((a, e) => a + e.perVtxoVb, 0);
+    expect(dust).toBe(10656);
+    expect(dust + r.totalExitVb).toBe(16060);
+  });
+
+  it('names every exclusion with an amount and a reason', () => {
+    const r = triage();
+    for (const e of r.excluded) {
+      expect(e.sats).toBeGreaterThan(0);
+      expect(e.reason).toBeTruthy();
+    }
+    expect(r.excluded.map((e) => e.reason)).toEqual([
+      'reserve-dwarfs-value',
+      'reserve-dwarfs-value',
+    ]);
+  });
+
+  it('reports what actually lands, net of each capsule claim fee', () => {
+    const r = triage();
+    // Six capsules, 76 vB each at 1 sat/vB.
+    expect(r.netRecoverableSats).toBe(4190 - 6 * 76);
+  });
+});
+
+describe('the threshold is not a sat amount', () => {
+  // This is the test that fails if anyone reintroduces a fixed dust floor.
+  it('keeps a 400-sat capsule at depth 2 and drops a 400-sat capsule at depth 17', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'shallow-400', sats: 400, exitDepth: 2, exitTxWeightWu: 1325 }),
+        v({ id: 'deep-400', sats: 400, exitDepth: 17, exitTxWeightWu: 12377 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['shallow-400']);
+    expect(r.excluded.map((e) => e.id)).toEqual(['deep-400']);
+    // Same value, same refresh verdict (both below ARK_REFRESH_MIN_SATS),
+    // opposite exit verdict, decided entirely by depth.
+    expect(r.selected[0].perVtxoVb).toBe(632);
+    expect(r.excluded[0].perVtxoVb).toBe(5645);
+  });
+
+  it('drops a large capsule whose tree is deep enough to outweigh it', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'deep-big', sats: 3000, exitDepth: 49, exitTxWeightWu: 24000 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // 6000 vB chain + 7350 CPFP = 13,350 vB to return 2,924 sats.
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+  });
+});
+
+describe('economic axis across the fee-rate matrix', () => {
+  const capsule = (sats: number, exitDepth: number, exitTxWeightWu: number) =>
+    v({ id: `c-${sats}-${exitDepth}`, sats, exitDepth, exitTxWeightWu });
+
+  it('never calls a 698 at 1 sat/vB profitable', () => {
+    const r = triageArkExit({
+      vtxos: [capsule(698, 2, 1325)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // 632 sats of reserve to return 622. The cheapest fee market in years and
+    // the best capsule in the wallet is still a fraction under water.
+    expect(r.selected[0].economic).toBe('marginal');
+    expect(r.selected[0].notes).toContain('under-water');
+  });
+
+  it.each([
+    [1, 'marginal', true],
+    [5, 'uneconomic', false],
+    [20, 'uneconomic', false],
+    [50, 'uneconomic', false],
+  ])('at %s sat/vB a 698 @ depth 2 is %s', (rate, verdict, kept) => {
+    const r = triageArkExit({
+      vtxos: [capsule(698, 2, 1325)],
+      feeRateSatPerVb: rate as number,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    const entry = [...r.selected, ...r.excluded][0];
+    expect(entry.economic).toBe(verdict);
+    expect(entry.included).toBe(kept);
+  });
+
+  // Positive control. Without this the suite would pass just as happily if the
+  // module excluded everything at every rate.
+  it.each([1, 5, 20, 50])(
+    'at %s sat/vB a 50,000-sat capsule @ depth 2 exits and pays for itself',
+    (rate) => {
+      const r = triageArkExit({
+        vtxos: [capsule(50_000, 2, 1325)],
+        feeRateSatPerVb: rate as number,
+        chainTipHeight: TIP,
+        vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(r.selectedIds).toEqual(['c-50000-2']);
+      expect(r.selected[0].economic).toBe('profitable');
+      expect(r.selected[0].notes).not.toContain('under-water');
+    },
+  );
+
+  it('drops the same 50,000-sat capsule once its tree is deep enough', () => {
+    // Value alone never decides it. At 20 sat/vB a depth-49 tree costs 267,000
+    // sats of reserve to return 48,480.
+    const r = triageArkExit({
+      vtxos: [capsule(50_000, 49, 24000)],
+      feeRateSatPerVb: 20,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+  });
+
+  it('excludes a capsule its own claim fee would swallow, and says so', () => {
+    const r = triageArkExit({
+      vtxos: [capsule(400, 2, 1325)],
+      feeRateSatPerVb: 20,
+      claimFeeRateSatPerVb: 20,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // 76 vB of claim at 20 sat/vB is 1,520 against a 400-sat capsule.
+    expect(r.excluded[0].reason).toBe('returns-nothing');
+    expect(r.excluded[0].netRecoveredSats).toBeLessThan(0);
+  });
+
+  it('prices the claim at the clamped rate the claim path actually pays', () => {
+    // Pricing claims at the fastest rate would condemn capsules the claim path
+    // recovers fine. The clamp is the same one that stopped bark rebuilding a
+    // 779-sat claim against a 698-sat output forever.
+    expect(claimRateFromExitRate(1)).toBe(1);
+    expect(claimRateFromExitRate(3)).toBe(3);
+    expect(claimRateFromExitRate(50)).toBe(5);
+
+    const r = triageArkExit({
+      vtxos: [capsule(400, 2, 1325)],
+      feeRateSatPerVb: 20,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // Same capsule, same fee spike, but the claim costs 380 rather than 1,520,
+    // so it is dropped for consuming reserve, not for returning nothing.
+    expect(r.excluded[0].marginalClaimSats).toBe(380);
+    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+  });
+
+  it('keeps the two costs in separate pots', () => {
+    const r = triageArkExit({
+      vtxos: [capsule(698, 2, 1325)],
+      feeRateSatPerVb: 1,
+      claimFeeRateSatPerVb: 3,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    const e = r.selected[0];
+    // Exit tree priced at the CPFP rate, claim priced at the claim rate.
+    expect(e.exitTreeCostSats).toBe(632);
+    expect(e.marginalClaimSats).toBe(228);
+    expect(e.netRecoveredSats).toBe(470);
+    // The reserve covers the exit tree only. The claim is never added to it.
+    expect(r.reserveSats).toBe(RESERVE_FLOOR_SATS);
+  });
+});
+
+describe('temporal axis', () => {
+  it('excludes a capsule that cannot clear its CSV before expiry', () => {
+    const r = triageArkExit({
+      // Healthy value, shallow tree, but 40 blocks of runway against 144 of CSV.
+      vtxos: [v({ id: 'fuse', sats: 20_000, expiryHeight: TIP + 40 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('too-close-to-expiry');
+  });
+
+  it('scales the confirmation budget with tree depth', () => {
+    // Same expiry, same value; only the depth differs.
+    const runway = TIP + 160;
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'shallow', sats: 20_000, exitDepth: 2, expiryHeight: runway }),
+        v({ id: 'deep', sats: 20_000, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: runway }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(requiredRunwayBlocks(2, EXIT_DELTA)).toBe(156);
+    expect(requiredRunwayBlocks(3, EXIT_DELTA)).toBe(162);
+    expect(r.selectedIds).toEqual(['shallow']);
+    expect(r.excluded[0].id).toBe('deep');
+  });
+
+  it('assumes the worst delta when ArkInfo was never cached, rather than skipping the check', () => {
+    const near = v({ id: 'near', sats: 20_000, exitDepth: 2, expiryHeight: TIP + 200 });
+    const cached = triageArkExit({
+      vtxos: [near],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    const uncached = triageArkExit({
+      vtxos: [near],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: null,
+    });
+    expect(cached.selectedIds).toEqual(['near']);
+    expect(cached.usedAssumedExitDelta).toBe(false);
+    // 200 blocks of runway clears 144 + 12 but not 288 + 12.
+    expect(uncached.selectedIds).toEqual([]);
+    expect(uncached.excluded[0].reason).toBe('too-close-to-expiry');
+    expect(uncached.usedAssumedExitDelta).toBe(true);
+    expect(ASSUMED_EXIT_DELTA_BLOCKS).toBeGreaterThan(EXIT_DELTA);
+  });
+
+  it('excludes the live 400s on runway alone once the delta is unknown', () => {
+    const r = triage({ vtxoExitDeltaBlocks: null });
+    const deep = r.excluded.find((e) => e.id === '095df741');
+    expect(deep?.reason).toBe('too-close-to-expiry');
+    expect(deep?.blocksUntilExpiry).toBe(268);
+    expect(deep?.requiredRunwayBlocks).toBe(390);
+  });
+
+  it('still exits, with a disclosure, when the chain tip is unreadable', () => {
+    // A failed tip read is a network fault, not evidence of a problem. Refusing
+    // to exit on it would disarm the emergency button exactly when the network
+    // is already misbehaving.
+    const r = triage({ chainTipHeight: null });
+    expect(r.selectedIds).toHaveLength(6);
+    expect(r.selected[0].notes).toContain('expiry-unknown');
+    expect(r.selected[0].blocksUntilExpiry).toBeNull();
+  });
+});
+
+describe('structural axis', () => {
+  it('exits unregistered capsules: registered is a mailbox flag, not exitability', () => {
+    // Measured 2026-08-19: all 117 unregistered capsules carried a full exit
+    // chain. Excluding them here would abandon arkoor change on every wallet.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'unreg', sats: 20_000, registered: false })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['unreg']);
+  });
+
+  it('exits a capsule past the server exit-depth cap, and flags it', () => {
+    // Past maxVtxoExitDepth the server refuses to cosign further arkoor spends,
+    // so exit and refresh are the only moves left. That is a reason to exit it,
+    // not a reason to abandon it.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'capped', sats: 500_000, exitDepth: 101, exitTxWeightWu: 24000 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      maxVtxoExitDepth: 100,
+    });
+    expect(r.selectedIds).toEqual(['capped']);
+    expect(r.selected[0].notes).toContain('beyond-server-depth-cap');
+  });
+
+  it('drops terminal capsules so finished exits stop inflating the reserve', () => {
+    // bark keeps returning a completed exit as state Exited from allVtxos()
+    // forever. The old reserve calc filtered only `spent`, so ten of these on
+    // the measured wallet added 7,252 vB of demanded reserve for value that was
+    // already on-chain.
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'live', sats: 20_000 }),
+        v({ id: 'gone', sats: 22_001, exitDepth: 4, exitTxWeightWu: 2657, stateTag: 'Exited' }),
+        v({ id: 'used', sats: 5000, stateTag: 'Spent' }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['live']);
+    expect(r.totalExitVb).toBe(632);
+    expect(r.skippedTerminalCount).toBe(2);
+  });
+
+  it('never lists terminal capsules as exclusions the user has to read', () => {
+    // The measured wallet holds 178 Spent and 10 Exited against 8 live ones.
+    // Putting those in the disclosure list would bury the two that matter.
+    const history = Array.from({ length: 100 }, (_, i) =>
+      v({ id: `old-${i}`, sats: 1000, stateTag: 'Spent' }),
+    );
+    const r = triageArkExit({
+      vtxos: [...history, ...LIVE],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.skippedTerminalCount).toBe(100);
+    expect(r.excluded).toHaveLength(2);
+    expect(r.excludedSats).toBe(800);
+  });
+
+  it('drops a capsule the SDK reports no exit chain for', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'chainless', sats: 20_000, exitDepth: 0, exitTxWeightWu: 0 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.excluded[0].reason).toBe('no-exit-chain');
+  });
+});
+
+describe('ordering under a constrained reserve', () => {
+  it('orders the exit set by what each capsule actually returns, highest first', () => {
+    // Deliberately fed smallest-first, so the assertion fails if the sort is
+    // removed rather than passing on the input order by luck.
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'tiny', sats: 600 }),
+        v({ id: 'mid', sats: 4_000 }),
+        v({ id: 'huge', sats: 90_000 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['huge', 'mid', 'tiny']);
+    const net = r.selected.map((e) => e.netRecoveredSats);
+    expect(net).toEqual([...net].sort((a, b) => b - a));
+  });
+
+  it('puts the largest live capsule first on the real wallet', () => {
+    expect(triage().selectedIds[0]).toBe('d4ec1101');
+  });
+
+  it('orders exclusions largest first so disclosure leads with the biggest loss', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'small', sats: 300, exitDepth: 17, exitTxWeightWu: 12377 }),
+        v({ id: 'large', sats: 900, exitDepth: 17, exitTxWeightWu: 12377 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.excluded.map((e) => e.id)).toEqual(['large', 'small']);
+  });
+});
+
+describe('reserve sizing', () => {
+  it('reserves nothing when nothing is selected, rather than the floor', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'dust', sats: 400, exitDepth: 17, exitTxWeightWu: 12377 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.reserveSats).toBe(0);
+  });
+
+  it('applies the floor once there is something to exit', () => {
+    expect(reserveSatsForExitVb(0, 1)).toBe(0);
+    expect(reserveSatsForExitVb(100, 1)).toBe(RESERVE_FLOOR_SATS);
+    expect(reserveSatsForExitVb(5404, 1)).toBe(10808);
+  });
+
+  it('scales the reserve with the fee rate', () => {
+    expect(reserveSatsForExitVb(5404, 5)).toBe(54040);
+  });
+});
+
+describe('marginal opt-out', () => {
+  it('can be told to exit only capsules that pay for themselves', () => {
+    const r = triage({ includeMarginal: false });
+    // At 1 sat/vB nothing in this wallet clears its own reserve cost, which is
+    // the finding, not a bug. Default-on is what keeps the exit useful.
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded).toHaveLength(8);
+  });
+});


### PR DESCRIPTION
## The problem

Emergency Exit marks every VTXO (`startExitForEntireWallet`) and sizes the on-chain fee reserve over every non-spent VTXO. Nothing filters anything, so the exit chases capsules it can never recover and bills the user for the attempt. `startExitForVtxos(vtxoIds)` has existed in the SDK the whole time and was never called.

Measured on the QA wallet at 1 sat/vB:

| | |
|---|---|
| Exit-tree cost, all 8 capsules | 16,060 sats |
| Value being rescued | 4,990 sats |
| Two 400-sat capsules' share of the cost | 10,656 sats, **66%** |
| Those capsules' share of the value | 800 sats, **16%** |
| Reserve demanded, all 8 | 32,120 sats |
| Reserve demanded, after triage | **10,808 sats** |

Separately, ten already-`Exited` capsules were adding another 7,252 vB of reserve for value that is already on-chain: bark keeps returning them from `allVtxos()` forever and the old filter only dropped `Spent`.

The failure mode is not the claim. `drainExits` batches, so a small capsule adds about 76 vB and returns its value. The damage is that dust consumes the CPFP reserve the healthy capsules need, and with no ordering policy, which capsules get stranded when the reserve runs dry was undefined.

## The rule is not a sat amount

A 400-sat capsule at `exitDepth` 17 costs 5,645 vB and is hopeless. A 400 at depth 2 costs 632 vB and is merely marginal. Both sit below the 500-sat refresh minimum, which is why that constant is the wrong tool for this decision. The verdict is computed per capsule from `exitDepth` and `exitTxWeightWu`.

## What this adds

`src/services/ark/exitTriage.ts`, pure and testable without the native bark module, following `exitFundingPlan.ts` / `refreshBatch.ts` / `exitReserveTarget.ts` / `autoBoardDecision.ts`. Three axes:

- **structural**: no exit chain at all. `registered: false` is explicitly NOT an exclusion; unregistered arkoor change carries a full exit chain.
- **temporal**: not enough runway to confirm the tree and then sit out the CSV before the server can sweep it. Measured against the cached `vtxoExitDelta`; a missing cache assumes the worst plausible delta rather than skipping the check.
- **economic**: exit-tree cost against what the capsule returns net of its own claim fee. Those are **two different pots**, the reserve and the capsule itself, and are never summed into one threshold.

The exit set is ordered most-recoverable-first, so a reserve that runs dry strands the least valuable capsules.

Also in this change:

- `startArkEmergencyExit(ids)` calls `startExitForVtxos`, and refuses an empty set rather than silently falling back to the whole wallet.
- `computeExitFeeReserveSats` sizes over the selected set only.
- The confirm dialog names every excluded capsule with amount and reason, and puts the required reserve next to what actually reaches the user's address, before they commit.
- `vtxoExitDelta` and `maxVtxoExitDepth` are cached from `arkInfo` during normal sync, alongside the existing round-interval fetch. The exit path must never call the server, since it is the path a user takes when the server is gone.

## Testing

42 unit tests built on the measured capsules, covering the classification matrix at 1, 5, 20 and 50 sat/vB, the reserve over the selected set, ordering, unregistered exitability, and the missing-`vtxoExitDelta` fallback.

Mutation-checked: restoring each old behaviour makes the suite fail.

| Restored behaviour | Tests failing |
|---|---|
| cost ignores `exitDepth` | 12 |
| no triage, exit everything | 23 |
| terminal filter is `spent` only | 1 |
| missing cache skips the temporal check | 2 |
| 500-sat refresh floor used as the exit rule | 2 |
| reserve sized over selected + excluded | 3 |
| unregistered treated as non-exitable | 1 |
| claim priced at the unclamped fast rate | 1 |
| ordering removed | 1 |

Full unit suite: 37 suites, 293 passed. `tsc` is unchanged against the `main` baseline: 405 errors, zero differing normalized lines.

Device verification against a dead ASP endpoint is next and will be reported on this PR.