### PR TITLE
style(strike): square the capsule's off-diagonal corners on iOS

### DIFF
--- a/src/components/StrikeView/styles.ts
+++ b/src/components/StrikeView/styles.ts
@@ -1,5 +1,14 @@
 import { colors, widths } from "@Cypher/style-guide";
-import { ImageStyle, StyleSheet, TextStyle, ViewStyle } from "react-native";
+import { ImageStyle, Platform, StyleSheet, TextStyle, ViewStyle } from "react-native";
+
+// The UTXO capsule squares off its top-right and bottom-left corners on iOS,
+// keeping the curve only on the top-left/bottom-right diagonal. Android keeps
+// the uniform radius: `widths` is `Dimensions.get('screen').width`, which on
+// Android reports the full display rather than the usable window, so the card
+// resolves wider there and the capsule sits clear of the card's corner. On iOS
+// the slot is narrower and the capsule sits hard against it, where the
+// asymmetric radius reads as deliberate rather than cramped.
+const IS_IOS = Platform.OS === 'ios';
 
 interface Style {
     container: ViewStyle;
@@ -114,10 +123,18 @@ export default StyleSheet.create<Style>({
         // so the BUY button below stays put.
         transform: [{ translateX: -30 }, { translateY: -30 }],
         justifyContent: 'center',
-        borderRadius: 20,
+        borderTopLeftRadius: 20,
+        borderTopRightRadius: IS_IOS ? 0 : 20,
+        borderBottomLeftRadius: IS_IOS ? 0 : 20,
+        borderBottomRightRadius: 20,
     },
     fiatBalanceBox3: {
-        borderRadius: 18,
+        // Mirrors fiatBalanceBox2 one step in, so the inner fill follows the
+        // outer shape instead of relying on the parent's overflow clip.
+        borderTopLeftRadius: 18,
+        borderTopRightRadius: IS_IOS ? 0 : 18,
+        borderBottomLeftRadius: IS_IOS ? 0 : 18,
+        borderBottomRightRadius: 18,
         width: 115,
         height: 88,
     },


### PR DESCRIPTION
## What

On iOS the UTXO capsule in the fiat balance card keeps its curve only on the **top-left / bottom-right** diagonal, and squares off the **top-right** and **bottom-left** corners.

Android is unchanged and keeps the uniform 20pt radius.

## Why iOS only

`widths` is `Dimensions.get('screen').width`. On iOS that matches the usable window. On Android `screen` reports the full display including the system bars, so it resolves larger and the card comes out wider.

The practical effect, on a 414pt iPhone:

| element | width |
|---|---|
| `LinearBorderView.gradientBackground` | `widths - 118` = 296 |
| each `sideContainer` (flex 1) | **148** |
| capsule footprint (`marginLeft 45 + width 121 + marginRight 20`) | **186** |

The slot can honour at most `148 - 121 - 20` = **7pt** of left margin against the 45 requested, and `transform: translateX(-30)` then pulls it 30pt further, so on iOS the capsule sits hard against the card's corner. Android has the extra width and sits clear of it.

Against that corner, the asymmetric radius reads as a deliberate shape rather than a rounded box that has been crowded.

## Scope

**Cosmetic only.** This does not change the capsule's position and does not address the 38pt overflow above, which is a separate layout question (the 50/50 `flex: 1` split gives a fixed-width capsule less room than it needs, and the margin/`transform` pairs in this file have been tuned against each other across several rounds). Worth doing properly, but not in this change.

Per-corner radii are used rather than a `Platform.select` spread so the style stays a plain typed `ViewStyle`.

## Verification

- `tsc`: 405 errors, **zero differing lines** against a baseline regenerated from the unmodified tree
- `npx jest -b -i tests/unit --rootDir .`: 36 suites, 251 passed, 1 skipped

**Not yet verified on device.** A mainnet unilateral-exit test is running against a deliberately dead ASP and the device build serves JS from a tree holding uncommitted endpoint overrides for it, so checking this branch out there would point the wallet at a live ASP mid-exit. Needs an eye on the simulator or device once that finishes.
