### PR TITLE
fix(strike): open the purchase screen when a capsule is affordable

### DIFF
--- a/src/components/StrikeView/index.tsx
+++ b/src/components/StrikeView/index.tsx
@@ -162,7 +162,13 @@ function StrikeView({ showLogo = false, isShowButtons = false,
         // SimpleToast.show('Amount is exceeded', SimpleToast.SHORT);
         return
       }
-      dispatchNavigate('SendScreen', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatType: "BUY" });
+      // Affordable capsule: go to the Strike purchase screen with the chosen
+      // size prefilled. This previously routed to the generic Send flow, so
+      // picking a capsule the user COULD afford opened a bitcoin send instead
+      // of a purchase, while picking one they could NOT afford (the branch
+      // above) correctly opened the purchase screen. `fiatTotal` is passed so
+      // the MAX button still has the balance to work from.
+      dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[1]?.available), fiatType: "BUY" });
     }
 
     const sellClickHandler = () => {
@@ -176,12 +182,16 @@ function StrikeView({ showLogo = false, isShowButtons = false,
             SimpleToast.show('Amount cannot be 0', SimpleToast.SHORT);
             return
         }
-        if(Number(strikeUser?.[0]?.available) < dollarStrikeText){
+        // `available` is BTC, `dollarStrikeText` is sats, so this compared
+        // across units and was true for every realistic balance. That sent
+        // SELL down the insufficient-funds branch every time, which hid the
+        // same mis-route the BUY path had.
+        if(Number(strikeUser?.[0]?.available) * SATS < dollarStrikeText){
             // SimpleToast.show('Amount is exceeded', SimpleToast.SHORT);
             dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: 0, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL" });    
             return
         }
-        dispatchNavigate('SendScreen', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatType: "SELL" });    
+        dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL" });    
     }
 
     const handleStrikeLogout = async () => {


### PR DESCRIPTION
## What

In the Strike fiat account, the capsule vending machine's **BUY** opened the generic bitcoin Send screen instead of the Strike purchase screen, whenever the user could afford the selected capsule.

## Repro

Fiat balance €102.87, select the 10K sats capsule (€6.70), tap BUY. Lands on "Send Bitcoin" with 10000 prefilled. Select a capsule costing more than the balance and it lands correctly on "Buy Bitcoin".

## Root cause

`buyClickHandler` has the two destinations inverted:

```js
if (Number(strikeUser?.[1]?.available) < amt) {
    dispatchNavigate('BuyBitcoin', ...)   // cannot afford -> purchase screen (correct)
    return
}
dispatchNavigate('SendScreen', ...)       // CAN afford    -> generic Send flow (wrong)
```

`amt` is the fiat cost of the capsule, `10000 * 66979.95 * btc(1)` = €6.70. With €102.87 available the guard is false, so it falls through to `SendScreen`, which resolves to `./Send`, the generic bitcoin send. The insufficient-funds guard firing first is the only reason the purchase screen was ever reached, which is why the bug looks inverted from the user's side.

## A second defect this was hiding

`sellClickHandler` carried the identical mis-route plus a unit mismatch:

```js
if (Number(strikeUser?.[0]?.available) < dollarStrikeText)   // BTC compared against sats
```

`available` is BTC, `dollarStrikeText` is sats, so the check was true for every realistic balance and SELL always took the insufficient-funds branch. That made SELL look correct by accident. The `console.log` two lines above already does `available * SATS`, so the conversion was known and simply missing from the comparison.

Sequencing matters here: **fixing the unit comparison on its own would have newly broken SELL**, exposing the same mis-route BUY had. Both are corrected together for that reason.

## The fix

Both paths now open the purchase screen with the chosen capsule size prefilled via `fiatAmount`, and pass the balance as `fiatTotal` so MAX still has something to work from. `BuyBitcoin` already supports the prefill, and `handleSendNext` reads the entered `sats`/`usd` rather than `fiatTotal`, so passing both is safe: only the MAX button consumes `fiatTotal`.

## Verification

- `tsc`: 405 errors, **zero differing lines** against a baseline regenerated from the unmodified file
- `npx jest -b -i tests/unit --rootDir .`: 36 suites, 251 passed, 1 skipped

**Not yet verified on device.** A mainnet unilateral-exit test is currently running against a deliberately dead ASP, and the device build serves JS from a tree holding uncommitted endpoint overrides for it. Checking this branch out there would point the wallet at a live ASP mid-exit. Device verification should happen once that run finishes.
