### PR TITLE
Give the chain-source fallback somewhere to fall back to

### DIFF
--- a/src/services/ark/config.ts
+++ b/src/services/ark/config.ts
@@ -1,5 +1,7 @@
 import { Config, Network } from '@secondts/bark-react-native';
 
+import { ESPLORA_FALLBACK_URLS } from './esploraProviders';
+
 /**
  * Master kill-switch for the Ark feature.
  *
@@ -148,7 +150,12 @@ export const ESPLORA_URL = 'https://blockstream.info/api';
  * targets the same datadir (BarkError.Database or worse). A hang behaves
  * exactly as it did before this list existed.
  */
-export const ESPLORA_URLS = [ESPLORA_URL, 'https://mempool.space/api'];
+/**
+ * Rotation list for the open-with-retry loop. The list, the attempt count and
+ * the invariant tying them together live in ./esploraProviders, which is pure
+ * and therefore unit-testable; config.ts cannot be imported under jest.
+ */
+export const ESPLORA_URLS: string[] = [...ESPLORA_FALLBACK_URLS];
 
 export function createArkConfig(overrides?: Partial<Parameters<typeof Config.create>[0]>) {
     return Config.create({

--- a/src/services/ark/esploraProviders.ts
+++ b/src/services/ark/esploraProviders.ts
@@ -1,0 +1,62 @@
+/**
+ * The chain sources the wallet falls back through, and the invariant that
+ * makes the list actually work.
+ *
+ * Pure and import-free so it stays unit-testable without the native bark
+ * module, matching exitTriage.ts, refreshBatch.ts and the other decision
+ * helpers. It lived in config.ts, which cannot be imported under jest because
+ * config.ts pulls in the SDK, so the list's invariants were unenforceable.
+ *
+ * WHY THIS MATTERS
+ *
+ * The list held two entries. On 2026-08-21 one of them was down for an entire
+ * session while the other rate-limited the device, so there was nowhere to
+ * rotate to: five open attempts alternating between a 429 and a dead host,
+ * for hours, and the wallet simply would not open. A unilateral exit that was
+ * already in flight stalled with it, because the drive cannot advance an exit
+ * tree without a chain source, and the UI showed nothing wrong the whole time.
+ *
+ * Two entries is not redundancy. It is a single point of failure with a spare
+ * that has to be perfect.
+ */
+
+/**
+ * Providers in rotation order.
+ *
+ * Ordered by OPERATOR INDEPENDENCE rather than preference. The first two are
+ * what we already relied on; the community mirror sits between the two
+ * mempool.space entries so one operator's outage cannot take out consecutive
+ * attempts, which is precisely the failure that happened. The regional
+ * mempool.space node is last because it stayed up while the apex did not,
+ * making it the useful backstop rather than a first choice.
+ *
+ * Verified 2026-08-21: each answered `/blocks/tip/hash` with a valid 64-char
+ * hash and served `/fee-estimates`.
+ *
+ * PRIVACY: rotation only happens once the provider before it has FAILED, and
+ * the wallet still opens against the first entry alone. A healthy wallet talks
+ * to exactly one provider, as it always did. These extra entries change who
+ * sees an address only in the case where the alternative is not working at all.
+ */
+export const ESPLORA_FALLBACK_URLS = [
+    'https://blockstream.info/api',
+    'https://mempool.space/api',
+    'https://mempool.emzy.de/api',
+    'https://mempool.va1.mempool.space/api',
+] as const;
+
+/**
+ * Attempts the open-with-retry loop makes.
+ *
+ * MUST be >= the provider count, or the last entries are never reached and
+ * adding a provider silently does nothing. That is the trap this module exists
+ * to make visible: the old list had no such check, so its second entry being
+ * dead was invisible until it mattered.
+ */
+export const ESPLORA_OPEN_ATTEMPTS = 5;
+
+/** Operator for a provider URL, used to keep same-operator entries apart. */
+export function esploraOperator(url: string): string {
+    const host = url.replace(/^https?:\/\//, '').split('/')[0];
+    return host.split('.').slice(-2).join('.');
+}

--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -2,6 +2,7 @@ import RNFS from 'react-native-fs';
 import * as Keychain from 'react-native-keychain';
 
 import { ESPLORA_URLS } from './config';
+import { ESPLORA_OPEN_ATTEMPTS } from './esploraProviders';
 import { ARK_DATADIR } from './datadir';
 import { cacheArkMnemonicForReopen, getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
 
@@ -17,7 +18,9 @@ const KEYCHAIN_SERVICE = 'ark-seed-phrase';
  * few times before giving up. Only transient connection errors are retried; a
  * genuine seed/datadir mismatch fails fast.
  */
-const OPEN_ATTEMPTS = 5;
+// Kept in ./esploraProviders alongside the list it has to outnumber: a count
+// below the provider count silently makes the last entries unreachable.
+const OPEN_ATTEMPTS = ESPLORA_OPEN_ATTEMPTS;
 const OPEN_RETRY_DELAY_MS = 6000;
 
 // Guards against two opens running against the same datadir at once — the

--- a/tests/unit/esploraProviders.test.ts
+++ b/tests/unit/esploraProviders.test.ts
@@ -1,0 +1,54 @@
+import {
+  ESPLORA_FALLBACK_URLS,
+  ESPLORA_OPEN_ATTEMPTS,
+  esploraOperator,
+} from '../../src/services/ark/esploraProviders';
+
+describe('esplora fallback list', () => {
+  it('has more than one real alternative', () => {
+    // The list held two entries on 2026-08-21. One was down all session and the
+    // other rate-limited the device, so there was nowhere to rotate to and the
+    // wallet could not open for hours. Two is not redundancy.
+    expect(ESPLORA_FALLBACK_URLS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('is fully reachable within the attempt budget', () => {
+    // The trap this module exists to make visible: a provider added past the
+    // attempt count is never tried, and nothing anywhere would have said so.
+    expect(ESPLORA_OPEN_ATTEMPTS).toBeGreaterThanOrEqual(ESPLORA_FALLBACK_URLS.length);
+  });
+
+  it('never places two providers from one operator back to back', () => {
+    // A single operator's outage must not be able to burn consecutive
+    // attempts. mempool.space's apex was down while its regional node was up,
+    // so the two must not sit next to each other.
+    const ops = ESPLORA_FALLBACK_URLS.map(esploraOperator);
+    for (let i = 1; i < ops.length; i++) {
+      expect(ops[i]).not.toBe(ops[i - 1]);
+    }
+  });
+
+  it('has no duplicates', () => {
+    expect(new Set(ESPLORA_FALLBACK_URLS).size).toBe(ESPLORA_FALLBACK_URLS.length);
+  });
+
+  it('is https only, with no trailing slash', () => {
+    for (const u of ESPLORA_FALLBACK_URLS) {
+      expect(u.startsWith('https://')).toBe(true);
+      expect(u.endsWith('/')).toBe(false);
+    }
+  });
+
+  it('keeps the previously configured primary first', () => {
+    // Changing the primary changes who sees every healthy wallet's addresses.
+    // That is a deliberate decision, not something to drift into by reordering.
+    expect(ESPLORA_FALLBACK_URLS[0]).toBe('https://blockstream.info/api');
+  });
+
+  it('reads the operator from the registrable domain', () => {
+    expect(esploraOperator('https://mempool.va1.mempool.space/api')).toBe('mempool.space');
+    expect(esploraOperator('https://mempool.space/api')).toBe('mempool.space');
+    expect(esploraOperator('https://blockstream.info/api')).toBe('blockstream.info');
+    expect(esploraOperator('https://mempool.emzy.de/api')).toBe('emzy.de');
+  });
+});


### PR DESCRIPTION
## What happened

The rotation list held two entries:

```ts
export const ESPLORA_URLS = [ESPLORA_URL, 'https://mempool.space/api'];
```

On 2026-08-21 one was down for an entire session while the other rate-limited the device. With nowhere to rotate, five open attempts alternated between a 429 and a dead host, repeatedly, for hours:

```
[Ark restore] open attempt 1/5 via https://blockstream.info/api failed
  Failed to create chain source: bad response from server (not a blockhash)
```

Measured from the dev machine at the same moment:

| | |
|---|---|
| blockstream.info | HTTP 200, but 429s the device's burst |
| mempool.space | **HTTP 000, nothing, all session** |

The rotation code was correct. It had nowhere to go.

## Why it is worse than a failed open

A **unilateral exit already in flight stalled with it.** The drive cannot advance an exit tree without a chain source, so seven capsules sat untouched while bark's view of the tip fell 14 blocks behind, and the UI showed nothing wrong the whole time.

Two entries is not redundancy. It is a single point of failure with a spare that has to be perfect.

## The change

Two more providers, both verified answering `/blocks/tip/hash` with a valid 64-char hash and serving `/fee-estimates`.

Ordered by **operator independence** rather than preference. The community mirror sits between the two mempool.space entries so a single operator's outage cannot burn consecutive attempts, which is exactly the failure observed. The regional mempool.space node is last because it stayed up while the apex did not, making it a backstop rather than a first choice.

## Why it moved to its own module

The invariant tying the list to the attempt count was unenforceable where it lived: **a provider added past `OPEN_ATTEMPTS` is never tried, and nothing anywhere says so.** `config.ts` cannot be imported under jest because it pulls in the SDK, so none of this was testable.

`esploraProviders.ts` has no imports at all, matching `exitTriage.ts`, `refreshBatch.ts` and the other decision helpers, and now carries the list, the attempt count and the operator helper together.

## Privacy

Unchanged for a working wallet. Rotation only happens once the provider before it has **failed**, and the wallet still opens against the first entry alone, so a healthy wallet talks to exactly one provider as it always did. The extra entries change who sees an address only when the alternative is not working at all.

The primary is deliberately pinned by a test, since changing it would change who sees every healthy wallet's addresses and that should be a decision rather than a reordering.

## Testing

7 unit tests. Mutation-checked:

| Restored behaviour | Tests failing |
|---|---|
| the old two-entry list | 1 |
| attempts below the provider count | 1 |
| same-operator entries adjacent | 1 |
| primary silently reordered | 1 |

Full unit suite 258 passed. `tsc` unchanged against the `main` baseline: 405 errors, zero differing normalized lines. Lint unchanged per file.

## Still open

This does not fix the misleading error. A 429 still surfaces as `not a blockhash ... Esplora client possibly misconfigured`, which points the user at their wallet rather than at a quota. That is item 1 of #194.