### PR TITLE
Wait on the ripening schedule, not a clock, so an exit lands as one UTXO

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -462,9 +462,29 @@ export default function useArkSync(): UseArkSync {
                     // an ordinary UTXO that only this wallet can spend, with no
                     // deadline and nobody to race.
                     const exitVtxosForBatch = await fetchArkExitVtxos();
-                    const stillProgressing = exitVtxosForBatch.filter(
+                    const stragglers = exitVtxosForBatch.filter(
                         (v) => isActiveExit(v) && !v.isClaimable,
-                    ).length;
+                    );
+                    const stillProgressing = stragglers.length;
+
+                    // The ripening schedule is knowable in advance:
+                    // AwaitingDelta carries the exact block each straggler
+                    // becomes claimable at, fixed from the moment its leaf
+                    // confirmed. Handing those to the decision lets it wait on
+                    // the chain rather than on a clock, which is what makes the
+                    // whole exit land as one UTXO instead of several. A
+                    // straggler still Processing has no such height yet, and
+                    // those are what the wall-clock backstop is for.
+                    const pendingClaimableHeights: number[] = [];
+                    let unknownScheduleCount = 0;
+                    for (const v of stragglers) {
+                        const h = Number(
+                            (v.state as { inner?: { claimableHeight?: number } })?.inner
+                                ?.claimableHeight ?? 0,
+                        );
+                        if (Number.isFinite(h) && h > 0) pendingClaimableHeights.push(h);
+                        else unknownScheduleCount += 1;
+                    }
 
                     const batchDecision = decideExitClaimBatch({
                         claimableCount: claimable.length,
@@ -472,6 +492,9 @@ export default function useArkSync(): UseArkSync {
                         batchSince: useAuthStore.getState().arkExitClaimBatchSince ?? null,
                         now: Date.now(),
                         maxWaitMs: EXIT_CLAIM_BATCH_MAX_WAIT_MS,
+                        tipHeight: useAuthStore.getState().arkChainTipHeight ?? null,
+                        pendingClaimableHeights,
+                        unknownScheduleCount,
                     });
                     if (
                         (useAuthStore.getState().arkExitClaimBatchSince ?? null) !==
@@ -483,7 +506,10 @@ export default function useArkSync(): UseArkSync {
                     if (claimable.length > 0 && !claimBatchReady) {
                         _stamp(
                             `exit claim held for batching (${batchDecision.reason}): ` +
-                            `${claimable.length} ready, ${stillProgressing} still progressing`,
+                            `${claimable.length} ready, ${stillProgressing} still progressing` +
+                            (batchDecision.blocksUntilAllReady != null
+                                ? `, ${batchDecision.blocksUntilAllReady} blocks to go`
+                                : ''),
                         );
                     }
 

--- a/src/services/ark/exitClaimBatch.ts
+++ b/src/services/ark/exitClaimBatch.ts
@@ -2,10 +2,12 @@
  * When should the exit claim sweep fire?
  *
  * `drainExits([])` already sweeps every currently-claimable capsule into ONE
- * transaction, so cost is per-claim, not per-capsule. Claiming the moment the
- * first capsule ripens therefore pays a separate fee for every one of them.
- * Seen on a five-capsule exit: 225 sats to move 877, with four more queued
- * behind it, on a fee wallet that had already fallen from 3654 to 699 sats.
+ * transaction, so cost is per-claim, not per-capsule, and the whole exit can
+ * land as a single UTXO at the destination. Claiming the moment the first
+ * capsule ripens instead pays a separate fee for every one of them and
+ * fragments the result. Seen on a five-capsule exit: 225 sats to move 877, with
+ * four more queued behind it, on a fee wallet that had already fallen from 3654
+ * to 699 sats, and 2,961 recovered sats delivered as five separate UTXOs.
  *
  * Capsules ripen apart because each has its own exit branch and its own CSV,
  * timed from when THAT branch's transaction confirmed. One block between two
@@ -14,6 +16,27 @@
  * Waiting is safe: past its CSV a claimable exit output is an ordinary UTXO
  * that only this wallet can spend, with no deadline and nobody to race. What is
  * NOT safe is waiting forever, so a wedged capsule cannot hold the rest hostage.
+ *
+ * BLOCKS, NOT A TIMER. The ripening schedule is known in advance:
+ * `ExitState.AwaitingDelta.inner.claimableHeight` is populated the moment a
+ * leaf confirms, and it does not move. So "has everything ripened" is a
+ * question about the chain tip, not about elapsed time, and answering it with a
+ * clock gets it wrong in exactly the case that matters.
+ *
+ * Measured on the 2026-08-17/20 exit, the three capsules still in flight
+ * reported claimableHeight 963101, 963142 and 963145. That is a 44-block spread,
+ * about 7.3 hours. Against a 6-hour wall-clock ceiling the window expires
+ * roughly 80 minutes BEFORE the last capsule ripens, with one of the three
+ * claimable, so the sweep fires early and the exit lands as two UTXOs instead
+ * of one. No ceiling tuned in hours fixes this in general: block intervals are
+ * stochastic, and the spread is a property of when each branch confirmed.
+ *
+ * So: when every straggler's ripening height is known, hold until the tip
+ * reaches the last of them. That wait provably terminates, because the heights
+ * are fixed and the chain only moves forward. The wall-clock backstop stays for
+ * the case it is actually good for, a straggler whose ripening height we do NOT
+ * know (still broadcasting, or the tip is unreadable), where there is no
+ * schedule to wait on and something has to bound the wait.
  *
  * Lives here rather than inline in useArkSync so the rule can be tested without
  * standing up the sync loop.
@@ -28,8 +51,25 @@ export type ExitClaimBatchInput = {
     batchSince: number | null;
     /** Current epoch ms. */
     now: number;
-    /** How long to wait for stragglers before sweeping without them. */
+    /** How long to wait for stragglers whose ripening height is UNKNOWN. */
     maxWaitMs: number;
+    /**
+     * Current chain tip, or null when every provider failed. A null tip means
+     * the schedule cannot be evaluated at all, so the wall-clock backstop
+     * governs.
+     */
+    tipHeight?: number | null;
+    /**
+     * Known `claimableHeight` of each straggler, from
+     * `ExitState.AwaitingDelta.inner.claimableHeight`. Stragglers with no known
+     * height are counted in `unknownScheduleCount` instead.
+     */
+    pendingClaimableHeights?: readonly number[];
+    /**
+     * Stragglers with no readable ripening height, e.g. still Processing so no
+     * leaf has confirmed yet. These are what the wall-clock backstop is for.
+     */
+    unknownScheduleCount?: number;
 };
 
 export type ExitClaimBatchDecision = {
@@ -38,7 +78,17 @@ export type ExitClaimBatchDecision = {
     /** Start (or keep) the batching window at this epoch ms, null to clear it. */
     batchSince: number | null;
     /** Why, for the drive log. */
-    reason: 'nothing-claimable' | 'all-ready' | 'window-expired' | 'waiting';
+    reason:
+        | 'nothing-claimable'
+        | 'all-ready'
+        | 'window-expired'
+        | 'waiting'
+        | 'waiting-for-schedule';
+    /**
+     * Blocks until the last straggler ripens, when the schedule is known. Feeds
+     * an honest "2 blocks to go" countdown instead of a fake seconds timer.
+     */
+    blocksUntilAllReady?: number;
 };
 
 export function decideExitClaimBatch(input: ExitClaimBatchInput): ExitClaimBatchDecision {
@@ -58,7 +108,39 @@ export function decideExitClaimBatch(input: ExitClaimBatchInput): ExitClaimBatch
         return { claim: true, batchSince: since, reason: 'all-ready' };
     }
 
-    // A straggler is wedged or simply slow. Bounded wait, then go without it.
+    const tip =
+        typeof input.tipHeight === 'number' && Number.isFinite(input.tipHeight)
+            ? Math.floor(input.tipHeight)
+            : null;
+    const heights = (input.pendingClaimableHeights ?? []).filter(
+        (h) => typeof h === 'number' && Number.isFinite(h) && h > 0,
+    );
+    const unknownSchedule = Math.max(
+        0,
+        input.unknownScheduleCount ?? stillProgressingCount - heights.length,
+    );
+
+    // Every straggler's ripening height is known and the tip is readable, so
+    // the wait has a definite end. Hold for it however long the chain takes.
+    if (tip != null && unknownSchedule === 0 && heights.length > 0) {
+        const lastHeight = Math.max(...heights);
+        const blocksUntilAllReady = lastHeight - tip;
+        if (blocksUntilAllReady > 0) {
+            return {
+                claim: false,
+                batchSince: since,
+                reason: 'waiting-for-schedule',
+                blocksUntilAllReady,
+            };
+        }
+        // The tip has passed every scheduled height but the stragglers still
+        // are not claimable, so they need confirmations bark has not seen yet,
+        // or they are wedged. There is no schedule left to wait on; fall
+        // through to the bounded wait.
+    }
+
+    // Either a straggler has no known ripening height, or the schedule has run
+    // out and something is stuck. Bounded wait, then go without it.
     if (now - since >= maxWaitMs) {
         return { claim: true, batchSince: since, reason: 'window-expired' };
     }

--- a/tests/unit/exitClaimBatch.test.ts
+++ b/tests/unit/exitClaimBatch.test.ts
@@ -131,3 +131,161 @@ describe('the batch we actually lived through', () => {
         expect(d.reason).toBe('all-ready');
     });
 });
+
+// --- Height-aware batching -------------------------------------------------
+//
+// The three capsules still in flight on the 2026-08-17/20 mainnet exit reported
+// these ripening heights. The spread is what makes a wall-clock ceiling wrong.
+const H = [963101, 963142, 963145];
+
+describe('one exit, one UTXO: waiting on the schedule rather than a clock', () => {
+  it('holds past the wall-clock ceiling while the tip has not reached the last height', () => {
+    // 6h after the first capsule ripened the tip is ~36 blocks on, still 8
+    // short of 963145. The old rule fired here and split the exit in two.
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [963142, 963145],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(false);
+    expect(d.reason).toBe('waiting-for-schedule');
+    expect(d.blocksUntilAllReady).toBe(8);
+  });
+
+  it('sweeps once the tip reaches the last scheduled height', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 3,
+      stillProgressingCount: 0,
+      batchSince: T0,
+      now: T0 + 8 * 60 * 60 * 1000,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963145,
+      pendingClaimableHeights: [],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('all-ready');
+  });
+
+  it('reports blocks remaining so the wait can be shown honestly', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + 60_000,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: H[0],
+      pendingClaimableHeights: [H[1], H[2]],
+      unknownScheduleCount: 0,
+    });
+    expect(d.blocksUntilAllReady).toBe(44);
+  });
+
+  it('still bounds the wait when a straggler has no known ripening height', () => {
+    // Still Processing, so no leaf has confirmed and there is no schedule to
+    // wait on. This is the case the wall-clock ceiling is actually for.
+    const held = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + MAX_WAIT - 1,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [],
+      unknownScheduleCount: 1,
+    });
+    expect(held.claim).toBe(false);
+    expect(held.reason).toBe('waiting');
+
+    const expired = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [],
+      unknownScheduleCount: 1,
+    });
+    expect(expired.claim).toBe(true);
+    expect(expired.reason).toBe('window-expired');
+  });
+
+  it('does not wait on a schedule when one straggler of several is unscheduled', () => {
+    // A known height for two of three proves nothing about the third.
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 3,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [963142, 963145],
+      unknownScheduleCount: 1,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('window-expired');
+  });
+
+  it('falls back to the clock when the chain tip is unreadable', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: null,
+      pendingClaimableHeights: [963142, 963145],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('window-expired');
+  });
+
+  it('stops waiting on a schedule the tip has already passed', () => {
+    // Heights reached but bark still does not call them claimable: they need
+    // confirmations, or they are wedged. Bound it rather than hold forever.
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963200,
+      pendingClaimableHeights: [963145],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('window-expired');
+  });
+
+  it('infers the unscheduled count when the caller does not pass one', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + 60_000,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [963142, 963145],
+    });
+    expect(d.reason).toBe('waiting-for-schedule');
+  });
+
+  it('keeps the old behaviour when no schedule is supplied at all', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + 60_000,
+      maxWaitMs: MAX_WAIT,
+    });
+    expect(d.claim).toBe(false);
+    expect(d.reason).toBe('waiting');
+  });
+});


### PR DESCRIPTION
Stacked on #181.

## One exit should arrive as one UTXO. It does not.

`drainExits` sweeps every claimable capsule into a single transaction, so the whole exit can land as one UTXO at the destination. The last mainnet exit delivered **2,961 sats as five separate UTXOs**.

#181 fixed the obvious half of that by holding the sweep instead of claiming the moment the first capsule ripens. The ceiling it holds against is wall-clock, and that is where it still breaks.

The three capsules still in flight on that exit reported:

```
05ec3efc  claimableHeight 963101
c51eb209  claimableHeight 963142
4b4e567e  claimableHeight 963145
```

44 blocks, about 7.3 hours. Against `EXIT_CLAIM_BATCH_MAX_WAIT_MS = 6h`:

| | |
|---|---|
| Window opens (first capsule ripe) | 963101 |
| Window expires, 6h later | ~963137 |
| Capsules claimable at that point | **1 of 3** |
| Last capsule ripens | 963145, ~80 min after the window closed |

So it fires `window-expired`, sweeps one capsule, and the exit splits into two UTXOs. No ceiling tuned in hours fixes this in general: block intervals are stochastic, and the spread is a property of when each branch happened to confirm, not of how long anyone waited.

## Blocks are the truth, time is the estimate

`ExitState.AwaitingDelta.inner.claimableHeight` is populated the moment a leaf confirms, and it does not move. The full schedule is known long before it matters, so "has everything ripened" is a question about the chain tip, not about elapsed time.

`decideExitClaimBatch` now holds until the tip reaches the last known `claimableHeight`. That wait provably terminates: the heights are fixed and the chain only goes forward.

The wall-clock backstop stays for the case it is actually good for, and only that case:

- a straggler with no known ripening height (still `Processing`, no leaf confirmed yet)
- an unreadable chain tip
- the tip has passed every scheduled height and the stragglers still are not claimable, which means wedged rather than slow

A partial schedule does not count. Knowing two heights of three proves nothing about the third, so that falls back to the clock too.

The decision also returns `blocksUntilAllReady`, which feeds an honest "2 blocks to go" rather than a seconds countdown that visibly stalls and jumps, per spec 7.2.

## Testing

21 unit tests, built on the three measured heights above. Mutation-checked:

| Restored behaviour | Tests failing |
|---|---|
| blind wall-clock ceiling (#181 as-is) | 3 |
| `min` instead of `max` of the ripening heights | 2 |
| wait on a schedule while a straggler is unscheduled | 1 |
| hold forever once the tip passes the schedule | 1 |

Full unit suite 37 suites / 272 tests. `tsc` unchanged at the 405 baseline.

## Relationship to #191

Independent, and they compound. #191 keeps capsules out of the exit set that would never have become claimable, so there are fewer stragglers to wait on and no dust exit that could hold the batch to its backstop. This one makes the remaining set arrive together.