### PR TITLE
Stop the exit-funding confirm screen hiding the amount and the fee

### DIFF
--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import SimpleToast from 'react-native-simple-toast';
 
 import { ScreenLayout, Text } from '@Cypher/component-library';
-import { GradientCard, SwipeButton } from '@Cypher/components';
+import { SwipeButton } from '@Cypher/components';
 import { colors } from '@Cypher/style-guide';
 import { formatNumber } from '@Cypher/helpers/coinosHelper';
 import useAuthStore from '@Cypher/stores/authStore';
@@ -270,7 +270,26 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                                 </Text>
                             </View>
                         )}
-                        <GradientCard disabled style={{ marginTop: 12 }}>
+                        {/* NOT GradientCard. That component hard-codes
+                            height: 60 on both its wrapper and its gradient,
+                            because it is the single-row input pill, and every
+                            other caller overrides it via linearStyle. Used here
+                            for a five-row details panel it clipped everything
+                            below the first row: observed on device as a screen
+                            showing only "From CoinOS", with the amount, the
+                            network fee and the total silently invisible on a
+                            money-moving confirmation. A details panel is the
+                            plain bordered View the sibling Ark review screens
+                            use. */}
+                        <View
+                            style={{
+                                marginTop: 12,
+                                borderRadius: 20,
+                                borderWidth: 1,
+                                borderColor: '#333',
+                                backgroundColor: '#1a1a1a',
+                            }}
+                        >
                             <View style={{ padding: 16 }}>
                                 <Row label="From" value={sourceLabel} />
                                 <Row label="To" value="Bark on-chain reserve" hint={address ?? undefined} />
@@ -302,7 +321,7 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                                     </Text>
                                 )}
                             </View>
-                        </GradientCard>
+                        </View>
 
                         {plan.ok && plan.partial && (
                             <Text style={{ fontSize: 12, color: '#FFD54F', marginTop: 12, lineHeight: 17 }}>

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import SimpleToast from 'react-native-simple-toast';
 
-import { ScreenLayout, Text } from '@Cypher/component-library';
-import { SwipeButton } from '@Cypher/components';
+import { Input, ScreenLayout, Text } from '@Cypher/component-library';
+import { GradientCard, SwipeButton } from '@Cypher/components';
 import { colors } from '@Cypher/style-guide';
 import { formatNumber } from '@Cypher/helpers/coinosHelper';
 import useAuthStore from '@Cypher/stores/authStore';
@@ -84,11 +84,19 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
 
     const [address, setAddress] = useState<string | null>(null);
     const [feeSats, setFeeSats] = useState<number | null>(null);
+    // What the user wants to LAND on-chain. Seeded with the shortfall, because
+    // that is the number that clears the gate, but editable: the exit accepts
+    // partial funding and a user may only want to part-fund it now.
+    const [amountText, setAmountText] = useState(
+        shortfallSats > 0 ? String(Math.floor(shortfallSats)) : '',
+    );
     const [loading, setLoading] = useState(true);
     const [sending, setSending] = useState(false);
     // Why preparation failed, if it did. Distinct from a plan that simply is
     // not fundable: this one means we never got far enough to compute a plan.
     const [prepError, setPrepError] = useState<string | null>(null);
+    // Debounce handle for re-estimating the fee as the amount is typed.
+    const feeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     // Latched once an outcome becomes unknown. Never cleared: the point is that
     // this screen must not offer to send again. Mirrors the Ark send review.
     const [indeterminate, setIndeterminate] = useState(false);
@@ -145,15 +153,62 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         };
     }, [shortfallSats]);
 
+    /** Digits only. An empty or zero field is "nothing to send", not an error
+     *  to shout about while the user is still typing. */
+    const amountSats = useMemo(() => {
+        const digits = amountText.replace(/[^0-9]/g, '');
+        const n = digits ? parseInt(digits, 10) : 0;
+        return Number.isFinite(n) ? n : 0;
+    }, [amountText]);
+
     const plan = useMemo(
         () =>
             planExitFunding({
-                shortfallSats,
+                // The field is the target now. planExitFunding calls it a
+                // shortfall because that is what seeds it, but it only ever
+                // means "sats the user wants to land".
+                shortfallSats: amountSats,
                 availableSats,
                 feeSats: feeSats ?? 0,
             }),
-        [shortfallSats, availableSats, feeSats],
+        [amountSats, availableSats, feeSats],
     );
+
+    /** True once the field no longer covers the gap the exit reported. */
+    const underSuggested = shortfallSats > 0 && amountSats > 0 && amountSats < shortfallSats;
+
+    // The fee depends on the amount, so a fee quoted for the mount-time
+    // shortfall goes stale the moment the field is edited, and "Leaves your
+    // wallet" is built from it. Re-estimate on a debounce rather than per
+    // keystroke: this is a network call to CoinOS.
+    useEffect(() => {
+        if (!address || amountSats <= 0) return;
+        if (feeTimer.current) clearTimeout(feeTimer.current);
+        let cancelled = false;
+        feeTimer.current = setTimeout(() => {
+            (async () => {
+                try {
+                    const raw = await withTimeout(
+                        bitcoinSendFee(amountSats, address, 0),
+                        PREPARE_TIMEOUT_MS,
+                        'Estimating the network fee',
+                    );
+                    const parsed =
+                        typeof raw === 'string' && raw.trim().startsWith('{')
+                            ? JSON.parse(raw)
+                            : null;
+                    if (!cancelled) setFeeSats(Number(parsed?.fee ?? 0) || 0);
+                } catch {
+                    // Keep the last estimate. A failed re-quote makes the
+                    // preview less precise; it must not blank the screen.
+                }
+            })();
+        }, 500);
+        return () => {
+            cancelled = true;
+            if (feeTimer.current) clearTimeout(feeTimer.current);
+        };
+    }, [amountSats, address]);
 
     // Reasons the swipe can never succeed, as opposed to "not yet". Ordered so
     // the most specific wins: an indeterminate send outranks a bad plan.
@@ -165,9 +220,11 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
             ? 'Cannot continue until the deposit address is available.'
             : sourceId !== 'coinos'
               ? `Funding from ${sourceLabel} is not available yet.`
-              : !plan.ok
-                ? plan.reason
-                : null;
+              : amountSats <= 0
+                ? 'Enter an amount to send.'
+                : !plan.ok
+                  ? plan.reason
+                  : null;
 
     const fiat = (sats: number) =>
         rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
@@ -183,7 +240,7 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         try {
             const res = await fundExitFeesFromCoinos(
                 {
-                    shortfallSats,
+                    shortfallSats: amountSats,
                     availableSats,
                     currentReserveSats: arkExitFeeReserveSats ?? 0,
                     idempotencyKey: idempotencyKey.current,
@@ -227,11 +284,21 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         }
     };
 
-    const Row = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (
+    const Row = ({
+        label,
+        value,
+        hint,
+        wrap,
+    }: {
+        label: string;
+        value: string;
+        hint?: string;
+        wrap?: boolean;
+    }) => (
         <View style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 10 }}>
             <Text style={{ fontSize: 14, color: '#BBB' }}>{label}</Text>
             <View style={{ alignItems: 'flex-end', flex: 1, paddingLeft: 12 }}>
-                <Text bold style={{ fontSize: 14 }} numberOfLines={1}>
+                <Text bold style={{ fontSize: 14 }} numberOfLines={wrap ? 2 : 1}>
                     {value}
                 </Text>
                 {!!hint && <Text style={{ fontSize: 11, color: '#888', marginTop: 2 }}>{hint}</Text>}
@@ -241,7 +308,11 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
 
     return (
         <ScreenLayout disableScroll showToolbar isBackButton title="Fund exit fees">
-            <View style={{ paddingHorizontal: 20, flex: 1 }}>
+            <ScrollView
+                style={{ flex: 1 }}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 16 }}
+                keyboardShouldPersistTaps="handled"
+            >
                 {loading ? (
                     <ActivityIndicator color={colors.pink.default} style={{ marginTop: 40 }} />
                 ) : (
@@ -281,6 +352,42 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                             money-moving confirmation. A details panel is the
                             plain bordered View the sibling Ark review screens
                             use. */}
+                        {/* Amount. GradientCard's fixed 60px height is
+                            CORRECT here: it is the single-field pill the rest
+                            of the app uses for exactly this, which is why the
+                            details panel below is a plain View instead. */}
+                        <GradientCard
+                            style={{ marginTop: 12 }}
+                            colors_={
+                                amountSats > 0
+                                    ? [colors.pink.extralight, colors.pink.default]
+                                    : [colors.gray.thin, colors.gray.thin2]
+                            }
+                        >
+                            <Input
+                                value={amountText}
+                                onChange={(t: string) => setAmountText(t.replace(/[^0-9]/g, ''))}
+                                keyboardType="number-pad"
+                                label="Amount in sats"
+                                maxLength={12}
+                            />
+                        </GradientCard>
+
+                        {shortfallSats > 0 && (
+                            <Text
+                                style={{
+                                    fontSize: 12,
+                                    color: underSuggested ? '#FFD54F' : '#888',
+                                    marginTop: 8,
+                                    lineHeight: 17,
+                                }}
+                            >
+                                {underSuggested
+                                    ? `Suggested ${formatNumber(shortfallSats)} sats. Less than that still helps: the exit runs as far as these fees allow.`
+                                    : `Suggested ${formatNumber(shortfallSats)} sats, which is what the exit is short by.`}
+                            </Text>
+                        )}
+
                         <View
                             style={{
                                 marginTop: 12,
@@ -292,7 +399,13 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                         >
                             <View style={{ padding: 16 }}>
                                 <Row label="From" value={sourceLabel} />
-                                <Row label="To" value="Bark on-chain reserve" hint={address ?? undefined} />
+                                <Row label="To" value="Bark on-chain wallet" />
+                                <Row
+                                    wrap
+                                    label="Address"
+                                    value={address ?? 'Preparing...'}
+                                    hint={address ? 'Deposit lands here and stays on-chain' : undefined}
+                                />
                                 {plan.ok ? (
                                     <>
                                         <Row
@@ -337,7 +450,7 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
 
                     </>
                 )}
-            </View>
+            </ScrollView>
 
             <View style={{ paddingHorizontal: 20, paddingBottom: 20 }}>
                 {blockedReason ? (

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -18,6 +18,7 @@ import {
     getTransactionHistory,
     sendBitcoinPayment,
 } from '@Cypher/api/coinOSApis';
+import { getFiatRate } from '../../../../models/fiatUnit';
 
 /**
  * Preparing the deposit needs bark's on-chain (BDK) wallet, and spawning that
@@ -97,6 +98,26 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
     const [prepError, setPrepError] = useState<string | null>(null);
     // Debounce handle for re-estimating the fee as the amount is typed.
     const feeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // The caller does not pass a rate, so every fiat figure here and on the
+    // success screen rendered as 0.00. Fetch it the same way the non-Strike
+    // rails do in SwapAmount. Failure just leaves the fiat hints blank.
+    const [fetchedRate, setFetchedRate] = useState(0);
+    useEffect(() => {
+        if (rate > 0) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const r = (await getFiatRate('USD')) || 0;
+                if (!cancelled) setFetchedRate(r);
+            } catch {
+                // Leave fiat blank rather than showing a wrong number.
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [rate]);
+    const effectiveRate = rate > 0 ? rate : fetchedRate;
     // Latched once an outcome becomes unknown. Never cleared: the point is that
     // this screen must not offer to send again. Mirrors the Ark send review.
     const [indeterminate, setIndeterminate] = useState(false);
@@ -227,7 +248,9 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                   : null;
 
     const fiat = (sats: number) =>
-        rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
+        effectiveRate > 0
+            ? `${currencySymbol}${((sats / SATS_PER_BTC) * effectiveRate).toFixed(2)}`
+            : '';
 
     const feePct =
         plan.ok && plan.sendSats > 0 && feeSats
@@ -264,11 +287,25 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
             if (res.ok) {
                 navigation.replace('ArkSendSuccessScreen', {
                     title: 'Exit fees funded',
+                    // These three were never passed, so the success screen fell
+                    // back to its defaults and reported "0 sats" for a real
+                    // deposit. It reads them; send them.
+                    value: String(res.sentSats),
+                    valueUsd:
+                        effectiveRate > 0
+                            ? ((res.sentSats / SATS_PER_BTC) * effectiveRate).toFixed(2)
+                            : '0.00',
+                    currency: currencySymbol === '$' ? 'USD' : currencySymbol,
+                    // On-chain, not Lightning. The default rail label and the
+                    // bolt both said otherwise.
+                    isOnchain: true,
+                    networkLabel: 'Bitcoin Network',
                     // The deposit is worthless until it confirms, and saying so
-                    // here is what stops "nothing happened" a minute later.
-                    message: res.partial
-                        ? `Sent ${formatNumber(res.sentSats)} sats. That is less than the full shortfall, so top up again if the exit still reports a gap. Emergency Exit unlocks once it confirms on-chain.`
-                        : `Sent ${formatNumber(res.sentSats)} sats. Emergency Exit unlocks once it confirms on-chain.`,
+                    // here is what stops "nothing happened" a minute later. The
+                    // amount is displayed above now, so it is not repeated.
+                    note: res.partial
+                        ? 'That is less than the full shortfall, so top up again if the exit still reports a gap. Emergency Exit unlocks once it confirms on-chain.'
+                        : 'Emergency Exit unlocks once it confirms on-chain.',
                     txid: res.txid ?? undefined,
                 });
                 return;

--- a/src/screens/Ark/ArkSendSuccessScreen/index.tsx
+++ b/src/screens/Ark/ArkSendSuccessScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Image, Vibration, View } from 'react-native';
+import { Image, ImageBackground, Vibration, View } from 'react-native';
 import Animated, {
     Easing,
     useAnimatedStyle,
@@ -10,7 +10,7 @@ import Animated, {
 import { ScreenLayout, Text } from '@Cypher/component-library';
 import { GradientButton, GradientCard } from '@Cypher/components';
 import Ring from '@Cypher/components/RingEffect';
-import { Electrik } from '@Cypher/assets/images';
+import { Bitcoin, BitcoinTower, Electrik } from '@Cypher/assets/images';
 import { dispatchReset } from '@Cypher/helpers/navigation';
 import { getStrikeCurrency } from '@Cypher/helpers/coinosHelper';
 import { colors } from '@Cypher/style-guide';
@@ -37,6 +37,19 @@ import styles from '../../Transaction/styles';
  *   value:    net sats sent (string)
  *   valueUsd: fiat equivalent (string, already formatted to 2dp)
  *   currency: fiat currency code
+ *
+ * Everything below is optional and exists because this screen is no longer
+ * only a Lightning send. The exit-fee top-up lands here too, and it is an
+ * ON-CHAIN deposit that is not usable until it confirms. Shown unchanged, it
+ * told that user "Payment Sent / 0 sats / Lightning Network": the wrong amount,
+ * the wrong rail, and an air of finality the transaction had not earned.
+ *
+ *   title:        headline, default 'Payment Sent'
+ *   networkLabel: rail under the animation, default 'Lightning Network'
+ *   isOnchain:    swap the Lightning bolt for the Bitcoin visual the on-chain
+ *                 broadcast screen already uses
+ *   note:         a line under the amount for anything the user still has to
+ *                 know, e.g. that an on-chain deposit has to confirm first
  */
 
 interface Props {
@@ -45,6 +58,10 @@ interface Props {
             value?: string | number;
             valueUsd?: string;
             currency?: string;
+            title?: string;
+            networkLabel?: string;
+            isOnchain?: boolean;
+            note?: string;
         };
     };
 }
@@ -53,6 +70,10 @@ export default function ArkSendSuccessScreen({ route }: Props) {
     const value = String(route?.params?.value ?? '0');
     const valueUsd = route?.params?.valueUsd ?? '0.00';
     const currency = route?.params?.currency ?? 'USD';
+    const title = route?.params?.title ?? 'Payment Sent';
+    const networkLabel = route?.params?.networkLabel ?? 'Lightning Network';
+    const isOnchain = route?.params?.isOnchain === true;
+    const note = route?.params?.note;
 
     const [response, setResponse] = useState(false);
     const fadeInOpacity = useSharedValue(0);
@@ -85,7 +106,7 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                     {response && (
                         <Animated.View style={animatedStyle}>
                             <Text h1 semibold center>
-                                Payment Sent
+                                {title}
                             </Text>
                             <Text semibold center style={styles.sats}>
                                 {value} sats
@@ -94,6 +115,20 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                                 {getStrikeCurrency(currency)}
                                 {valueUsd}
                             </Text>
+                            {!!note && (
+                                <Text
+                                    center
+                                    style={{
+                                        fontSize: 13,
+                                        color: '#BBB',
+                                        lineHeight: 18,
+                                        marginTop: 10,
+                                        paddingHorizontal: 24,
+                                    }}
+                                >
+                                    {note}
+                                </Text>
+                            )}
                         </Animated.View>
                     )}
                 </View>
@@ -113,27 +148,56 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                             Transaction screen note). White ark gradient stands
                             in for Strike's pink; the dark inner circles keep
                             the bolt readable. */}
-                        <GradientCard
-                            style={styles.gradient}
-                            linearStyle={styles.gradient}
-                            colors_={[colors.ark.gradient1, colors.ark.gradient2]}
-                        >
-                            <View style={styles.inner}>
-                                <GradientCard
-                                    style={styles.gradientInner}
-                                    linearStyle={styles.gradientInner}
-                                    colors_={[colors.ark.gradient1, colors.ark.gradient2]}
-                                >
-                                    <View style={styles.inside}>
-                                        <Image
-                                            source={Electrik}
-                                            style={styles.image}
-                                            resizeMode="contain"
-                                        />
-                                    </View>
-                                </GradientCard>
-                            </View>
-                        </GradientCard>
+                        {isOnchain ? (
+                            // The same Bitcoin visual the on-chain broadcast
+                            // screen uses. A Lightning bolt over an on-chain
+                            // deposit is not a styling detail: it tells the
+                            // user the wrong thing about what just happened
+                            // and about how soon they can use it.
+                            <ImageBackground
+                                source={BitcoinTower}
+                                style={styles.image}
+                                resizeMode="contain"
+                            >
+                                <Image
+                                    source={Bitcoin}
+                                    // Matches TransactionBroadCast's `bitcoin`
+                                    // style, which the shared Transaction
+                                    // stylesheet does not carry.
+                                    style={{
+                                        width: 60,
+                                        height: 60,
+                                        marginTop: 60,
+                                        justifyContent: 'center',
+                                        alignSelf: 'center',
+                                        position: 'absolute',
+                                    }}
+                                    resizeMode="contain"
+                                />
+                            </ImageBackground>
+                        ) : (
+                            <GradientCard
+                                style={styles.gradient}
+                                linearStyle={styles.gradient}
+                                colors_={[colors.ark.gradient1, colors.ark.gradient2]}
+                            >
+                                <View style={styles.inner}>
+                                    <GradientCard
+                                        style={styles.gradientInner}
+                                        linearStyle={styles.gradientInner}
+                                        colors_={[colors.ark.gradient1, colors.ark.gradient2]}
+                                    >
+                                        <View style={styles.inside}>
+                                            <Image
+                                                source={Electrik}
+                                                style={styles.image}
+                                                resizeMode="contain"
+                                            />
+                                        </View>
+                                    </GradientCard>
+                                </View>
+                            </GradientCard>
+                        )}
                     </View>
                 )}
 
@@ -142,7 +206,7 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                 {response && (
                     <>
                         <Text semibold center style={styles.text}>
-                            Lightning Network
+                            {networkLabel}
                         </Text>
                         {/* White button → black label for contrast (the
                             white-on-white trap the rest of the Ark UI hit). */}


### PR DESCRIPTION
Stacked on #183.

## What the user sees

The Fund exit fees screen showed one line, `From: CoinOS`, then a swipe control. The amount being sent, the network fee, the total leaving the wallet and the destination address were all absent, on a screen whose entire job is to state those numbers before the user swipes to move money.

Nothing errored and nothing logged. The numbers simply were not on screen.

## Cause

`GradientCard` hard-codes `height: 60` on **both** its `TouchableOpacity` wrapper and its `LinearGradient`:

```ts
linearGradient: { borderRadius: 20, height: 60 },
shadow:         { ..., height: 60, borderRadius: 20 },
```

It is the single-row input pill. Every other caller overrides that height through `linearStyle`, e.g. `ArkWithdrawReviewScreen` passes `linearStyle={reviewStyles.heigth}`. This screen passed only `style={{ marginTop: 12 }}`, which merges into the wrapper but leaves the gradient at 60px, so the card clipped every row below the first.

## Fix

A details panel is not a pill. Replaced with the plain bordered `View` the sibling Ark review screens already use, which grows with its content and cannot silently truncate.

## Notes

Found on device while topping up a real exit-fee reserve, not by review.

The 20 `react-native/no-inline-styles` lint errors on this file are unchanged by this commit: 20 before, 20 after. They came with the file.

Worth a separate look: `GradientCard` will do this to any caller that forgets `linearStyle`, and the failure mode is invisible truncation rather than an error. Making the height a default that content can grow past, rather than a hard cap, would remove the trap. Not done here because it touches every existing caller.