### PR TITLE
fix(ark): warn that a Bark address is not a passive receive method

### DIFF
--- a/src/screens/Ark/ArkReceiveScreen/index.tsx
+++ b/src/screens/Ark/ArkReceiveScreen/index.tsx
@@ -150,16 +150,6 @@ export default function ArkReceiveScreen() {
                                         Instant VTXO capsule transfer from another Bark user.
                                         No fees, no confirmations.
                                     </Text>
-                                    {/* A capsule that lands here is short-lived, and the
-                                        expiry reminders are LOCAL alarms scheduled by the
-                                        foreground sync loop and the arkoor receive hook.
-                                        Nothing schedules them while the app is closed, so a
-                                        payment that arrives to a shared address on a closed
-                                        app has no reminder attached to it at all. Same amber
-                                        treatment as the on-chain minimum below. */}
-                                    <Text style={{ color: '#FFD54F', fontSize: 12, marginTop: 6, fontWeight: '600' }}>
-                                        Open the app soon after you're paid here. Capsules arriving at this address are short-lived, and reminders can only be set while the app is open.
-                                    </Text>
                                 </View>
                                 <Image source={LeftArrow} style={styles.image} resizeMode="contain" />
                             </View>

--- a/src/screens/Ark/ArkReceiveScreen/index.tsx
+++ b/src/screens/Ark/ArkReceiveScreen/index.tsx
@@ -150,6 +150,16 @@ export default function ArkReceiveScreen() {
                                         Instant VTXO capsule transfer from another Bark user.
                                         No fees, no confirmations.
                                     </Text>
+                                    {/* A capsule that lands here is short-lived, and the
+                                        expiry reminders are LOCAL alarms scheduled by the
+                                        foreground sync loop and the arkoor receive hook.
+                                        Nothing schedules them while the app is closed, so a
+                                        payment that arrives to a shared address on a closed
+                                        app has no reminder attached to it at all. Same amber
+                                        treatment as the on-chain minimum below. */}
+                                    <Text style={{ color: '#FFD54F', fontSize: 12, marginTop: 6, fontWeight: '600' }}>
+                                        Open the app soon after you're paid here. Capsules arriving at this address are short-lived, and reminders can only be set while the app is open.
+                                    </Text>
                                 </View>
                                 <Image source={LeftArrow} style={styles.image} resizeMode="contain" />
                             </View>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -958,6 +958,16 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                     <Text semibold style={styles.bitcoinAddressText}>
                       Receive 0% fee payments from another Bark user
                     </Text>
+                    {/* A capsule arriving here is short-lived, and the expiry
+                        reminders are LOCAL alarms scheduled by the foreground
+                        sync loop and the arkoor receive hook. Nothing schedules
+                        them while the app is closed, so a payment made to a
+                        shared Bark address on a closed app has no reminder
+                        attached to it at all. Same amber treatment as the tip at
+                        the top of this sheet. */}
+                    <Text style={{ color: '#FFD54F', fontSize: 12, marginTop: 8, fontWeight: '600', textAlign: 'center' }}>
+                      Open the app soon after you're paid here. Capsules arriving at this address are short-lived, and reminders can only be set while the app is open.
+                    </Text>
                   </>
                 )}
               </View>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -631,6 +631,22 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               </Text>
             )}
 
+            {/* Bark-address specific, so it is gated to that tab: "this address"
+                only means something while the Bark address is on screen.
+                The point is that expiry reminders are LOCAL alarms scheduled by
+                the app when it SEES the capsule, so a payment made to a shared
+                address while the app is closed has no reminder attached to it at
+                all. Sits with the tip above rather than under the QR so the
+                advice reads as one block. COPY: Bam finalizes. */}
+            {selectedItem === 5 && tab === 2 && (
+              <Text
+                center
+                style={{ marginHorizontal: 24, marginTop: 6, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
+              >
+                To receive 700-sat or above capsule from another Bark user. You need to be present with the app being open when you receive to this address.
+              </Text>
+            )}
+
             {/* Tabs */}
             {tabs.length > 0 && (
               <CustomTabView
@@ -957,16 +973,6 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                     </View>
                     <Text semibold style={styles.bitcoinAddressText}>
                       Receive 0% fee payments from another Bark user
-                    </Text>
-                    {/* A capsule arriving here is short-lived, and the expiry
-                        reminders are LOCAL alarms scheduled by the foreground
-                        sync loop and the arkoor receive hook. Nothing schedules
-                        them while the app is closed, so a payment made to a
-                        shared Bark address on a closed app has no reminder
-                        attached to it at all. Same amber treatment as the tip at
-                        the top of this sheet. */}
-                    <Text style={{ color: '#FFD54F', fontSize: 12, marginTop: 8, fontWeight: '600', textAlign: 'center' }}>
-                      Open the app soon after you're paid here. Capsules arriving at this address are short-lived, and reminders can only be set while the app is open.
                     </Text>
                   </>
                 )}

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -620,17 +620,6 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               </View>
             </View>
 
-            {/* Bark receive advice: small receives can leave sub-refreshable
-                dust that expires; nudge larger amounts. COPY: Bam finalizes. */}
-            {selectedItem === 5 && (
-              <Text
-                center
-                style={{ marginHorizontal: 24, marginTop: 8, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
-              >
-                Tip: receive above 700 sats at a time, via a Lightning invoice or your Bark address, so they stay refreshable and don't expire as dust.
-              </Text>
-            )}
-
             {/* Bark-address specific, so it is gated to that tab: "this address"
                 only means something while the Bark address is on screen.
                 The point is that expiry reminders are LOCAL alarms scheduled by
@@ -641,9 +630,9 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
             {selectedItem === 5 && tab === 2 && (
               <Text
                 center
-                style={{ marginHorizontal: 24, marginTop: 6, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
+                style={{ marginHorizontal: 24, marginTop: 8, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
               >
-                To receive 700-sat or above capsule from another Bark user. You need to be present with the app being open when you receive to this address.
+                To receive 700-sat or above capsule from another Bark user. Need to be present with the app being open when you receive to this address.
               </Text>
             )}
 


### PR DESCRIPTION
## What

Adds a caveat to the **Bark address** option on the receive screen: it is not a passive, leave-it-and-forget-it way to be paid.

Uses the same amber treatment already on this screen for the on-chain minimum, so no new pattern.

## Why

A capsule arriving at a Bark address is short-lived, and the expiry reminders are **local OS alarms**. Every call site that schedules them is in the foreground:

```
useArkSync.ts:985                     (sync loop)
useArkoorReceivePrompt.ts:183/416/443 (arkoor receive hook)
```

So the notification that would tell the user to open the app can only be created **by opening the app**. If someone is paid at a shared Bark address while the app is closed, no alarm was ever scheduled and nothing in the system can reach them.

Nothing external can cover it either: the push server watches on-chain addresses and Lightning, while an arkoor VTXO is off-chain and known only to the ASP.

The other two receive methods are materially safer and are left alone:

- **Lightning**: the invoice is generated in-app and paid seconds later, so the user is almost always foregrounded and the receive hook catches it.
- **On-chain**: board outputs carry roughly 28 days, so there is ample runway to open the app for unrelated reasons, and users are already advised not to leave the app unopened for long.

## On the wording

Draft, expected to be rewritten.

Deliberately **no number**. The received-capsule TTL is set by the server, the spec only has it as "roughly 3 days" from a single measurement, and unlike `minBoardSats` there is no live value to read at address-display time because the VTXO does not exist yet. A wrong-but-specific figure would be worse than a vague-but-true one. If a number is wanted, the received-capsule TTL should be measured properly first.

## Verification

- `tsc`: 405 errors, zero differing lines against a baseline regenerated from the unmodified tree
- `npx jest -b -i tests/unit --rootDir .`: 36 suites, 251 passed, 1 skipped

Copy-only, no logic touched. Not yet verified on device: a mainnet unilateral-exit test is running and the device build serves JS from a tree holding uncommitted endpoint overrides for it.
