### PR TITLE
Land 23 device-tested fixes as one bundle: exit, refresh, vault, chain source

### DIFF
--- a/Navigation.js
+++ b/Navigation.js
@@ -112,6 +112,7 @@ import ArkSendScreen from '@Cypher/screens/Ark/ArkSendScreen';
 import ArkSendReviewScreen from '@Cypher/screens/Ark/ArkSendReviewScreen';
 import ArkSendSuccessScreen from '@Cypher/screens/Ark/ArkSendSuccessScreen';
 import ArkWithdrawReviewScreen from '@Cypher/screens/Ark/ArkWithdrawReviewScreen';
+import ArkExitFundingConfirmScreen from '@Cypher/screens/Ark/ArkExitFundingConfirmScreen';
 import ArkCapsulesInfoScreen from '@Cypher/screens/Ark/ArkCapsulesInfoScreen';
 import ArkStuckCapsuleScreen from '@Cypher/screens/Ark/ArkStuckCapsuleScreen';
 
@@ -229,6 +230,7 @@ const WalletsRoot = () => {
       <WalletsStack.Screen name="ArkSendReviewScreen" component={ArkSendReviewScreen} options={{ headerShown: false, gestureEnabled: true }} />
       <WalletsStack.Screen name="ArkSendSuccessScreen" component={ArkSendSuccessScreen} options={{ headerShown: false, gestureEnabled: false }} />
       <WalletsStack.Screen name="ArkWithdrawReviewScreen" component={ArkWithdrawReviewScreen} options={{ headerShown: false, gestureEnabled: true }} />
+      <WalletsStack.Screen name="ArkExitFundingConfirmScreen" component={ArkExitFundingConfirmScreen} options={{ headerShown: false, gestureEnabled: true }} />
       <WalletsStack.Screen name="ForgotCoinOSScreen" component={ForgetPassword} options={{ headerShown: false }} />
       <WalletsStack.Screen name="ChangeUsername" component={ChangeUsername} options={{ headerShown: false }} />
       <WalletsStack.Screen name="LoginCoinOSScreen" component={LoginCoinOSScreen} options={{ headerShown: false }} />

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ npm start
 
 * ✅ Bark SDK upgrade (bark 0.6.1): capsules stay spendable while refreshing, dust consolidation, safer exit
 * ⏳ Revive the e2e test suite on RN 0.77
+* ⏳ **Bring your own chain source**: point the Bark Vault at your own esplora endpoint (Umbrel, Start9, self-hosted Electrs) instead of a public block explorer, so your addresses never leave your node. Bitcoin Core RPC to follow. Changing the chain source touches refresh, unilateral exit, backup and recovery, so it ships only after all four are re-tested end to end.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Swap between rails in-app: Lightning ↔ Bark, top-up vaults from Lightning, wit
 ## ⛵ Bark Vault — non-custodial Lightning (Ark protocol)
 
 Read full user guide: https://cypherbox.io/how-to-use-your-bark-vault/
-Your sats live in **lightning capsules (VTXOs)** on Bitcoin mainnet via the [Ark protocol](https://ark-protocol.org) and [Second's Bark SDK](https://gitlab.com/ark-bitcoin/bark). Self-custodial: you can exit to the chain without the server's permission (not completed ⏳).
+Your sats live in **lightning capsules (VTXOs)** on Bitcoin mainnet via the [Ark protocol](https://ark-protocol.org) and [Second's Bark SDK](https://gitlab.com/ark-bitcoin/bark). Self-custodial: you can exit to the chain without the server's permission.
 
 
 * Send & receive over Lightning, receive on Ark addresses, board from on-chain

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
       "node_modules/(?!((jest-)?react-native(-.*)?|@react-native(-community)?)/)"
     ],
     "moduleNameMapper": {
-      "\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/tests/__mocks__/imageMock.js"
+      "\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/tests/__mocks__/imageMock.js",
+      "^@Cypher/(.*)$": "<rootDir>/src/$1"
     },
     "setupFiles": [
       "./node_modules/react-native-gesture-handler/jestSetup.js",

--- a/screen/wallets/addresses.js
+++ b/screen/wallets/addresses.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useContext, useRef, useEffect, useLayoutEffect } from 'react';
-import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, FlatList, StyleSheet, Text, View } from 'react-native';
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
 import Privacy from '../../blue_modules/Privacy';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
@@ -92,15 +92,24 @@ const WalletAddresses = () => {
 
   const addressList = useRef();
 
+  // `wallet` can legitimately come back undefined, and every line below used to
+  // dereference it unconditionally. This screen is reached by walletID from six
+  // different flows, and that pointer can outlive the wallet it names: after a
+  // reset, a re-import, or any of the pointer drift the recovery flow already
+  // heals for. When it did, `wallet.getPreferredBalanceUnit()` threw during
+  // render, and a render-time throw has no error boundary above it, so release
+  // builds terminated the process outright. Reported from the field as tapping
+  // the address closing the app and forcing a fresh login.
   const wallet = wallets.find(w => w.getID() === walletID);
 
-  const balanceUnit = wallet.getPreferredBalanceUnit();
+  const balanceUnit = wallet ? wallet.getPreferredBalanceUnit() : undefined;
 
-  const isWatchOnly = wallet.type === WatchOnlyWallet.type;
+  const isWatchOnly = !!wallet && wallet.type === WatchOnlyWallet.type;
 
   const walletInstance = isWatchOnly ? wallet._hdWalletInstance : wallet;
 
-  const allowSignVerifyMessage = 'allowSignVerifyMessage' in wallet && wallet.allowSignVerifyMessage();
+  const allowSignVerifyMessage =
+    !!wallet && 'allowSignVerifyMessage' in wallet && wallet.allowSignVerifyMessage();
 
   const { colors } = useTheme();
 
@@ -134,6 +143,12 @@ const WalletAddresses = () => {
   }, [setOptions]);
 
   const getAddresses = () => {
+    // Second crash site for the same missing wallet: this runs from
+    // useFocusEffect, so the throw landed in an effect rather than in render,
+    // but it was just as fatal. Bail quietly and let the empty state below
+    // explain itself.
+    if (!walletInstance) return;
+
     const newAddresses = [];
 
     for (let index = 0; index <= walletInstance.next_free_change_address_index; index++) {
@@ -232,6 +247,24 @@ const WalletAddresses = () => {
     return <AddressItem {...item} balanceUnit={balanceUnit} walletID={walletID} allowSignVerifyMessage={allowSignVerifyMessage} isTouchable={isTouchable} navigateToReceive={navigateToReceive} />;
   };
 
+  // Placed after every hook above, so hook order stays identical on the render
+  // where the wallet is found and the one where it is not.
+  //
+  // Without this the list would sit on a permanent spinner, since its empty
+  // state renders an ActivityIndicator and no addresses will ever arrive. Say
+  // what happened instead: the screen is unusable either way, but a dead end
+  // the user can back out of beats one that looks like it is still loading.
+  if (!wallet) {
+    return (
+      <View style={[styles.root, stylesHook.root, styles.missingWallet]}>
+        <Text style={{ color: colors.foregroundColor, textAlign: 'center' }}>
+          This vault is no longer available on this device. Go back and open it
+          again from the home screen.
+        </Text>
+      </View>
+    );
+  }
+
   return (
     <View style={[styles.root, stylesHook.root]}>
       <FlatList
@@ -260,5 +293,10 @@ export default WalletAddresses;
 const styles = StyleSheet.create({
   root: {
     flex: 1,
+  },
+  missingWallet: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
   },
 });

--- a/src/api/coinOSApis.ts
+++ b/src/api/coinOSApis.ts
@@ -1,3 +1,7 @@
+import {
+  isNetworkShapedFailure,
+  markWithdrawIndeterminate,
+} from '@Cypher/services/coinos/withdrawGuard';
 import useAuthStore from '@Cypher/stores/authStore';
 import SimpleToast from "react-native-simple-toast";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -470,18 +474,40 @@ export const bitcoinSendFee = async (amount: number, address: string, feeRate: n
   }
 };
 
-export const sendBitcoinPayment = async (amount: number, address: string, feeRate: number, memo: string) => {
+export const sendBitcoinPayment = async (
+  amount: number,
+  address: string,
+  feeRate: number,
+  memo: string,
+  idempotencyKey?: string,
+) => {
   try {
     const response = await fetch(`${BASE_URL}/bitcoin/send`, await withAuthToken({
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        // Best-effort only. We have NOT confirmed CoinOS honours this, so
+        // nothing depends on it: the real duplicate protection is the
+        // history check and the indeterminate marker in
+        // services/coinos/withdrawGuard. Sending it costs nothing and helps
+        // if support exists or arrives later.
+        ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
       },
       body: feeRate === 0 ? JSON.stringify({ amount, address }) : JSON.stringify({ amount, address, feeRate, memo }),
     }));
     return await response.text();
   } catch (error) {
     console.error('Error sending bitcoin payment:', error);
+    // A network-shaped throw means the request's fate is UNKNOWN: CoinOS may
+    // well have accepted it and the reply was lost. Reporting that as a
+    // failure is what made the withdraw screen say "Please try again" and
+    // re-arm the button, which sends the money a second time. Flag it so
+    // callers can branch on a marker instead of guessing from the text.
+    if (isNetworkShapedFailure(error)) {
+      throw markWithdrawIndeterminate(
+        'This withdrawal may already have been sent. Check your CoinOS history before trying again.',
+      );
+    }
     throw error;
   }
 };

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -9,6 +9,7 @@ import {
     cancelArkPendingRound,
     estimateArkOnchainRecover,
     fetchArkMinBoardSats,
+    isVtxoMidRound,
     recoverArkOnchainBoard,
 } from "@Cypher/services/ark";
 import { getCapsuleColorBand } from "@Cypher/helpers/arkCapsuleColor";
@@ -328,10 +329,12 @@ export default function ArkWallet({
         if (arkChainTipHeight === null || arkVtxos.length === 0) return null;
         let minBlocks = Infinity;
         for (const v of arkVtxos) {
-            // Skip arkoor (no own expiry) and Locked (mid-round — expiry
-            // countdown is meaningless until the round finalises).
+            // Skip arkoor (no own expiry) and anything mid-round (expiry
+            // countdown is meaningless until the round finalises). Includes
+            // delegated refreshes, which stay Spendable rather than Locked and
+            // whose expiryHeight is the pre-refresh one.
             if (v.expiryHeight === 0) continue;
-            if (v.state.toLowerCase() === 'locked') continue;
+            if (isVtxoMidRound(v, refreshingIds)) continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
             // Skip already-expired VTXOs (they stay in the store so the
             // Capsules tab can render them) — "refresh soon" is wrong
@@ -341,7 +344,7 @@ export default function ArkWallet({
         }
         if (!isFinite(minBlocks)) return null;
         return Math.max(0, blocksToDays(minBlocks));
-    }, [arkVtxos, arkChainTipHeight]);
+    }, [arkVtxos, arkChainTipHeight, refreshingIds]);
 
     const expiryWarning = soonestDaysLeft !== null && soonestDaysLeft < 7
         ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`

--- a/src/components/ExitFundingSourceList/index.tsx
+++ b/src/components/ExitFundingSourceList/index.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+import { Text } from '@Cypher/component-library';
+import { colors } from '@Cypher/style-guide';
+import type {
+    ExitFundingSource,
+    ExitFundingSourceId,
+} from '@Cypher/services/ark/exitFundingSources';
+
+/**
+ * "Fund exit fees from another wallet" picker.
+ *
+ * Presentational only: the caller decides which sources exist (see
+ * buildExitFundingSources) and what selecting one does. Keeping the rules out
+ * of here is what lets them be unit-tested.
+ *
+ * Unavailable rows are rendered, dimmed, with their reason. Hiding them makes
+ * the feature look broken to someone who expected their wallet to be listed;
+ * showing them says what to fix. They are not tappable, so the dead end is
+ * visible rather than discovered by tapping.
+ */
+
+type Props = {
+    sources: readonly ExitFundingSource[];
+    onSelect: (id: ExitFundingSourceId) => void;
+    /** Sats still needed, for the per-row "covers it / partial" hint. */
+    shortfallSats?: number;
+};
+
+function balanceLine(source: ExitFundingSource, shortfallSats?: number): string | null {
+    if (source.balanceSats == null) return null;
+    const bal = `${source.balanceSats.toLocaleString()} sats`;
+    if (!shortfallSats || shortfallSats <= 0) return bal;
+    // Say up front whether this one finishes the job, so the user does not pick
+    // a wallet, walk through a confirm screen and only then discover it is
+    // short.
+    return source.balanceSats >= shortfallSats ? `${bal} · covers it` : `${bal} · partial`;
+}
+
+export default function ExitFundingSourceList({ sources, onSelect, shortfallSats }: Props) {
+    return (
+        <View>
+            {sources.map((source) => {
+                const sub = source.available
+                    ? balanceLine(source, shortfallSats)
+                    : source.unavailableReason ?? null;
+
+                return (
+                    <TouchableOpacity
+                        key={source.id}
+                        accessibilityRole="button"
+                        accessibilityState={{ disabled: !source.available }}
+                        disabled={!source.available}
+                        activeOpacity={0.7}
+                        onPress={() => onSelect(source.id)}
+                        style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            paddingHorizontal: 14,
+                            paddingVertical: 14,
+                            borderRadius: 12,
+                            marginBottom: 8,
+                            backgroundColor: 'rgba(255,255,255,0.06)',
+                            opacity: source.available ? 1 : 0.45,
+                        }}
+                    >
+                        <View style={{ flex: 1, paddingRight: 12 }}>
+                            <Text bold style={{ fontSize: 15 }}>
+                                {source.label}
+                            </Text>
+                            {!!sub && (
+                                <Text style={{ fontSize: 12, color: '#AAA', marginTop: 3 }}>
+                                    {sub}
+                                </Text>
+                            )}
+                        </View>
+
+                        {/* Cold Vault is the slow one. Saying so on the row is the
+                            difference between an informed choice and a surprise
+                            hardware-wallet round-trip mid-exit. */}
+                        {source.slow && source.available && (
+                            <Text style={{ fontSize: 11, color: colors.gray?.thin ?? '#888' }}>
+                                needs your signing device
+                            </Text>
+                        )}
+                    </TouchableOpacity>
+                );
+            })}
+        </View>
+    );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -37,3 +37,4 @@ export { default as CircularView } from './CircularView';
 export { default as CustomTabView } from './CustomTabView';
 export { default as VaultCapsules } from './VaultCapsules';
 export { default as StrikeSignupSheet, type StrikeSignupSheetRef } from './StrikeSignupSheet';
+export { default as ExitFundingSourceList } from './ExitFundingSourceList';

--- a/src/custom-hooks/useArkExitDestinationBackfill.ts
+++ b/src/custom-hooks/useArkExitDestinationBackfill.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 
 import {
     deriveArkExitAddress,
@@ -59,17 +59,38 @@ export default function useArkExitDestinationBackfill(): void {
         (s) => s.setArkExitDestinationAddress,
     );
 
+    // Last logged input signature. `wallets` arrives from context with a fresh
+    // array identity on nearly every provider render, so this effect re-runs
+    // constantly even when nothing it cares about changed.
+    const lastLoggedRef = useRef<string | null>(null);
+
     useEffect(() => {
         // Diagnostic: surface which guard short-circuits us so we can tell
         // "no Hot Vault" from "already set" from "wallets not loaded yet".
         // Cheap; remove once the feature has shipped a couple of releases.
-        console.log(
-            '[ArkExitBackfill] tick',
-            'arkAuth=', arkAuth,
-            'walletID=', walletID ? `${walletID.slice(0, 8)}…` : null,
-            'destination=', arkExitDestinationAddress ? `${arkExitDestinationAddress.slice(0, 12)}…` : null,
-            'walletsLen=', Array.isArray(wallets) ? wallets.length : 'not-array',
-        );
+        //
+        // Logged only when the inputs actually change. Unconditionally, this
+        // fired about once a second for an entire session (observed live during
+        // a 36h unilateral exit) and buried the exit-drive lines sitting next
+        // to it, which is the opposite of what a diagnostic is for. The effect
+        // body below is already a no-op once the destination is set, so it is
+        // only the log that needed rate-limiting, not the work.
+        const signature = [
+            arkAuth,
+            walletID ?? '',
+            arkExitDestinationAddress ?? '',
+            Array.isArray(wallets) ? wallets.length : 'not-array',
+        ].join('|');
+        if (lastLoggedRef.current !== signature) {
+            lastLoggedRef.current = signature;
+            console.log(
+                '[ArkExitBackfill] tick',
+                'arkAuth=', arkAuth,
+                'walletID=', walletID ? `${walletID.slice(0, 8)}…` : null,
+                'destination=', arkExitDestinationAddress ? `${arkExitDestinationAddress.slice(0, 12)}…` : null,
+                'walletsLen=', Array.isArray(wallets) ? wallets.length : 'not-array',
+            );
+        }
         if (!arkAuth) return;
         if (!walletID) return;
         if (!Array.isArray(wallets) || wallets.length === 0) return;

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -18,6 +18,7 @@ import {
     fetchArkVtxos,
     fetchChainTipHeight,
     fetchArkExitVtxos,
+    decideExitClaimBatch,
     fetchClaimableExitVtxos,
     fetchPendingExitsTotalSats,
     getArkWalletHandle,
@@ -115,6 +116,20 @@ const URGENCY_THRESHOLD_BLOCKS = Math.round(
 // in practice: switch networks and retry, then Emergency Exit while
 // there is still time. Re-shown at most once per gap window so the sync
 // tick doesn't nag while the user is following the steps.
+/**
+ * How long the claim sweep waits for slower capsules before going without them.
+ *
+ * Each claim is one transaction paying one fee, and drainExits already batches
+ * every claimable capsule into it, so the only thing that costs money is
+ * claiming more than once. Six hours comfortably covers capsules whose exit
+ * branches confirmed a few blocks apart, which is the normal case, while
+ * bounding how long a healthy capsule can be held up by a wedged sibling.
+ *
+ * Safe to wait: past its CSV a claimable exit output is an ordinary UTXO only
+ * this wallet can spend. There is no deadline and nobody to race.
+ */
+const EXIT_CLAIM_BATCH_MAX_WAIT_MS = 6 * 60 * 60 * 1000;
+
 const REFRESH_FAIL_ESCALATE_STREAK = 3;
 const REFRESH_FAIL_ALERT_GAP_MS = 6 * 60 * 60 * 1000;
 
@@ -421,7 +436,58 @@ export default function useArkSync(): UseArkSync {
 
                     const claimable = await fetchClaimableExitVtxos();
                     _stamp(`fetchClaimableExitVtxos: ${claimable.length} ready`);
-                    if (claimable.length > 0 && arkExitDestinationAddress) {
+
+                    // CLAIM BATCHING.
+                    //
+                    // drainExits([]) already sweeps every currently-claimable
+                    // capsule into ONE transaction, so the cost of claiming is
+                    // per-claim, not per-capsule. Firing the moment the first
+                    // capsule ripens therefore pays a separate fee for each one.
+                    // Observed on a five-capsule exit: the first claim cost 225
+                    // sats to move 877, and four more were queued behind it, on
+                    // an exit-fee wallet that had already dropped from 3654 to
+                    // 699 sats. Five fees where one would have done.
+                    //
+                    // Capsules ripen apart because each has its own exit branch
+                    // and its own CSV, timed from when THAT branch's tx
+                    // confirmed. A single block between two confirmations is
+                    // enough to split the batch.
+                    //
+                    // So wait for the stragglers, but never indefinitely: one
+                    // wedged leaf must not hold the others hostage. Claim when
+                    // nothing else is still working its way through, or when the
+                    // window expires, whichever comes first.
+                    //
+                    // Waiting is safe. Past its CSV a claimable exit output is
+                    // an ordinary UTXO that only this wallet can spend, with no
+                    // deadline and nobody to race.
+                    const exitVtxosForBatch = await fetchArkExitVtxos();
+                    const stillProgressing = exitVtxosForBatch.filter(
+                        (v) => isActiveExit(v) && !v.isClaimable,
+                    ).length;
+
+                    const batchDecision = decideExitClaimBatch({
+                        claimableCount: claimable.length,
+                        stillProgressingCount: stillProgressing,
+                        batchSince: useAuthStore.getState().arkExitClaimBatchSince ?? null,
+                        now: Date.now(),
+                        maxWaitMs: EXIT_CLAIM_BATCH_MAX_WAIT_MS,
+                    });
+                    if (
+                        (useAuthStore.getState().arkExitClaimBatchSince ?? null) !==
+                        batchDecision.batchSince
+                    ) {
+                        useAuthStore.getState().setArkExitClaimBatchSince(batchDecision.batchSince);
+                    }
+                    const claimBatchReady = batchDecision.claim;
+                    if (claimable.length > 0 && !claimBatchReady) {
+                        _stamp(
+                            `exit claim held for batching (${batchDecision.reason}): ` +
+                            `${claimable.length} ready, ${stillProgressing} still progressing`,
+                        );
+                    }
+
+                    if (claimable.length > 0 && arkExitDestinationAddress && claimBatchReady) {
                         // claimArkExitsToAddress now finalizes AND broadcasts the
                         // claim (drainExits alone only builds a PSBT). Gate
                         // arkExitDrained on a real broadcast txid: a non-throwing
@@ -437,6 +503,10 @@ export default function useArkSync(): UseArkSync {
                                     `exit claim broadcast txid=${claim.txid} fee=${claim.feeSats} sats`,
                                 );
                                 setArkExitDrained(true);
+                                // Batch consumed. A later capsule ripening
+                                // opens a fresh window rather than inheriting
+                                // this one's elapsed time.
+                                useAuthStore.getState().setArkExitClaimBatchSince(null);
                             } else {
                                 _stamp('exit claim returned no txid, NOT marking drained');
                             }
@@ -456,7 +526,9 @@ export default function useArkSync(): UseArkSync {
                     // block comment above). `pendingTotal` is kept only as a
                     // belt-and-suspenders OR-term in case a future SDK
                     // version starts counting something we don't model.
-                    const exitVtxos = await fetchArkExitVtxos();
+                    // Reuses the list fetched for the batching decision above:
+                    // this runs every drive tick and the call is not cheap.
+                    const exitVtxos = exitVtxosForBatch;
                     // bark 0.6.1: count in-flight exits by the not-terminal
                     // check so we never under-count active exits, which would
                     // retire an exit early (the mid-exit wallet-deletion bug).

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -18,6 +18,7 @@ import {
     fetchArkVtxos,
     fetchChainTipHeight,
     fetchArkExitVtxos,
+    isVtxoMidRound,
     fetchClaimableExitVtxos,
     fetchPendingExitsTotalSats,
     getArkWalletHandle,
@@ -1042,12 +1043,18 @@ export default function useArkSync(): UseArkSync {
                     const seen = nextFirstSeen[String(r.id)];
                     return seen != null && now - seen > stuckThresholdMs;
                 });
+                const refreshingIdsForStuck =
+                    useAuthStore.getState().arkRefreshingVtxoIds ?? [];
                 // "stuckSats" = sum of Locked VTXO amounts. The SDK doesn't
                 // expose a vtxo→round link, so this is the total locked across
                 // all rounds, not strictly the stuck-round subset. Fine for a
                 // banner headline since the user cancels all stuck rounds anyway.
+                // Includes delegated refreshes, which stay `Spendable` for the
+                // whole round: testing `Locked` alone meant a wedged delegated
+                // round reported 0 stuck sats and the rescue banner never
+                // appeared for the very case it exists to catch.
                 const lockedVtxos = (vtxos?.all ?? []).filter(
-                    (v) => v.state.toLowerCase() === 'locked',
+                    (v) => isVtxoMidRound(v, refreshingIdsForStuck),
                 );
                 const lockedSats = lockedVtxos.reduce((sum, v) => sum + v.sats, 0);
                 // nearExpiry: is any Locked VTXO inside the swap-out window of
@@ -1119,9 +1126,15 @@ export default function useArkSync(): UseArkSync {
                 if (stuckNow && useAuthStore.getState().arkBgRefreshEnabled) {
                     const blockMs2 = AVG_BLOCK_MINUTES * 60 * 1000;
                     const nowMs2 = Date.now();
+                    const refreshingIdsForAutoCancel =
+                        useAuthStore.getState().arkRefreshingVtxoIds ?? [];
                     let anyWithinAutoCancel = false;
                     for (const v of vtxos.all) {
-                        if (v.state.toLowerCase() !== 'locked') continue;
+                        // Same union as the stuck-sats sum above: a delegated
+                        // round leaves the VTXO Spendable, so a Locked-only
+                        // test skipped every delegated refresh and the
+                        // auto-cancel safety net never armed for them.
+                        if (!isVtxoMidRound(v, refreshingIdsForAutoCancel)) continue;
                         if (v.expiryHeight <= 0) continue;
                         const expiryAtMs = nowMs2 + Math.max(0, v.expiryHeight - tip) * blockMs2;
                         const msLeft = expiryAtMs - nowMs2;
@@ -1229,7 +1242,11 @@ export default function useArkSync(): UseArkSync {
             if (tip !== null && vtxos) {
                 for (const v of vtxos.spendable) {
                     if (v.expiryHeight === 0) continue;
-                    if (v.state.toLowerCase() === 'locked') continue;
+                    // Skip anything mid-round: its expiry is the pre-refresh
+                    // one, and escalating on it would raise the blocking rescue
+                    // Alert while a refresh is already in flight fixing it.
+                    // Locked alone missed every delegated refresh.
+                    if (isVtxoMidRound(v, state.arkRefreshingVtxoIds ?? [])) continue;
                     const blocks = v.expiryHeight - tip;
                     // Skip already-expired VTXOs: they can't be refreshed (the
                     // ASP can sweep them at any time past expiry), so they must

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -14,6 +14,7 @@ import {
     fetchArkBalance,
     fetchArkPendingLightningReceives,
     fetchArkPendingRoundStates,
+    fetchArkExitParams,
     fetchArkRoundIntervalSecs,
     fetchArkVtxos,
     fetchChainTipHeight,
@@ -247,6 +248,7 @@ export default function useArkSync(): UseArkSync {
     const setArkLastBackupAt = useAuthStore((s) => s.setArkLastBackupAt);
     const arkRoundIntervalSecs = useAuthStore((s) => s.arkRoundIntervalSecs);
     const setArkRoundIntervalSecs = useAuthStore((s) => s.setArkRoundIntervalSecs);
+    const arkVtxoExitDeltaBlocks = useAuthStore((s) => s.arkVtxoExitDeltaBlocks);
     const arkExitInProgress = useAuthStore((s) => s.arkExitInProgress);
     const arkExitDestinationAddress = useAuthStore((s) => s.arkExitDestinationAddress);
     const setArkExitInProgress = useAuthStore((s) => s.setArkExitInProgress);
@@ -1392,7 +1394,19 @@ export default function useArkSync(): UseArkSync {
                 if (secs != null) setArkRoundIntervalSecs(secs);
             });
         };
+
+        // Same shape, different reason: `vtxoExitDelta` and `maxVtxoExitDepth`
+        // are server-side static config too, but the exit path is not allowed
+        // to ask for them (the user pressing Emergency Exit may be doing it
+        // BECAUSE the server is gone). Cache them while it is reachable so exit
+        // triage can measure a capsule's runway against the real CSV rather
+        // than the worst case it has to assume without them.
+        const maybeFetchExitParams = () => {
+            if (arkVtxoExitDeltaBlocks != null) return;
+            void fetchArkExitParams();
+        };
         maybeFetchRoundInterval();
+        maybeFetchExitParams();
 
         // Fast retry: catch the wallet handle the moment boot finishes.
         let pollTries = 0;
@@ -1404,6 +1418,7 @@ export default function useArkSync(): UseArkSync {
                 clearInterval(fastPollId);
                 void sync();
                 maybeFetchRoundInterval();
+                maybeFetchExitParams();
             } else if (pollTries >= POLL_MAX_TRIES) {
                 clearInterval(fastPollId);
             }
@@ -1416,7 +1431,7 @@ export default function useArkSync(): UseArkSync {
             clearInterval(id);
             clearInterval(fastPollId);
         };
-    }, [isArkAuth, sync, arkRoundIntervalSecs, setArkRoundIntervalSecs]);
+    }, [isArkAuth, sync, arkRoundIntervalSecs, setArkRoundIntervalSecs, arkVtxoExitDeltaBlocks]);
 
     // Foreground kick — refresh the moment the user returns to the app,
     // regardless of where the interval is in its cycle.

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -14,6 +14,7 @@ import {
     fetchArkBalance,
     fetchArkPendingLightningReceives,
     fetchArkPendingRoundStates,
+    fetchArkExitDriveFeeRate,
     fetchArkExitParams,
     fetchArkRoundIntervalSecs,
     fetchArkVtxos,
@@ -405,8 +406,19 @@ export default function useArkSync(): UseArkSync {
                     } catch (syncErr: any) {
                         console.warn('[Ark exit] pre-drive wallet sync failed (continuing):', syncErr?.message ?? syncErr);
                     }
-                    const progressResult = await progressArkExits();
-                    _stamp('progressArkExits done');
+                    // Bid at the runway-derived rate rather than letting bark
+                    // pick. Passing nothing meant the rate actually paid had no
+                    // relationship to the reserve the user was asked to fund;
+                    // now both come from how much runway the tightest capsule
+                    // has left, re-derived here every tick as that shrinks.
+                    let driveFeeRate: bigint | undefined;
+                    try {
+                        driveFeeRate = await fetchArkExitDriveFeeRate();
+                    } catch (rateErr: any) {
+                        console.warn('[Ark exit] drive fee-rate lookup failed, letting the SDK choose:', rateErr?.message ?? rateErr);
+                    }
+                    const progressResult = await progressArkExits(driveFeeRate);
+                    _stamp(`progressArkExits done${driveFeeRate != null ? ` at ${driveFeeRate} sat/vB` : ''}`);
                     // Diagnostic: the per-VTXO progress payload is the only
                     // signal of WHERE the state machine is (build?
                     // broadcast? awaiting confs?). Serialize defensively;

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -462,9 +462,29 @@ export default function useArkSync(): UseArkSync {
                     // an ordinary UTXO that only this wallet can spend, with no
                     // deadline and nobody to race.
                     const exitVtxosForBatch = await fetchArkExitVtxos();
-                    const stillProgressing = exitVtxosForBatch.filter(
+                    const stragglers = exitVtxosForBatch.filter(
                         (v) => isActiveExit(v) && !v.isClaimable,
-                    ).length;
+                    );
+                    const stillProgressing = stragglers.length;
+
+                    // The ripening schedule is knowable in advance:
+                    // AwaitingDelta carries the exact block each straggler
+                    // becomes claimable at, fixed from the moment its leaf
+                    // confirmed. Handing those to the decision lets it wait on
+                    // the chain rather than on a clock, which is what makes the
+                    // whole exit land as one UTXO instead of several. A
+                    // straggler still Processing has no such height yet, and
+                    // those are what the wall-clock backstop is for.
+                    const pendingClaimableHeights: number[] = [];
+                    let unknownScheduleCount = 0;
+                    for (const v of stragglers) {
+                        const h = Number(
+                            (v.state as { inner?: { claimableHeight?: number } })?.inner
+                                ?.claimableHeight ?? 0,
+                        );
+                        if (Number.isFinite(h) && h > 0) pendingClaimableHeights.push(h);
+                        else unknownScheduleCount += 1;
+                    }
 
                     const batchDecision = decideExitClaimBatch({
                         claimableCount: claimable.length,
@@ -472,6 +492,9 @@ export default function useArkSync(): UseArkSync {
                         batchSince: useAuthStore.getState().arkExitClaimBatchSince ?? null,
                         now: Date.now(),
                         maxWaitMs: EXIT_CLAIM_BATCH_MAX_WAIT_MS,
+                        tipHeight: useAuthStore.getState().arkChainTipHeight ?? null,
+                        pendingClaimableHeights,
+                        unknownScheduleCount,
                     });
                     if (
                         (useAuthStore.getState().arkExitClaimBatchSince ?? null) !==
@@ -483,7 +506,10 @@ export default function useArkSync(): UseArkSync {
                     if (claimable.length > 0 && !claimBatchReady) {
                         _stamp(
                             `exit claim held for batching (${batchDecision.reason}): ` +
-                            `${claimable.length} ready, ${stillProgressing} still progressing`,
+                            `${claimable.length} ready, ${stillProgressing} still progressing` +
+                            (batchDecision.blocksUntilAllReady != null
+                                ? `, ${batchDecision.blocksUntilAllReady} blocks to go`
+                                : ''),
                         );
                     }
 

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -9,6 +9,7 @@ import {
     cancelVtxoExpiryWarnings,
     cancelVtxoStuckSwapWarnings,
     claimArkExitsToAddress,
+    fetchClaimFeeRateSatPerVb,
     getArkCancelling,
     setArkCancelling,
     fetchArkBalance,
@@ -428,9 +429,20 @@ export default function useArkSync(): UseArkSync {
                         // return is NOT proof the funds left, and treating it as
                         // such pinned the exit "active" forever (the claim VTXO
                         // stayed claimable because nothing was ever relayed).
+                        let claimRateForLog = 0;
                         try {
+                            // Price the claim explicitly. Passing undefined lets
+                            // bark pick, and it picks for speed: observed live
+                            // bidding 779 sats to sweep a 698 sat output, which
+                            // it then refuses to build. The claim races nothing
+                            // once the CSV has matured, and its fee comes out of
+                            // the claimed value, so the 1-hour rate is correct
+                            // and "fastest" is actively harmful.
+                            const claimRate = await fetchClaimFeeRateSatPerVb();
+                            claimRateForLog = claimRate;
                             const claim = await claimArkExitsToAddress(
                                 arkExitDestinationAddress,
+                                BigInt(claimRate),
                             );
                             if (claim.txid) {
                                 _stamp(
@@ -445,10 +457,24 @@ export default function useArkSync(): UseArkSync {
                             // as-is so the next cycle retries; the claim VTXO
                             // stays listClaimableExits()-visible until the tx
                             // actually lands, which is the correct retry gate.
-                            console.warn(
-                                '[Ark exit] claim sweep failed (will retry next cycle):',
-                                claimErr?.message ?? claimErr,
-                            );
+                            // "Claim Fee Exceeds Output" is not a transient
+                            // failure and retrying identically cannot fix it:
+                            // the capsule is worth less than it costs to sweep
+                            // at the current rate. Name it, so it is not just
+                            // an anonymous warning repeating every drive tick.
+                            const msg = String(claimErr?.message ?? claimErr);
+                            if (/Claim Fee Exceeds Output/i.test(msg)) {
+                                console.warn(
+                                    '[Ark exit] claim UNECONOMIC at',
+                                    claimRateForLog, 'sat/vB:', msg,
+                                    '- will retry, but this cannot clear until the fee rate drops or more capsules ripen and batch.',
+                                );
+                            } else {
+                                console.warn(
+                                    '[Ark exit] claim sweep failed (will retry next cycle):',
+                                    msg,
+                                );
+                            }
                         }
                     }
 

--- a/src/helpers/capsuleSelection.ts
+++ b/src/helpers/capsuleSelection.ts
@@ -1,0 +1,55 @@
+/**
+ * Capsule (UTXO) selection for vault sends.
+ *
+ * Selecting capsules is mandatory in Cypher Box: you cannot send from a vault
+ * without choosing coins first. Every entry point into ColdStorage passes both
+ * the UTXO set and the selected ids, and Capsules gates each of its four send
+ * paths on a non-empty selection.
+ *
+ * This lives in its own module rather than inline in the screen so the rule can
+ * be tested directly. The screen used to hand the UNFILTERED set to
+ * createTransaction, so coinselect (which sorts descending and takes the
+ * largest) spent whatever coin it liked regardless of what the user ticked, and
+ * the change figure on the confirm screen, derived from the selection, could be
+ * wrong by orders of magnitude. That matters most when change is routed to a
+ * Strike or CoinOS deposit address.
+ */
+
+/** Minimum shape this module needs. Real UTXOs carry more fields. */
+export type SelectableUtxo = {
+    txid: string;
+    vout: number;
+    value: number;
+};
+
+/** Canonical outpoint key. Both halves matter: one txid can fund several vouts. */
+export function outpointKey(u: Pick<SelectableUtxo, 'txid' | 'vout'>): string {
+    return `${u.txid}:${u.vout}`;
+}
+
+/**
+ * The capsules the user picked, and the ONLY coins a vault send may spend.
+ *
+ * Order follows `utxo`, not `ids`, so the caller's coin ordering is preserved
+ * for coinselect. Ids with no matching UTXO are ignored rather than throwing:
+ * a stale selection (coin spent elsewhere since the picker rendered) should
+ * narrow the spend, never fabricate an input.
+ *
+ * There is deliberately NO whole-wallet fallback. If the selection is empty
+ * that is a caller bug, and quietly spending the rest of the vault is the worst
+ * available response, so this returns an empty array and callers must refuse to
+ * build a transaction.
+ */
+export function selectCapsules<T extends SelectableUtxo>(
+    utxo: readonly T[] | null | undefined,
+    ids: readonly string[] | null | undefined,
+): T[] {
+    if (!utxo || !ids || ids.length === 0) return [];
+    const wanted = new Set(ids);
+    return utxo.filter((u) => wanted.has(outpointKey(u)));
+}
+
+/** Total value of a selection, in sats. */
+export function selectedTotalSats(utxo: readonly SelectableUtxo[]): number {
+    return utxo.reduce((sum, u) => sum + u.value, 0);
+}

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import SimpleToast from 'react-native-simple-toast';
 
 import { ScreenLayout, Text } from '@Cypher/component-library';
-import { GradientCard, SwipeButton } from '@Cypher/components';
+import { SwipeButton } from '@Cypher/components';
 import { colors } from '@Cypher/style-guide';
 import { formatNumber } from '@Cypher/helpers/coinosHelper';
 import useAuthStore from '@Cypher/stores/authStore';
@@ -270,7 +270,26 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                                 </Text>
                             </View>
                         )}
-                        <GradientCard disabled style={{ marginTop: 12 }}>
+                        {/* NOT GradientCard. That component hard-codes
+                            height: 60 on both its wrapper and its gradient,
+                            because it is the single-row input pill, and every
+                            other caller overrides it via linearStyle. Used here
+                            for a five-row details panel it clipped everything
+                            below the first row: observed on device as a screen
+                            showing only "From CoinOS", with the amount, the
+                            network fee and the total silently invisible on a
+                            money-moving confirmation. A details panel is the
+                            plain bordered View the sibling Ark review screens
+                            use. */}
+                        <View
+                            style={{
+                                marginTop: 12,
+                                borderRadius: 20,
+                                borderWidth: 1,
+                                borderColor: '#333',
+                                backgroundColor: '#1a1a1a',
+                            }}
+                        >
                             <View style={{ padding: 16 }}>
                                 <Row label="From" value={sourceLabel} />
                                 <Row label="To" value="Bark on-chain reserve" hint={address ?? undefined} />
@@ -302,7 +321,7 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                                     </Text>
                                 )}
                             </View>
-                        </GradientCard>
+                        </View>
 
                         {plan.ok && plan.partial && (
                             <Text style={{ fontSize: 12, color: '#FFD54F', marginTop: 12, lineHeight: 17 }}>

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import SimpleToast from 'react-native-simple-toast';
 
-import { ScreenLayout, Text } from '@Cypher/component-library';
-import { SwipeButton } from '@Cypher/components';
+import { Input, ScreenLayout, Text } from '@Cypher/component-library';
+import { GradientCard, SwipeButton } from '@Cypher/components';
 import { colors } from '@Cypher/style-guide';
 import { formatNumber } from '@Cypher/helpers/coinosHelper';
 import useAuthStore from '@Cypher/stores/authStore';
@@ -84,11 +84,19 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
 
     const [address, setAddress] = useState<string | null>(null);
     const [feeSats, setFeeSats] = useState<number | null>(null);
+    // What the user wants to LAND on-chain. Seeded with the shortfall, because
+    // that is the number that clears the gate, but editable: the exit accepts
+    // partial funding and a user may only want to part-fund it now.
+    const [amountText, setAmountText] = useState(
+        shortfallSats > 0 ? String(Math.floor(shortfallSats)) : '',
+    );
     const [loading, setLoading] = useState(true);
     const [sending, setSending] = useState(false);
     // Why preparation failed, if it did. Distinct from a plan that simply is
     // not fundable: this one means we never got far enough to compute a plan.
     const [prepError, setPrepError] = useState<string | null>(null);
+    // Debounce handle for re-estimating the fee as the amount is typed.
+    const feeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     // Latched once an outcome becomes unknown. Never cleared: the point is that
     // this screen must not offer to send again. Mirrors the Ark send review.
     const [indeterminate, setIndeterminate] = useState(false);
@@ -145,15 +153,62 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         };
     }, [shortfallSats]);
 
+    /** Digits only. An empty or zero field is "nothing to send", not an error
+     *  to shout about while the user is still typing. */
+    const amountSats = useMemo(() => {
+        const digits = amountText.replace(/[^0-9]/g, '');
+        const n = digits ? parseInt(digits, 10) : 0;
+        return Number.isFinite(n) ? n : 0;
+    }, [amountText]);
+
     const plan = useMemo(
         () =>
             planExitFunding({
-                shortfallSats,
+                // The field is the target now. planExitFunding calls it a
+                // shortfall because that is what seeds it, but it only ever
+                // means "sats the user wants to land".
+                shortfallSats: amountSats,
                 availableSats,
                 feeSats: feeSats ?? 0,
             }),
-        [shortfallSats, availableSats, feeSats],
+        [amountSats, availableSats, feeSats],
     );
+
+    /** True once the field no longer covers the gap the exit reported. */
+    const underSuggested = shortfallSats > 0 && amountSats > 0 && amountSats < shortfallSats;
+
+    // The fee depends on the amount, so a fee quoted for the mount-time
+    // shortfall goes stale the moment the field is edited, and "Leaves your
+    // wallet" is built from it. Re-estimate on a debounce rather than per
+    // keystroke: this is a network call to CoinOS.
+    useEffect(() => {
+        if (!address || amountSats <= 0) return;
+        if (feeTimer.current) clearTimeout(feeTimer.current);
+        let cancelled = false;
+        feeTimer.current = setTimeout(() => {
+            (async () => {
+                try {
+                    const raw = await withTimeout(
+                        bitcoinSendFee(amountSats, address, 0),
+                        PREPARE_TIMEOUT_MS,
+                        'Estimating the network fee',
+                    );
+                    const parsed =
+                        typeof raw === 'string' && raw.trim().startsWith('{')
+                            ? JSON.parse(raw)
+                            : null;
+                    if (!cancelled) setFeeSats(Number(parsed?.fee ?? 0) || 0);
+                } catch {
+                    // Keep the last estimate. A failed re-quote makes the
+                    // preview less precise; it must not blank the screen.
+                }
+            })();
+        }, 500);
+        return () => {
+            cancelled = true;
+            if (feeTimer.current) clearTimeout(feeTimer.current);
+        };
+    }, [amountSats, address]);
 
     // Reasons the swipe can never succeed, as opposed to "not yet". Ordered so
     // the most specific wins: an indeterminate send outranks a bad plan.
@@ -165,9 +220,11 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
             ? 'Cannot continue until the deposit address is available.'
             : sourceId !== 'coinos'
               ? `Funding from ${sourceLabel} is not available yet.`
-              : !plan.ok
-                ? plan.reason
-                : null;
+              : amountSats <= 0
+                ? 'Enter an amount to send.'
+                : !plan.ok
+                  ? plan.reason
+                  : null;
 
     const fiat = (sats: number) =>
         rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
@@ -183,7 +240,7 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         try {
             const res = await fundExitFeesFromCoinos(
                 {
-                    shortfallSats,
+                    shortfallSats: amountSats,
                     availableSats,
                     currentReserveSats: arkExitFeeReserveSats ?? 0,
                     idempotencyKey: idempotencyKey.current,
@@ -227,11 +284,21 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         }
     };
 
-    const Row = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (
+    const Row = ({
+        label,
+        value,
+        hint,
+        wrap,
+    }: {
+        label: string;
+        value: string;
+        hint?: string;
+        wrap?: boolean;
+    }) => (
         <View style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 10 }}>
             <Text style={{ fontSize: 14, color: '#BBB' }}>{label}</Text>
             <View style={{ alignItems: 'flex-end', flex: 1, paddingLeft: 12 }}>
-                <Text bold style={{ fontSize: 14 }} numberOfLines={1}>
+                <Text bold style={{ fontSize: 14 }} numberOfLines={wrap ? 2 : 1}>
                     {value}
                 </Text>
                 {!!hint && <Text style={{ fontSize: 11, color: '#888', marginTop: 2 }}>{hint}</Text>}
@@ -241,7 +308,11 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
 
     return (
         <ScreenLayout disableScroll showToolbar isBackButton title="Fund exit fees">
-            <View style={{ paddingHorizontal: 20, flex: 1 }}>
+            <ScrollView
+                style={{ flex: 1 }}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 16 }}
+                keyboardShouldPersistTaps="handled"
+            >
                 {loading ? (
                     <ActivityIndicator color={colors.pink.default} style={{ marginTop: 40 }} />
                 ) : (
@@ -281,6 +352,42 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                             money-moving confirmation. A details panel is the
                             plain bordered View the sibling Ark review screens
                             use. */}
+                        {/* Amount. GradientCard's fixed 60px height is
+                            CORRECT here: it is the single-field pill the rest
+                            of the app uses for exactly this, which is why the
+                            details panel below is a plain View instead. */}
+                        <GradientCard
+                            style={{ marginTop: 12 }}
+                            colors_={
+                                amountSats > 0
+                                    ? [colors.pink.extralight, colors.pink.default]
+                                    : [colors.gray.thin, colors.gray.thin2]
+                            }
+                        >
+                            <Input
+                                value={amountText}
+                                onChange={(t: string) => setAmountText(t.replace(/[^0-9]/g, ''))}
+                                keyboardType="number-pad"
+                                label="Amount in sats"
+                                maxLength={12}
+                            />
+                        </GradientCard>
+
+                        {shortfallSats > 0 && (
+                            <Text
+                                style={{
+                                    fontSize: 12,
+                                    color: underSuggested ? '#FFD54F' : '#888',
+                                    marginTop: 8,
+                                    lineHeight: 17,
+                                }}
+                            >
+                                {underSuggested
+                                    ? `Suggested ${formatNumber(shortfallSats)} sats. Less than that still helps: the exit runs as far as these fees allow.`
+                                    : `Suggested ${formatNumber(shortfallSats)} sats, which is what the exit is short by.`}
+                            </Text>
+                        )}
+
                         <View
                             style={{
                                 marginTop: 12,
@@ -292,7 +399,13 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                         >
                             <View style={{ padding: 16 }}>
                                 <Row label="From" value={sourceLabel} />
-                                <Row label="To" value="Bark on-chain reserve" hint={address ?? undefined} />
+                                <Row label="To" value="Bark on-chain wallet" />
+                                <Row
+                                    wrap
+                                    label="Address"
+                                    value={address ?? 'Preparing...'}
+                                    hint={address ? 'Deposit lands here and stays on-chain' : undefined}
+                                />
                                 {plan.ok ? (
                                     <>
                                         <Row
@@ -337,7 +450,7 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
 
                     </>
                 )}
-            </View>
+            </ScrollView>
 
             <View style={{ paddingHorizontal: 20, paddingBottom: 20 }}>
                 {blockedReason ? (

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import SimpleToast from 'react-native-simple-toast';
+
+import { ScreenLayout, Text } from '@Cypher/component-library';
+import { GradientCard, SwipeButton } from '@Cypher/components';
+import { colors } from '@Cypher/style-guide';
+import { formatNumber } from '@Cypher/helpers/coinosHelper';
+import useAuthStore from '@Cypher/stores/authStore';
+import {
+    fundExitFeesFromCoinos,
+    getArkOnchainAddress,
+    planExitFunding,
+} from '@Cypher/services/ark';
+import {
+    bitcoinSendFee,
+    getTransactionHistory,
+    sendBitcoinPayment,
+} from '@Cypher/api/coinOSApis';
+
+/**
+ * Confirm screen for topping up the exit-fee reserve from another wallet.
+ *
+ * Everything that decides an outcome lives in services/ark/exitFundingCoinos
+ * and exitFundingPlan, both unit-tested. This screen only shows the numbers and
+ * hands the work over, so the money path is not defined by a component.
+ *
+ * The figures here answer the two questions the old flow left open: what
+ * actually LANDS (the miner fee comes off the top, so it is not what you typed)
+ * and when it takes effect (an on-chain deposit is useless until it confirms).
+ */
+
+type Props = {
+    route: {
+        params?: {
+            /** Funding source id from the picker. Only 'coinos' is wired. */
+            sourceId?: string;
+            sourceLabel?: string;
+            shortfallSats?: number;
+            availableSats?: number | null;
+            /** Fiat per BTC, for the dollar figures. */
+            rate?: number;
+            currencySymbol?: string;
+        };
+    };
+};
+
+const SATS_PER_BTC = 100_000_000;
+
+export default function ArkExitFundingConfirmScreen({ route }: Props) {
+    const navigation = useNavigation<any>();
+    const {
+        sourceId = 'coinos',
+        sourceLabel = 'CoinOS',
+        shortfallSats = 0,
+        availableSats = null,
+        rate = 0,
+        currencySymbol = '$',
+    } = route?.params ?? {};
+
+    const { arkExitFeeReserveSats, setArkExitFeeReserveSats } = useAuthStore();
+
+    const [address, setAddress] = useState<string | null>(null);
+    const [feeSats, setFeeSats] = useState<number | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [sending, setSending] = useState(false);
+    // Latched once an outcome becomes unknown. Never cleared: the point is that
+    // this screen must not offer to send again. Mirrors the Ark send review.
+    const [indeterminate, setIndeterminate] = useState(false);
+    const swipeRef = useRef<any>(null);
+    // Stable per mount, so a retry of the SAME intended top-up carries the same
+    // key rather than looking like a fresh request.
+    const idempotencyKey = useRef(
+        `cbx-fund-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+    );
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const addr = await getArkOnchainAddress();
+                if (cancelled) return;
+                setAddress(addr);
+                try {
+                    const raw = await bitcoinSendFee(shortfallSats, addr, 0);
+                    const parsed =
+                        typeof raw === 'string' && raw.trim().startsWith('{')
+                            ? JSON.parse(raw)
+                            : null;
+                    if (!cancelled) setFeeSats(Number(parsed?.fee ?? 0) || 0);
+                } catch {
+                    // A missing estimate must not block funding; it only makes
+                    // the preview less precise.
+                    if (!cancelled) setFeeSats(0);
+                }
+            } catch (err: any) {
+                if (!cancelled) {
+                    SimpleToast.show(
+                        `Could not prepare the top-up: ${err?.message ?? 'unknown error'}`,
+                        SimpleToast.LONG,
+                    );
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [shortfallSats]);
+
+    const plan = useMemo(
+        () =>
+            planExitFunding({
+                shortfallSats,
+                availableSats,
+                feeSats: feeSats ?? 0,
+            }),
+        [shortfallSats, availableSats, feeSats],
+    );
+
+    const fiat = (sats: number) =>
+        rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
+
+    const feePct =
+        plan.ok && plan.sendSats > 0 && feeSats
+            ? ((feeSats / plan.sendSats) * 100).toFixed(feeSats / plan.sendSats < 0.01 ? 2 : 1)
+            : null;
+
+    const onConfirm = async () => {
+        if (!plan.ok || sending || indeterminate) return;
+        setSending(true);
+        try {
+            const res = await fundExitFeesFromCoinos(
+                {
+                    shortfallSats,
+                    availableSats,
+                    currentReserveSats: arkExitFeeReserveSats ?? 0,
+                    idempotencyKey: idempotencyKey.current,
+                },
+                {
+                    getOnchainAddress: getArkOnchainAddress,
+                    getRecentPayments: () => getTransactionHistory(0, 20),
+                    estimateFeeSats: async (addr, amt) => {
+                        const raw = await bitcoinSendFee(amt, addr, 0);
+                        const parsed =
+                            typeof raw === 'string' && raw.trim().startsWith('{')
+                                ? JSON.parse(raw)
+                                : null;
+                        return Number(parsed?.fee ?? 0) || 0;
+                    },
+                    send: (addr, amt, key) => sendBitcoinPayment(amt, addr, 0, 'Exit fee reserve', key),
+                    armReserve: setArkExitFeeReserveSats,
+                },
+            );
+
+            if (res.ok) {
+                navigation.replace('ArkSendSuccessScreen', {
+                    title: 'Exit fees funded',
+                    // The deposit is worthless until it confirms, and saying so
+                    // here is what stops "nothing happened" a minute later.
+                    message: res.partial
+                        ? `Sent ${formatNumber(res.sentSats)} sats. That is less than the full shortfall, so top up again if the exit still reports a gap. Emergency Exit unlocks once it confirms on-chain.`
+                        : `Sent ${formatNumber(res.sentSats)} sats. Emergency Exit unlocks once it confirms on-chain.`,
+                    txid: res.txid ?? undefined,
+                });
+                return;
+            }
+
+            if (res.indeterminate) {
+                setIndeterminate(true);
+            }
+            SimpleToast.show(res.reason, SimpleToast.LONG);
+            swipeRef.current?.reset?.();
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const Row = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 10 }}>
+            <Text style={{ fontSize: 14, color: '#BBB' }}>{label}</Text>
+            <View style={{ alignItems: 'flex-end', flex: 1, paddingLeft: 12 }}>
+                <Text bold style={{ fontSize: 14 }} numberOfLines={1}>
+                    {value}
+                </Text>
+                {!!hint && <Text style={{ fontSize: 11, color: '#888', marginTop: 2 }}>{hint}</Text>}
+            </View>
+        </View>
+    );
+
+    return (
+        <ScreenLayout disableScroll showToolbar isBackButton title="Fund exit fees">
+            <View style={{ paddingHorizontal: 20, flex: 1 }}>
+                {loading ? (
+                    <ActivityIndicator color={colors.pink.default} style={{ marginTop: 40 }} />
+                ) : (
+                    <>
+                        <GradientCard disabled style={{ marginTop: 12 }}>
+                            <View style={{ padding: 16 }}>
+                                <Row label="From" value={sourceLabel} />
+                                <Row label="To" value="Bark on-chain reserve" hint={address ?? undefined} />
+                                {plan.ok ? (
+                                    <>
+                                        <Row
+                                            label="Amount"
+                                            value={`${formatNumber(plan.sendSats)} sats`}
+                                            hint={fiat(plan.sendSats) || undefined}
+                                        />
+                                        <Row
+                                            label="Network fee"
+                                            value={`${formatNumber(feeSats ?? 0)} sats`}
+                                            hint={
+                                                feePct
+                                                    ? `${feePct}%${fiat(feeSats ?? 0) ? ` · ${fiat(feeSats ?? 0)}` : ''}`
+                                                    : fiat(feeSats ?? 0) || undefined
+                                            }
+                                        />
+                                        <Row
+                                            label="Leaves your wallet"
+                                            value={`${formatNumber(plan.totalCostSats)} sats`}
+                                            hint={fiat(plan.totalCostSats) || undefined}
+                                        />
+                                    </>
+                                ) : (
+                                    <Text style={{ fontSize: 13, color: '#FFD54F', paddingVertical: 12 }}>
+                                        {plan.reason}
+                                    </Text>
+                                )}
+                            </View>
+                        </GradientCard>
+
+                        {plan.ok && plan.partial && (
+                            <Text style={{ fontSize: 12, color: '#FFD54F', marginTop: 12, lineHeight: 17 }}>
+                                This does not cover the whole shortfall. It still helps: the exit
+                                resumes as far as these fees allow.
+                            </Text>
+                        )}
+
+                        <Text style={{ fontSize: 12, color: '#888', marginTop: 12, lineHeight: 17 }}>
+                            These sats stay on-chain to pay miner fees and are not moved into Ark.
+                            Emergency Exit unlocks once the deposit confirms.
+                        </Text>
+
+                        {indeterminate && (
+                            <Text style={{ fontSize: 12, color: '#FF8A80', marginTop: 12, lineHeight: 17 }}>
+                                This top-up may already have been sent. Check your {sourceLabel}{' '}
+                                history before trying again.
+                            </Text>
+                        )}
+                    </>
+                )}
+            </View>
+
+            <View style={{ paddingHorizontal: 20, paddingBottom: 20 }}>
+                <SwipeButton
+                    title="Slide to Fund"
+                    ref={swipeRef}
+                    onToggle={onConfirm}
+                    isLoading={sending || loading || !plan.ok || indeterminate || sourceId !== 'coinos'}
+                />
+            </View>
+        </ScreenLayout>
+    );
+}

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -18,6 +18,7 @@ import {
     getTransactionHistory,
     sendBitcoinPayment,
 } from '@Cypher/api/coinOSApis';
+import { getFiatRate } from '../../../../models/fiatUnit';
 
 /**
  * Preparing the deposit needs bark's on-chain (BDK) wallet, and spawning that
@@ -97,6 +98,26 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
     const [prepError, setPrepError] = useState<string | null>(null);
     // Debounce handle for re-estimating the fee as the amount is typed.
     const feeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // The caller does not pass a rate, so every fiat figure here and on the
+    // success screen rendered as 0.00. Fetch it the same way the non-Strike
+    // rails do in SwapAmount. Failure just leaves the fiat hints blank.
+    const [fetchedRate, setFetchedRate] = useState(0);
+    useEffect(() => {
+        if (rate > 0) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const r = (await getFiatRate('USD')) || 0;
+                if (!cancelled) setFetchedRate(r);
+            } catch {
+                // Leave fiat blank rather than showing a wrong number.
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [rate]);
+    const effectiveRate = rate > 0 ? rate : fetchedRate;
     // Latched once an outcome becomes unknown. Never cleared: the point is that
     // this screen must not offer to send again. Mirrors the Ark send review.
     const [indeterminate, setIndeterminate] = useState(false);
@@ -227,7 +248,9 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                   : null;
 
     const fiat = (sats: number) =>
-        rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
+        effectiveRate > 0
+            ? `${currencySymbol}${((sats / SATS_PER_BTC) * effectiveRate).toFixed(2)}`
+            : '';
 
     const feePct =
         plan.ok && plan.sendSats > 0 && feeSats
@@ -264,11 +287,25 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
             if (res.ok) {
                 navigation.replace('ArkSendSuccessScreen', {
                     title: 'Exit fees funded',
+                    // These three were never passed, so the success screen fell
+                    // back to its defaults and reported "0 sats" for a real
+                    // deposit. It reads them; send them.
+                    value: String(res.sentSats),
+                    valueUsd:
+                        effectiveRate > 0
+                            ? ((res.sentSats / SATS_PER_BTC) * effectiveRate).toFixed(2)
+                            : '0.00',
+                    currency: currencySymbol === '$' ? 'USD' : currencySymbol,
+                    // On-chain, not Lightning. The default rail label and the
+                    // bolt both said otherwise.
+                    isOnchain: true,
+                    networkLabel: 'Bitcoin Network',
                     // The deposit is worthless until it confirms, and saying so
-                    // here is what stops "nothing happened" a minute later.
-                    message: res.partial
-                        ? `Sent ${formatNumber(res.sentSats)} sats. That is less than the full shortfall, so top up again if the exit still reports a gap. Emergency Exit unlocks once it confirms on-chain.`
-                        : `Sent ${formatNumber(res.sentSats)} sats. Emergency Exit unlocks once it confirms on-chain.`,
+                    // here is what stops "nothing happened" a minute later. The
+                    // amount is displayed above now, so it is not repeated.
+                    note: res.partial
+                        ? 'That is less than the full shortfall, so top up again if the exit still reports a gap. Emergency Exit unlocks once it confirms on-chain.'
+                        : 'Emergency Exit unlocks once it confirms on-chain.',
                     txid: res.txid ?? undefined,
                 });
                 return;

--- a/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
+++ b/src/screens/Ark/ArkExitFundingConfirmScreen/index.tsx
@@ -20,6 +20,27 @@ import {
 } from '@Cypher/api/coinOSApis';
 
 /**
+ * Preparing the deposit needs bark's on-chain (BDK) wallet, and spawning that
+ * hits an esplora endpoint. `ensureArkOnchainHandle` has no timeout of its own,
+ * so a provider that accepts the connection and then never answers hangs this
+ * screen forever with no error. Bound it here rather than leave the user on a
+ * spinner that can never resolve.
+ */
+const PREPARE_TIMEOUT_MS = 20_000;
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+    return Promise.race([
+        p,
+        new Promise<T>((_, reject) =>
+            setTimeout(
+                () => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s`)),
+                ms,
+            ),
+        ),
+    ]);
+}
+
+/**
  * Confirm screen for topping up the exit-fee reserve from another wallet.
  *
  * Everything that decides an outcome lives in services/ark/exitFundingCoinos
@@ -65,6 +86,9 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
     const [feeSats, setFeeSats] = useState<number | null>(null);
     const [loading, setLoading] = useState(true);
     const [sending, setSending] = useState(false);
+    // Why preparation failed, if it did. Distinct from a plan that simply is
+    // not fundable: this one means we never got far enough to compute a plan.
+    const [prepError, setPrepError] = useState<string | null>(null);
     // Latched once an outcome becomes unknown. Never cleared: the point is that
     // this screen must not offer to send again. Mirrors the Ark send review.
     const [indeterminate, setIndeterminate] = useState(false);
@@ -79,11 +103,19 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
         let cancelled = false;
         (async () => {
             try {
-                const addr = await getArkOnchainAddress();
+                const addr = await withTimeout(
+                    getArkOnchainAddress(),
+                    PREPARE_TIMEOUT_MS,
+                    'Preparing the deposit address',
+                );
                 if (cancelled) return;
                 setAddress(addr);
                 try {
-                    const raw = await bitcoinSendFee(shortfallSats, addr, 0);
+                    const raw = await withTimeout(
+                        bitcoinSendFee(shortfallSats, addr, 0),
+                        PREPARE_TIMEOUT_MS,
+                        'Estimating the network fee',
+                    );
                     const parsed =
                         typeof raw === 'string' && raw.trim().startsWith('{')
                             ? JSON.parse(raw)
@@ -96,10 +128,13 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                 }
             } catch (err: any) {
                 if (!cancelled) {
-                    SimpleToast.show(
-                        `Could not prepare the top-up: ${err?.message ?? 'unknown error'}`,
-                        SimpleToast.LONG,
-                    );
+                    const msg = err?.message ?? 'unknown error';
+                    // Show it ON the screen, not only as a toast that vanishes.
+                    // The deposit address comes from the on-chain wallet, so the
+                    // usual cause is the chain source being unreachable, which
+                    // the user can often fix by changing network.
+                    setPrepError(msg);
+                    SimpleToast.show(`Could not prepare the top-up: ${msg}`, SimpleToast.LONG);
                 }
             } finally {
                 if (!cancelled) setLoading(false);
@@ -119,6 +154,20 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
             }),
         [shortfallSats, availableSats, feeSats],
     );
+
+    // Reasons the swipe can never succeed, as opposed to "not yet". Ordered so
+    // the most specific wins: an indeterminate send outranks a bad plan.
+    const blockedReason: string | null = loading
+        ? null
+        : indeterminate
+          ? `This top-up may already have been sent. Check your ${sourceLabel} history before trying again.`
+          : prepError
+            ? 'Cannot continue until the deposit address is available.'
+            : sourceId !== 'coinos'
+              ? `Funding from ${sourceLabel} is not available yet.`
+              : !plan.ok
+                ? plan.reason
+                : null;
 
     const fiat = (sats: number) =>
         rate > 0 ? `${currencySymbol}${((sats / SATS_PER_BTC) * rate).toFixed(2)}` : '';
@@ -197,6 +246,30 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                     <ActivityIndicator color={colors.pink.default} style={{ marginTop: 40 }} />
                 ) : (
                     <>
+                        {prepError && (
+                            <View
+                                style={{
+                                    marginTop: 12,
+                                    padding: 14,
+                                    borderRadius: 12,
+                                    borderWidth: 1,
+                                    borderColor: '#FF8A80',
+                                    backgroundColor: '#1a1a1a',
+                                }}
+                            >
+                                <Text bold style={{ fontSize: 14, color: '#FF8A80', marginBottom: 6 }}>
+                                    Could not prepare the top-up
+                                </Text>
+                                <Text style={{ fontSize: 12, color: '#DDD', lineHeight: 17 }}>
+                                    {prepError}
+                                </Text>
+                                <Text style={{ fontSize: 12, color: '#888', lineHeight: 17, marginTop: 8 }}>
+                                    The deposit address comes from the on-chain wallet, which needs a
+                                    reachable chain source. Changing network often clears this. Go back
+                                    and reopen this screen to retry.
+                                </Text>
+                            </View>
+                        )}
                         <GradientCard disabled style={{ marginTop: 12 }}>
                             <View style={{ padding: 16 }}>
                                 <Row label="From" value={sourceLabel} />
@@ -243,23 +316,40 @@ export default function ArkExitFundingConfirmScreen({ route }: Props) {
                             Emergency Exit unlocks once the deposit confirms.
                         </Text>
 
-                        {indeterminate && (
-                            <Text style={{ fontSize: 12, color: '#FF8A80', marginTop: 12, lineHeight: 17 }}>
-                                This top-up may already have been sent. Check your {sourceLabel}{' '}
-                                history before trying again.
-                            </Text>
-                        )}
                     </>
                 )}
             </View>
 
             <View style={{ paddingHorizontal: 20, paddingBottom: 20 }}>
-                <SwipeButton
-                    title="Slide to Fund"
-                    ref={swipeRef}
-                    onToggle={onConfirm}
-                    isLoading={sending || loading || !plan.ok || indeterminate || sourceId !== 'coinos'}
-                />
+                {blockedReason ? (
+                    // SwipeButton only knows `isLoading`, and that renders a
+                    // spinner captioned "Please wait". Feeding a permanent
+                    // condition (no fundable plan, unsupported source, latched
+                    // indeterminate) into it told the user we were working on
+                    // something that was never going to happen: observed on
+                    // device as an endless "Please wait" with no explanation.
+                    // A blocked state is not a busy state, so say which it is.
+                    <View
+                        style={{
+                            padding: 16,
+                            borderRadius: 12,
+                            backgroundColor: '#1a1a1a',
+                            borderWidth: 1,
+                            borderColor: '#333',
+                        }}
+                    >
+                        <Text style={{ fontSize: 13, color: '#FFD54F', lineHeight: 18 }}>
+                            {blockedReason}
+                        </Text>
+                    </View>
+                ) : (
+                    <SwipeButton
+                        title="Slide to Fund"
+                        ref={swipeRef}
+                        onToggle={onConfirm}
+                        isLoading={sending || loading}
+                    />
+                )}
             </View>
         </ScreenLayout>
     );

--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -5,7 +5,13 @@ import SimpleToast from "react-native-simple-toast";
 import { ScreenLayout } from "@Cypher/component-library";
 import { CustomKeyboard, GradientInput } from "@Cypher/components";
 import { getStrikeCurrency, SATS } from "@Cypher/helpers/coinosHelper";
-import { createArkLightningInvoice } from "@Cypher/services/ark";
+import {
+    ARK_SERVER_URL,
+    ESPLORA_URLS,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+    createArkLightningInvoice,
+} from "@Cypher/services/ark";
 import { colors } from "@Cypher/style-guide";
 
 import styles from "./styles";
@@ -97,8 +103,21 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
             });
         } catch (err) {
             console.error("Ark invoice creation failed:", err);
+            // Minting an invoice needs the Ark server, so this fails whenever
+            // the ASP is unreachable. Naming the side that is down beats
+            // pasting a raw SDK string, and it decides whether "try mobile
+            // data" is useful advice or a waste of the user's time. Falls back
+            // to the raw message when the cause is not recognisable.
+            const faultMsg = arkNetworkFaultMessage(
+                classifyArkNetworkFault(err, {
+                    chainUrls: ESPLORA_URLS,
+                    arkUrl: ARK_SERVER_URL,
+                }),
+            );
             SimpleToast.show(
-                `Failed to create Ark invoice: ${(err as Error)?.message ?? "unknown error"}`,
+                faultMsg
+                    ? `Could not create the invoice. ${faultMsg}`
+                    : `Failed to create Ark invoice: ${(err as Error)?.message ?? "unknown error"}`,
                 SimpleToast.LONG,
             );
         } finally {

--- a/src/screens/Ark/ArkSendReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkSendReviewScreen/index.tsx
@@ -11,6 +11,7 @@ import {
     classifyArkDestination,
     estimateArkSendFee,
     executeArkSend,
+    isArkSendIndeterminate,
     labelForDestinationKind,
     type ArkDestination,
     type ArkSendFeeView,
@@ -149,8 +150,15 @@ export default function ArkSendReviewScreen({ route }: Props) {
         setAmountSats(sendAllAmount); // triggers re-estimate via the effect
     }, [sendAllAmount]);
 
+    // Latched once a send returns an INDETERMINATE outcome (see
+    // isArkSendIndeterminate). Never cleared: the whole point is that this
+    // screen must not offer to send again, because a retry to an ln-address
+    // mints a fresh invoice and can pay the recipient a second time.
+    const [sendIndeterminate, setSendIndeterminate] = useState(false);
+
     const canSend =
-        destinationValid && !!fee && grossWithinBalance && !isEstimating && !isSending;
+        destinationValid && !!fee && grossWithinBalance && !isEstimating && !isSending &&
+        !sendIndeterminate;
 
     const runSend = useCallback(async () => {
         if (!canSend || !fee) return;
@@ -167,9 +175,17 @@ export default function ArkSendReviewScreen({ route }: Props) {
             });
         } catch (err: any) {
             console.error('[ArkSendReview] send failed:', err);
-            setErrorMsg(
-                `Send failed: ${err?.message ?? 'unknown error'}. Your funds were not moved.`,
-            );
+            if (isArkSendIndeterminate(err)) {
+                // Outcome UNKNOWN. Do not claim the funds are safe, and do not
+                // re-arm Send: the payment may still settle, and a retry to an
+                // ln-address would mint a new invoice and pay twice.
+                setSendIndeterminate(true);
+                setErrorMsg(err?.message ?? 'This payment may still be in flight. Do not send it again.');
+            } else {
+                setErrorMsg(
+                    `Send failed: ${err?.message ?? 'unknown error'}. Your funds were not moved.`,
+                );
+            }
         } finally {
             setIsSending(false);
         }

--- a/src/screens/Ark/ArkSendSuccessScreen/index.tsx
+++ b/src/screens/Ark/ArkSendSuccessScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Image, Vibration, View } from 'react-native';
+import { Image, ImageBackground, Vibration, View } from 'react-native';
 import Animated, {
     Easing,
     useAnimatedStyle,
@@ -10,7 +10,7 @@ import Animated, {
 import { ScreenLayout, Text } from '@Cypher/component-library';
 import { GradientButton, GradientCard } from '@Cypher/components';
 import Ring from '@Cypher/components/RingEffect';
-import { Electrik } from '@Cypher/assets/images';
+import { Bitcoin, BitcoinTower, Electrik } from '@Cypher/assets/images';
 import { dispatchReset } from '@Cypher/helpers/navigation';
 import { getStrikeCurrency } from '@Cypher/helpers/coinosHelper';
 import { colors } from '@Cypher/style-guide';
@@ -37,6 +37,19 @@ import styles from '../../Transaction/styles';
  *   value:    net sats sent (string)
  *   valueUsd: fiat equivalent (string, already formatted to 2dp)
  *   currency: fiat currency code
+ *
+ * Everything below is optional and exists because this screen is no longer
+ * only a Lightning send. The exit-fee top-up lands here too, and it is an
+ * ON-CHAIN deposit that is not usable until it confirms. Shown unchanged, it
+ * told that user "Payment Sent / 0 sats / Lightning Network": the wrong amount,
+ * the wrong rail, and an air of finality the transaction had not earned.
+ *
+ *   title:        headline, default 'Payment Sent'
+ *   networkLabel: rail under the animation, default 'Lightning Network'
+ *   isOnchain:    swap the Lightning bolt for the Bitcoin visual the on-chain
+ *                 broadcast screen already uses
+ *   note:         a line under the amount for anything the user still has to
+ *                 know, e.g. that an on-chain deposit has to confirm first
  */
 
 interface Props {
@@ -45,6 +58,10 @@ interface Props {
             value?: string | number;
             valueUsd?: string;
             currency?: string;
+            title?: string;
+            networkLabel?: string;
+            isOnchain?: boolean;
+            note?: string;
         };
     };
 }
@@ -53,6 +70,10 @@ export default function ArkSendSuccessScreen({ route }: Props) {
     const value = String(route?.params?.value ?? '0');
     const valueUsd = route?.params?.valueUsd ?? '0.00';
     const currency = route?.params?.currency ?? 'USD';
+    const title = route?.params?.title ?? 'Payment Sent';
+    const networkLabel = route?.params?.networkLabel ?? 'Lightning Network';
+    const isOnchain = route?.params?.isOnchain === true;
+    const note = route?.params?.note;
 
     const [response, setResponse] = useState(false);
     const fadeInOpacity = useSharedValue(0);
@@ -85,7 +106,7 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                     {response && (
                         <Animated.View style={animatedStyle}>
                             <Text h1 semibold center>
-                                Payment Sent
+                                {title}
                             </Text>
                             <Text semibold center style={styles.sats}>
                                 {value} sats
@@ -94,6 +115,20 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                                 {getStrikeCurrency(currency)}
                                 {valueUsd}
                             </Text>
+                            {!!note && (
+                                <Text
+                                    center
+                                    style={{
+                                        fontSize: 13,
+                                        color: '#BBB',
+                                        lineHeight: 18,
+                                        marginTop: 10,
+                                        paddingHorizontal: 24,
+                                    }}
+                                >
+                                    {note}
+                                </Text>
+                            )}
                         </Animated.View>
                     )}
                 </View>
@@ -113,27 +148,56 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                             Transaction screen note). White ark gradient stands
                             in for Strike's pink; the dark inner circles keep
                             the bolt readable. */}
-                        <GradientCard
-                            style={styles.gradient}
-                            linearStyle={styles.gradient}
-                            colors_={[colors.ark.gradient1, colors.ark.gradient2]}
-                        >
-                            <View style={styles.inner}>
-                                <GradientCard
-                                    style={styles.gradientInner}
-                                    linearStyle={styles.gradientInner}
-                                    colors_={[colors.ark.gradient1, colors.ark.gradient2]}
-                                >
-                                    <View style={styles.inside}>
-                                        <Image
-                                            source={Electrik}
-                                            style={styles.image}
-                                            resizeMode="contain"
-                                        />
-                                    </View>
-                                </GradientCard>
-                            </View>
-                        </GradientCard>
+                        {isOnchain ? (
+                            // The same Bitcoin visual the on-chain broadcast
+                            // screen uses. A Lightning bolt over an on-chain
+                            // deposit is not a styling detail: it tells the
+                            // user the wrong thing about what just happened
+                            // and about how soon they can use it.
+                            <ImageBackground
+                                source={BitcoinTower}
+                                style={styles.image}
+                                resizeMode="contain"
+                            >
+                                <Image
+                                    source={Bitcoin}
+                                    // Matches TransactionBroadCast's `bitcoin`
+                                    // style, which the shared Transaction
+                                    // stylesheet does not carry.
+                                    style={{
+                                        width: 60,
+                                        height: 60,
+                                        marginTop: 60,
+                                        justifyContent: 'center',
+                                        alignSelf: 'center',
+                                        position: 'absolute',
+                                    }}
+                                    resizeMode="contain"
+                                />
+                            </ImageBackground>
+                        ) : (
+                            <GradientCard
+                                style={styles.gradient}
+                                linearStyle={styles.gradient}
+                                colors_={[colors.ark.gradient1, colors.ark.gradient2]}
+                            >
+                                <View style={styles.inner}>
+                                    <GradientCard
+                                        style={styles.gradientInner}
+                                        linearStyle={styles.gradientInner}
+                                        colors_={[colors.ark.gradient1, colors.ark.gradient2]}
+                                    >
+                                        <View style={styles.inside}>
+                                            <Image
+                                                source={Electrik}
+                                                style={styles.image}
+                                                resizeMode="contain"
+                                            />
+                                        </View>
+                                    </GradientCard>
+                                </View>
+                            </GradientCard>
+                        )}
                     </View>
                 )}
 
@@ -142,7 +206,7 @@ export default function ArkSendSuccessScreen({ route }: Props) {
                 {response && (
                     <>
                         <Text semibold center style={styles.text}>
-                            Lightning Network
+                            {networkLabel}
                         </Text>
                         {/* White button → black label for contrast (the
                             white-on-white trap the rest of the Ark UI hit). */}

--- a/src/screens/ColdStorage/index.tsx
+++ b/src/screens/ColdStorage/index.tsx
@@ -97,6 +97,23 @@ export default function ColdStorage({ route, navigation }: Props) {
     const [satsEditable, setSatsEditable] = useState(false);
     const fUtxo = utxo.filter(({ txid, vout }) => ids.includes(`${txid}:${vout}`));
     const balance = fUtxo ? fUtxo.reduce((prev, curr) => prev + curr.value, 0) : wallet?.getBalance();
+    // The capsules the user picked, and the ONLY coins this screen may spend.
+    //
+    // Selecting capsules is mandatory in Cypher Box: you cannot send from a
+    // vault without choosing coins first. Every entry point into this screen
+    // passes both `utxo` and `ids`, and Capsules gates each of its four send
+    // paths on `ids.length > 0`. So `fUtxo` is always the full picture of what
+    // the user chose.
+    //
+    // Previously the unfiltered `utxo` was handed to createTransaction, so
+    // coinselect (which sorts descending and takes the largest) spent whatever
+    // coin it liked, and the change figure on the confirm screen, derived from
+    // the selection, could be wrong by orders of magnitude.
+    //
+    // There is deliberately NO whole-wallet fallback here. If the selection is
+    // ever empty that is a bug in the caller, and quietly spending the rest of
+    // the vault is the worst available response to it.
+    const selectedUtxo = fUtxo;
     const allBalance = formatBalanceWithoutSuffix(balance, BitcoinUnit.BTC, true);
     const balanceWallet = !wallet?.hideBalance && formatBalance(Number(wallet?.getBalance()), wallet?.getPreferredBalanceUnit(), true);
     const balanceWithoutSuffix = !wallet?.hideBalance && formatBalanceWithoutSuffix(Number(wallet?.getBalance()), wallet?.getPreferredBalanceUnit(), true);
@@ -306,7 +323,10 @@ export default function ColdStorage({ route, navigation }: Props) {
       const fees = networkTransactionFees;
       const change = getChangeAddressFast();
       const requestedSatPerByte = Number(feeRate);
-      const lutxo = utxo || wallet.getUtxo();
+      // Estimate against the SAME inputs the send will really use, otherwise the
+      // quoted fee is for a different transaction than the one built below.
+      if (!selectedUtxo || selectedUtxo.length === 0) return; // nothing selected: nothing to quote
+      const lutxo = selectedUtxo;
       let frozen = 0;
       if (!utxo) {
         // if utxo is not limited search for frozen outputs and calc it's balance
@@ -546,7 +566,16 @@ export default function ColdStorage({ route, navigation }: Props) {
             ? changeDepositAddress
             : await getChangeAddressAsync();
         const requestedSatPerByte = Number(feeRate);
-        const lutxo = utxo || wallet.getUtxo();
+        // Spend the capsules the user selected, and only those. See the note on
+        // `selectedUtxo` above for why there is no whole-wallet fallback.
+        const lutxo = selectedUtxo;
+        if (!lutxo || lutxo.length === 0) {
+            Alert.alert(
+                'No capsules selected',
+                'Go back and choose which capsules to spend before sending.',
+            );
+            return;
+        }
         console.log({ requestedSatPerByte, lutxo: lutxo.length });
 
         const targets = [];

--- a/src/screens/ColdStorage/index.tsx
+++ b/src/screens/ColdStorage/index.tsx
@@ -9,6 +9,7 @@ import { ScreenLayout, Text } from "@Cypher/component-library";
 import { GradientView, SavingVault, VaultCapsules } from "@Cypher/components";
 import { colors } from "@Cypher/style-guide";
 import { dispatchNavigate } from "@Cypher/helpers";
+import { selectCapsules } from "@Cypher/helpers/capsuleSelection";
 import { isCoinosAllowed } from "@Cypher/services/featureFlags";
 import Clipboard from '@react-native-clipboard/clipboard'
 import loc, { formatBalance, formatBalanceWithoutSuffix } from "../../../loc";
@@ -95,7 +96,7 @@ export default function ColdStorage({ route, navigation }: Props) {
     const [feeUSD, setFeeUSD] = useState(1);
     const [feesEditable, setFeesEditable] = useState(false);
     const [satsEditable, setSatsEditable] = useState(false);
-    const fUtxo = utxo.filter(({ txid, vout }) => ids.includes(`${txid}:${vout}`));
+    const fUtxo = selectCapsules(utxo, ids);
     const balance = fUtxo ? fUtxo.reduce((prev, curr) => prev + curr.value, 0) : wallet?.getBalance();
     // The capsules the user picked, and the ONLY coins this screen may spend.
     //

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -124,18 +124,37 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
     if (selectedItem === 5) {
       let mounted = true;
       void (async () => {
-        try {
-          const [arkAddr, onchainAddr] = await Promise.all([
-            getArkAddress(),
-            getArkOnchainAddress(),
-          ]);
-          if (!mounted) return;
-          setArkAddress(arkAddr);
-          setArkOnchainAddress(onchainAddr);
-        } catch (err) {
-          if (!mounted) return;
-          console.warn('[Receive] Ark address fetch failed:', err);
-          SimpleToast.show('Failed to fetch Ark addresses', SimpleToast.SHORT);
+        // allSettled, NOT all. These are independent: the Ark address needs
+        // the Ark wallet, the on-chain address is a local BDK call. Promise.all
+        // discarded BOTH when either failed, so a locked wallet threw away a
+        // perfectly good on-chain address and left the sheet spinning on null
+        // state. That is how funding an exit became impossible: the on-chain
+        // address is the ASP-independent way in, and it was collateral damage
+        // from the Ark address failing.
+        const [arkRes, onchainRes] = await Promise.allSettled([
+          getArkAddress(),
+          getArkOnchainAddress(),
+        ]);
+        if (!mounted) return;
+        if (arkRes.status === 'fulfilled') setArkAddress(arkRes.value);
+        if (onchainRes.status === 'fulfilled') setArkOnchainAddress(onchainRes.value);
+
+        if (arkRes.status === 'rejected' || onchainRes.status === 'rejected') {
+          const reason = (arkRes.status === 'rejected' ? arkRes.reason : null)
+            ?? (onchainRes.status === 'rejected' ? onchainRes.reason : null);
+          console.warn('[Receive] Ark address fetch failed:', reason);
+          // Name the actual cause. "Failed to fetch Ark addresses" next to a
+          // spinner that never stops tells the user nothing they can act on,
+          // and the usual cause is simply that the wallet is not open yet.
+          const locked = /not initialized|not ready|no wallet/i.test(
+            String((reason as Error)?.message ?? reason ?? ''),
+          );
+          SimpleToast.show(
+            locked
+              ? 'Bark vault is locked. Open the vault first, then try again.'
+              : 'Could not fetch an address. Pull to retry.',
+            SimpleToast.LONG,
+          );
         }
       })();
       return () => {

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -1,7 +1,7 @@
 import { ArkWallet, CircularView, CoinosWallet, GradientButtonWithShadow, StrikeDollarWallet, StrikeWallet } from "@Cypher/components";
 import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
-import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound } from "@Cypher/services/ark";
+import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";
@@ -138,7 +138,10 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         let minBlocks = Infinity;
         for (const v of arkVtxos) {
             if (v.expiryHeight === 0) continue;
-            if (v.state.toLowerCase() === 'locked') continue;
+            // Mid-round VTXOs carry their PRE-refresh expiry, so counting them
+            // shows an alarming "expires soon" while a refresh is already in
+            // flight extending it. Locked alone missed delegated refreshes.
+            if (isVtxoMidRound(v, arkRefreshingVtxoIds)) continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
             // Skip already-expired VTXOs (they stay in the store so the
             // Capsules tab can render them) — "refresh soon" is wrong
@@ -178,21 +181,16 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         return count;
     }, [arkVtxos, arkChainTipHeight, arkRefreshingVtxoIds]);
 
-    // VTXOs currently mid-round (state === 'locked' — refresh / send / board
-    // in flight). The headline balance EXCLUDES these (only spendable
-    // capsules count), so without surfacing this the user sees their
-    // balance drop with no explanation while a refresh is in progress.
-    const pendingRound = useMemo(() => {
-        if (!arkVtxos) return { count: 0, sats: 0 };
-        let count = 0;
-        let sats = 0;
-        for (const v of arkVtxos) {
-            if (v.state.toLowerCase() !== 'locked') continue;
-            count++;
-            sats += v.sats;
-        }
-        return { count, sats };
-    }, [arkVtxos]);
+    // VTXOs currently mid-round (refresh / send / board in flight). The
+    // headline balance EXCLUDES these (only spendable capsules count), so
+    // without surfacing this the user sees their balance drop with no
+    // explanation while a refresh is in progress. Testing `Locked` alone
+    // reintroduced exactly that symptom for delegated refreshes, which leave
+    // the VTXO Spendable. See isVtxoMidRound.
+    const pendingRound = useMemo(
+        () => sumMidRoundVtxos(arkVtxos, arkRefreshingVtxoIds),
+        [arkVtxos, arkRefreshingVtxoIds],
+    );
 
     /**
      * Unified status line for the shared Send/Receive row's status slot.

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -1,7 +1,7 @@
 import { ArkWallet, CircularView, CoinosWallet, GradientButtonWithShadow, StrikeDollarWallet, StrikeWallet } from "@Cypher/components";
 import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
-import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound } from "@Cypher/services/ark";
+import { ARK_REFRESH_MIN_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";
@@ -154,28 +154,40 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`
         : null;
 
-    // Count of dust capsules (≤ ARK_VTXO_DUST_SATS = 330 sats) that are
-    // still spendable and haven't expired. These can't be refreshed
-    // individually (refresh fee > capsule value) — only batch refresh on
-    // the Capsules tab consolidates them into above-dust outputs.
-    const dustCapsuleCount = useMemo(() => {
-        if (!arkVtxos || arkChainTipHeight == null) return 0;
+    // Dust capsules: below the PER-INPUT refresh floor (ARK_REFRESH_MIN_SATS,
+    // 500 sats), still spendable, not expired, not already mid-sweep. Below
+    // that floor a capsule cannot join a round on its own; it can only be
+    // folded into a dust-only delegated batch, or spent. Returns the total too,
+    // because whether batching produces a HEALTHY capsule or just a smaller
+    // dust one depends on the sum, and the two cases need different advice.
+    const dustCapsules = useMemo(() => {
+        if (!arkVtxos || arkChainTipHeight == null) return { count: 0, sats: 0 };
         // bark 0.6.1 keeps a delegated-refreshing VTXO Spendable (not Locked),
         // so a dust capsule mid-sweep still looks spendable here. Exclude the
         // client-tracked refreshing set so the "needs action" dust warning
         // doesn't fire on capsules that are already being consolidated.
         const refreshing = new Set(arkRefreshingVtxoIds ?? []);
         let count = 0;
+        let sats = 0;
         for (const v of arkVtxos) {
-            if (v.sats > ARK_VTXO_DUST_SATS) continue;
+            // ARK_REFRESH_MIN_SATS (500), not ARK_VTXO_DUST_SATS (330). The
+            // refresh floor is what decides whether a capsule can be rescued on
+            // its own, and it is PER INPUT: below it, a capsule cannot join a
+            // round and can only be swept as part of a dust-only delegated
+            // batch, or spent. The Capsules tab already draws the line there
+            // (see strandedDust), so counting at 330 here left a whole band
+            // invisible on Home. Observed on device 2026-08-20: two 400 sat
+            // capsules on a 1d 21h fuse, flagged in Capsules, silent on Home.
+            if (v.sats >= ARK_REFRESH_MIN_SATS) continue;
             if (v.state.toLowerCase() !== 'spendable') continue;
             if (v.expiryHeight === 0) continue;
             if (refreshing.has(v.id)) continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
             if (blocks <= 0) continue;
             count++;
+            sats += v.sats;
         }
-        return count;
+        return { count, sats };
     }, [arkVtxos, arkChainTipHeight, arkRefreshingVtxoIds]);
 
     // VTXOs currently mid-round (state === 'locked' — refresh / send / board
@@ -264,7 +276,21 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
             }
         }
 
-        if (dustCapsuleCount > 0) {
+        if (dustCapsules.count > 0) {
+            // Two different situations, and only one of them has a clean fix.
+            // When the dust TOTAL clears the refresh floor, a dust-only
+            // delegated batch folds them into one healthy capsule for about a
+            // sat, which resets both the value problem and the expiry clock.
+            // Below that, batching still reduces the capsule count but the
+            // result is itself dust, so spending is the honest advice.
+            if (dustCapsules.sats >= ARK_REFRESH_MIN_SATS) {
+                return {
+                    text: 'You have dust Bark capsules above 500 sats, tap here to batch refresh',
+                    linkText: 'here',
+                    tapTab: 0, // Capsules tab
+                    error: true,
+                };
+            }
             return {
                 text: 'Attention: you have dust ark capsules that might expire. Batch refresh or spend them here.',
                 linkText: 'here',
@@ -298,7 +324,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         return null;
     }, [
         expiryWarning,
-        dustCapsuleCount,
+        dustCapsules,
         notificationsEnabled,
         arkIosBackupReminderActive,
         pendingRound,

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -1,7 +1,7 @@
 import { ArkWallet, CircularView, CoinosWallet, GradientButtonWithShadow, StrikeDollarWallet, StrikeWallet } from "@Cypher/components";
 import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
-import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, sumMidRoundVtxos } from "@Cypher/services/ark";
+import { ARK_VTXO_DUST_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, isVtxoMidRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";

--- a/src/screens/RecoverSavingVault/index.tsx
+++ b/src/screens/RecoverSavingVault/index.tsx
@@ -14,7 +14,6 @@ import {
     listHotVaultKeychainBackupsWithMeta,
     resetHotVaultBackupFully,
     HotVaultBackupSummary,
-    HotVaultMeta,
 } from '@Cypher/services/hotVaultKeychain';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 
@@ -88,7 +87,7 @@ export default function RecoverSavingVault({ route }: Props) {
             setKeychainBackups(summaries);
             if (summaries.length === 1 && !autoAttempted.current) {
                 autoAttempted.current = true;
-                handleKeychainRecover(summaries[0].walletID, summaries[0].meta);
+                handleKeychainRecover(summaries[0].walletID);
             }
         })();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -173,18 +172,17 @@ export default function RecoverSavingVault({ route }: Props) {
             w.setPassphrase(passphrase);
         }
         const id = w.getID();
-        // Keychain path verification: the words came from OUR OWN Keychain
-        // entry, whose walletID was derived from words+passphrase at save
-        // time. A mismatch here can only mean the passphrase is wrong,
-        // missing, or extra — importing anyway would surface an empty
-        // stranger wallet and read as "my funds are gone". Hard stop.
-        if (restoredWalletID && restoredWalletID !== id) {
-            Alert.alert(
-                'Passphrase mismatch',
-                'The recovered words are correct, but the passphrase does not match this vault. Check the passphrase (it is case-sensitive and spaces count) and try again. Nothing was imported.',
-            );
-            return;
-        }
+        // NO mismatch alert. The sidecar's walletID was derived from
+        // words+passphrase at save time, so a passphrase-free keychain import
+        // legitimately produces a different id. This used to hard-stop with
+        // "the passphrase does not match this vault", which told anyone holding
+        // the phone that a hidden wallet existed — the exact thing a BIP39
+        // passphrase is meant to conceal.
+        //
+        // A differing id is now simply the decoy, imported in silence. The
+        // `restoredWalletID === id` check below still runs, so the "backed up
+        // to Keychain" marker is only ever set on a vault that genuinely owns
+        // that keychain entry.
         setWalletID(id);
         if (restoredWalletID && restoredWalletID === id) {
             setHotVaultKeychainBackup(id, true);
@@ -232,10 +230,10 @@ export default function RecoverSavingVault({ route }: Props) {
      * onWallet callback rehydrate the zustand "backed up" flag so the
      * Settings UI stays in sync post-recovery.
      */
-    const handleKeychainRecover = async (
-        walletID: string,
-        knownMeta?: HotVaultMeta | null,
-    ) => {
+    // No `knownMeta` parameter by design: this flow must not be able to read
+    // the sidecar's passphrase state, because acting on it is what leaked the
+    // existence of a hidden wallet. The words are all it needs.
+    const handleKeychainRecover = async (walletID: string) => {
         if (keychainLoading || loading) return;
         setKeychainLoading(true);
         const result = await getHotVaultSeedFromKeychain(walletID);
@@ -252,37 +250,29 @@ export default function RecoverSavingVault({ route }: Props) {
             // therefore an HDSegwitBech32Wallet. Saves 3–8s of perceived
             // latency compared to the generic handleImport path.
             //
-            // Passphrase vaults: the Keychain holds the words only (the
-            // passphrase is deliberately never stored), so the meta flag
-            // routes through a secure prompt first. fastImportHotVault's
-            // walletID check then verifies the entered passphrase actually
-            // reproduces this vault. iOS-only Alert.prompt is fine here —
-            // the iPhone Keychain flow is an iOS-only feature.
-            // Prefer the meta the caller passed in. The single-backup
-            // auto-recover fires from the mount effect immediately after
-            // setKeychainBackups(), so reading `keychainBackups` state here
-            // would see the stale pre-commit [] and miss hasPassphrase. The
-            // state lookup is only a fallback for callers that don't thread it.
-            const meta =
-                knownMeta !== undefined
-                    ? knownMeta
-                    : keychainBackups.find(s => s.walletID === walletID)?.meta;
-            if (meta?.hasPassphrase) {
-                Alert.prompt(
-                    'Vault passphrase',
-                    'This vault is passphrase-protected. Enter the passphrase to finish recovery.',
-                    [
-                        { text: 'Cancel', style: 'cancel' },
-                        {
-                            text: 'Recover',
-                            onPress: (text?: string) =>
-                                fastImportHotVault(result.mnemonic, walletID, text || ''),
-                        },
-                    ],
-                    'secure-text',
-                );
-                return;
-            }
+            // PASSPHRASE-AGNOSTIC BY DESIGN. This path imports the words with
+            // no passphrase and says nothing about whether one exists.
+            //
+            // A BIP39 passphrase is a deniability tool: under duress you hand
+            // over twelve words and the wallet they open is the only wallet
+            // anyone can see. This flow used to break that. It read a
+            // `hasPassphrase` flag from the keychain sidecar and, when set,
+            // announced "This vault is passphrase-protected" before prompting.
+            // Anyone holding the unlocked phone (which, under duress, is the
+            // whole premise) learned a hidden wallet existed. Clearing the flag
+            // did not help either: the sidecar's walletID was derived WITH the
+            // passphrase, so a passphrase-free import mismatched and the guard
+            // in fastImportHotVault said "the passphrase does not match this
+            // vault" instead. Both branches leaked.
+            //
+            // So: no prompt, no mismatch alert, no flag. The decoy opens
+            // silently, exactly as typing the words by hand would. Reaching the
+            // real vault means adding the passphrase on the manual recovery
+            // path below, which is where the toggle already lives.
+            //
+            // The cost, accepted deliberately: a passphrase user who taps this
+            // lands in their decoy with no explanation. Explaining it is the
+            // leak, so there is nothing to say here.
             fastImportHotVault(result.mnemonic, walletID);
             return;
         }
@@ -452,7 +442,7 @@ export default function RecoverSavingVault({ route }: Props) {
                             <TouchableOpacity
                                 key={walletID}
                                 style={styles.keychainButton}
-                                onPress={() => handleKeychainRecover(walletID, meta)}
+                                onPress={() => handleKeychainRecover(walletID)}
                                 disabled={keychainLoading || loading}
                                 activeOpacity={0.8}
                             >
@@ -475,7 +465,7 @@ export default function RecoverSavingVault({ route }: Props) {
                         <View key={walletID} style={styles.keychainRowWrap}>
                             <TouchableOpacity
                                 style={styles.keychainRow}
-                                onPress={() => handleKeychainRecover(walletID, meta)}
+                                onPress={() => handleKeychainRecover(walletID)}
                                 disabled={
                                     isBusyOther ||
                                     isDeleting ||

--- a/src/screens/ReviewWithdrawal/index.tsx
+++ b/src/screens/ReviewWithdrawal/index.tsx
@@ -4,6 +4,10 @@ import SimpleToast from 'react-native-simple-toast';
 import { Icon } from 'react-native-elements';
 import ReactNativeModal from 'react-native-modal';
 import styles from './styles';
+import {
+    findRecentMatchingWithdrawal,
+    isCoinosWithdrawIndeterminate,
+} from '@Cypher/services/coinos/withdrawGuard';
 import { Input, LoadingSpinner, ScreenLayout, Text } from '@Cypher/component-library';
 import { CoinOSSmall, ProgressBar2 } from '@Cypher/assets/images';
 import {
@@ -26,6 +30,7 @@ import {
     bitcoinSendFee,
     getCurrencyRates,
     getMe,
+    getTransactionHistory,
     sendBitcoinPayment,
     sendCoinsViaUsername,
     sendLightningPayment,
@@ -58,6 +63,14 @@ export default function ReviewWithdrawal({ route }: Props) {
     const [isStartLoading, setIsStartLoading] = useState(false);
     const [selectedFee, setSelectedFee] = useState<number | null>(null);
     const [selectedFeeName, setSelectedFeeName] = useState<string>('Select Fee');
+    // Latched once a withdrawal's outcome becomes UNKNOWN. Never cleared on
+    // this screen: the whole point is that it must not offer to send again.
+    const [sendIndeterminate, setSendIndeterminate] = useState(false);
+    // Stable per mount, so a retry of the SAME intended withdrawal carries the
+    // same key rather than looking like a fresh request.
+    const withdrawIdempotencyKey = useRef(
+        `cbx-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+    );
     const [estimatedFee, setEstimatedFee] = useState<number>(0);
     const [networkFee, setNetworkFee] = useState<number>(0);
     const [bamskiiFee, setBamskiiFee] = useState<number>(0);
@@ -263,7 +276,42 @@ export default function ReviewWithdrawal({ route }: Props) {
 
             console.log('selectedFee: ', selectedFee);
             try {
-                const sendResponse = await sendBitcoinPayment(remainingAmount, to, selectedFee, note);
+                // Pre-flight duplicate check. If a previous attempt reached
+                // CoinOS and only its reply was lost, the withdrawal is already
+                // in the history and sending again pays twice. Checking costs
+                // one request and is the only protection that does not depend
+                // on CoinOS honouring an idempotency key.
+                //
+                // A failed check must NOT block the send: being unable to read
+                // history is not evidence of a duplicate, and refusing here
+                // would strand the user.
+                try {
+                    const recent = await getTransactionHistory(0, 20);
+                    const dupe = findRecentMatchingWithdrawal(recent?.payments, {
+                        address: to,
+                        amountSats: remainingAmount,
+                        now: Date.now(),
+                    });
+                    if (dupe) {
+                        setSendIndeterminate(true);
+                        SimpleToast.show(
+                            'This withdrawal already went out a moment ago. Check your history rather than sending again.',
+                            SimpleToast.LONG,
+                        );
+                        setIsSendLoading(false);
+                        return;
+                    }
+                } catch (histErr) {
+                    console.warn('[CoinOS] duplicate pre-check failed, continuing:', histErr);
+                }
+
+                const sendResponse = await sendBitcoinPayment(
+                    remainingAmount,
+                    to,
+                    selectedFee,
+                    note,
+                    withdrawIdempotencyKey.current,
+                );
 
                 let jsonSend = null;
                 console.log('sendResponse: ', sendResponse);
@@ -281,7 +329,19 @@ export default function ReviewWithdrawal({ route }: Props) {
                 }
             } catch (error) {
                 console.error('Error Send to bitcoin:', error);
-                SimpleToast.show('Failed to Send to bitcoin. Please try again.', SimpleToast.SHORT);
+                if (isCoinosWithdrawIndeterminate(error)) {
+                    // Outcome UNKNOWN. Never say it failed and never invite a
+                    // retry: the old copy here was literally "Please try again",
+                    // and following it sends the money a second time.
+                    setSendIndeterminate(true);
+                    SimpleToast.show(
+                        (error as Error)?.message ??
+                            'This withdrawal may already have been sent. Check your history before trying again.',
+                        SimpleToast.LONG,
+                    );
+                } else {
+                    SimpleToast.show('Failed to Send to bitcoin. Please try again.', SimpleToast.SHORT);
+                }
             } finally {
                 setIsSendLoading(false);
             }
@@ -557,7 +617,7 @@ export default function ReviewWithdrawal({ route }: Props) {
                 </GradientCard>
             </View>
             <View style={styles.container}>
-                <SwipeButton ref={swipeButtonRef} onToggle={handleToggle} isLoading={isSendLoading} />
+                <SwipeButton ref={swipeButtonRef} onToggle={handleToggle} isLoading={isSendLoading || sendIndeterminate} />
                 {/* <GradientButton style={styles.invoiceButton} texStyle={{ fontFamily: 'Lato-Medium', }} title="Send" onPress={sendClickHandler} /> */}
             </View>
         </ScreenLayout>

--- a/src/screens/SavingVault/index.tsx
+++ b/src/screens/SavingVault/index.tsx
@@ -84,10 +84,12 @@ export default function SavingVault() {
                     mnemonic,
                     {
                         createdAt: Date.now(),
-                        // Keychain stores the words only; this flag makes the
-                        // recovery flow prompt for the (never-stored)
-                        // passphrase after the biometric read.
-                        hasPassphrase: !!wallet?.getPassphrase?.(),
+                        // No passphrase flag. Recording whether this vault has a
+                        // passphrase is what let the recovery flow announce a
+                        // hidden wallet exists, defeating the point of having
+                        // one. Keychain recovery is passphrase-agnostic now: it
+                        // opens the words as-is and stays silent. See
+                        // HotVaultMeta in services/hotVaultKeychain.
                     },
                 );
                 if (result.ok) {

--- a/src/screens/Strike/CheckingAccountNew/Account.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Account.tsx
@@ -10,7 +10,7 @@ import useAuthStore from "@Cypher/stores/authStore";
 import { ArkSettingsBody } from "./Settings";
 
 import { btc } from "@Cypher/helpers/coinosHelper";
-import { blocksToDays } from "@Cypher/services/ark";
+import { blocksToDays, isVtxoMidRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import { getCapsuleColorBand } from "@Cypher/helpers/arkCapsuleColor";
 
 interface AccountProps {
@@ -31,6 +31,10 @@ export default function Account({ matchedRate, currency, receiveType, balance, c
     reserveArkAmount,
   } = useAuthStore();
   const arkVtxos = useAuthStore((s) => s.arkVtxos);
+  // Needed because a delegated refresh leaves the VTXO `Spendable`: without
+  // this the counts below read zero for the whole round and this card
+  // contradicts the home card it was written to mirror.
+  const arkRefreshingVtxoIds = useAuthStore((s) => s.arkRefreshingVtxoIds);
   const navigation = useNavigation();
 
   // Mirror ArkWallet's pendingRound derivation so the in-tab Ark Card
@@ -39,20 +43,12 @@ export default function Account({ matchedRate, currency, receiveType, balance, c
   // this, the Vault menu's Ark Card would display "0 sats ~ $0.00"
   // whenever the homescreen card was correctly showing a refresh in
   // flight, contradicting the home view.
-  const pendingRoundSats = useMemo(
-    () => arkVtxos.reduce(
-      (sum, v) => (v.state.toLowerCase() === 'locked' ? sum + v.sats : sum),
-      0,
-    ),
-    [arkVtxos],
+  const midRound = useMemo(
+    () => sumMidRoundVtxos(arkVtxos, arkRefreshingVtxoIds),
+    [arkVtxos, arkRefreshingVtxoIds],
   );
-  const pendingRoundCount = useMemo(
-    () => arkVtxos.reduce(
-      (n, v) => (v.state.toLowerCase() === 'locked' ? n + 1 : n),
-      0,
-    ),
-    [arkVtxos],
-  );
+  const pendingRoundSats = midRound.sats;
+  const pendingRoundCount = midRound.count;
 
   // Same per-VTXO capsule-slot data as the homescreen ArkWallet card —
   // see ArkWallet/index.tsx for the rationale. Kept in sync visually so
@@ -68,13 +64,13 @@ export default function Account({ matchedRate, currency, receiveType, balance, c
           : 30;
         return {
           color: getCapsuleColorBand(daysLeft).color,
-          refreshing: v.state.toLowerCase() === 'locked',
+          refreshing: isVtxoMidRound(v, arkRefreshingVtxoIds),
           daysLeft,
         };
       })
       .sort((a, b) => a.daysLeft - b.daysLeft)
       .map(({ color, refreshing }) => ({ color, refreshing }));
-  }, [arkVtxos, arkChainTipHeight]);
+  }, [arkVtxos, arkChainTipHeight, arkRefreshingVtxoIds]);
 
   const handleCoinosLogout = () => {
     clearAuth();

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -23,6 +23,7 @@ import {
     fetchArkVtxos,
     getArkCancelling,
     getArkWalletHandle,
+    isVtxoMidRound,
     ArkRefreshInFlightError,
     refreshArkVtxosDelegatedAndSync,
     restoreArkWalletFromDisk,
@@ -1269,9 +1270,9 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             const stateLower = v.state.toLowerCase();
             const kindLower = v.kind.toLowerCase();
             // bark 0.6.0: a mid-refresh VTXO stays `Spendable` (not `Locked`),
-            // so drive the "Refreshing…" row treatment off the client-tracked
-            // ids too (see authStore arkRefreshingVtxoIds).
-            const pendingRound = stateLower === "locked" || refreshingSet.has(v.id);
+            // so the "Refreshing…" row treatment is driven off the client-
+            // tracked ids too (see isVtxoMidRound).
+            const pendingRound = isVtxoMidRound(v, refreshingSet);
 
             // Tri-state recoverability — see VtxoRowData.recoverability
             // for the full reasoning. Quick summary: a Pubkey/Spendable
@@ -1884,7 +1885,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         // Exiting VTXOs excluded for the same reason as the tap-refresh
         // batch above: the exit owns them.
         const projected = freshVtxos.filter((v) => !v.exiting).map((v) => {
-            const pending = v.state.toLowerCase() === 'locked';
+            // Union, not Locked alone: a delegated round leaves the VTXO
+            // Spendable. Matches the row derivation above.
+            const pending = isVtxoMidRound(
+                v,
+                useAuthStore.getState().arkRefreshingVtxoIds ?? [],
+            );
             if (v.expiryHeight === 0 || freshTip === null) {
                 return {
                     id: v.id,

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1026,6 +1026,13 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     };
   }, [exitFundingOpen]);
 
+  // Convert is unavailable mid-exit (cooperative offboard, ASP-gated), and its
+  // tab button disappears. If that was the selected tab the sheet would render
+  // nothing at all, so fall back to the path that always works.
+  useEffect(() => {
+    if (arkExitInProgress && fundingTab === 'convert') setFundingTab('receive');
+  }, [arkExitInProgress, fundingTab]);
+
   // Debounced fee estimate for the CONVERT tab. Skipped when the ASP is known
   // unreachable (the offboard would fail) or the amount is empty/invalid.
   useEffect(() => {
@@ -1926,6 +1933,38 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 Started {new Date(arkExitStartedAt).toLocaleString()}. Funds sweep to the destination when the timelock expires; the vault stays afterwards.
               </Text>
             )}
+
+            {/* FEE RESERVE, DURING THE EXIT.
+                Previously this whole section was replaced by the panel above,
+                so the one moment the reserve matters most was the one moment
+                the user could neither see it nor top it up. Worse, the panel
+                promises funds sweep automatically while removing the means to
+                make that true: every exit branch needs a CPFP broadcast and
+                every claim needs a fee, and running dry strands capsules
+                mid-exit until someone tops up.
+                Observed live 2026-08-18 on a five-capsule exit that ran out at
+                699 sats with four claims still owed.
+                The receive path is ASP-independent, so it works during an
+                outage, which is exactly when an exit is running. */}
+            <View style={{ marginTop: 14, paddingTop: 12, borderTopWidth: 1, borderTopColor: '#2A2A2A' }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text style={{ fontSize: 12, color: '#AAA' }}>Fee reserve on-chain</Text>
+                <Text bold style={{ fontSize: 13, color: onchainReserveSats > 0 ? colors.green : '#FFD54F' }}>
+                  {onchainReserveSats.toLocaleString()} sats
+                </Text>
+              </View>
+              <Text style={{ fontSize: 11, color: '#777', marginTop: 6, lineHeight: 15 }}>
+                Pays the miner fees for each capsule's exit and claim. If it runs
+                out, the remaining capsules wait until you top it up.
+              </Text>
+              <TouchableOpacity
+                onPress={() => setExitFundingOpen(true)}
+                activeOpacity={0.7}
+                style={{ marginTop: 10, paddingVertical: 10, borderRadius: 10, alignItems: 'center', backgroundColor: 'rgba(255,255,255,0.08)' }}
+              >
+                <Text bold style={{ fontSize: 13, color: '#FFF' }}>Top up exit fees</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         ) : (
           <>
@@ -2478,7 +2517,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
 
               {/* Tab switch */}
               <View style={{ flexDirection: 'row', marginBottom: 14, borderRadius: 10, backgroundColor: '#222', padding: 3 }}>
-                {(['receive', 'wallet', 'convert'] as const).map((tab) => {
+                {((arkExitInProgress
+                  ? (['receive', 'wallet'] as const)
+                  : (['receive', 'wallet', 'convert'] as const)) as readonly ('receive' | 'wallet' | 'convert')[]).map((tab) => {
                   const active = fundingTab === tab;
                   return (
                     <TouchableOpacity

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -3,7 +3,7 @@ import QRCode from "react-native-qrcode-svg";
 
 import { Copy, StrikeFull } from "@Cypher/assets/images";
 import { GradientSwitch, Text } from "@Cypher/component-library";
-import { GradientView } from "@Cypher/components";
+import { ExitFundingSourceList, GradientView } from "@Cypher/components";
 import useAuthStore from "@Cypher/stores/authStore";
 import { colors, widths } from "@Cypher/style-guide";
 import React, { useContext, useEffect, useState } from "react";
@@ -57,6 +57,7 @@ import {
   startArkEmergencyExit,
   writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
+  buildExitFundingSources,
 } from "@Cypher/services/ark";
 import type { ExitFeeConvertEstimate } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
@@ -338,6 +339,8 @@ export default function Settings({ receiveType, currency, isArk }: Props) {
 export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'actions' }) {
   const {
     clearArkAuth,
+    isAuth,
+    isStrikeAuth,
     walletID,
     coldStorageWalletID,
     arkBalanceDetail,
@@ -901,7 +904,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   // `null` while the first computation is in flight.
   const [recommendedReserveSats, setRecommendedReserveSats] = useState<number | null>(null);
   const [exitFundingOpen, setExitFundingOpen] = useState(false);
-  const [fundingTab, setFundingTab] = useState<'receive' | 'convert'>('receive');
+  const [fundingTab, setFundingTab] = useState<'receive' | 'wallet' | 'convert'>('receive');
   const [onchainFundAddr, setOnchainFundAddr] = useState<string | null>(null);
   // ASP reachability for the CONVERT (cooperative-offboard) tab. null = probing.
   const [aspReachable, setAspReachable] = useState<boolean | null>(null);
@@ -2475,7 +2478,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
 
               {/* Tab switch */}
               <View style={{ flexDirection: 'row', marginBottom: 14, borderRadius: 10, backgroundColor: '#222', padding: 3 }}>
-                {(['receive', 'convert'] as const).map((tab) => {
+                {(['receive', 'wallet', 'convert'] as const).map((tab) => {
                   const active = fundingTab === tab;
                   return (
                     <TouchableOpacity
@@ -2484,7 +2487,11 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                       style={{ flex: 1, paddingVertical: 8, borderRadius: 8, alignItems: 'center', backgroundColor: active ? (colors.ark?.light ?? colors.pink.default) : 'transparent' }}
                     >
                       <Text bold style={{ fontSize: 12, color: active ? '#1C1C1C' : '#AAA' }}>
-                        {tab === 'receive' ? 'Receive Bitcoin' : 'Convert from balance'}
+                        {tab === 'receive'
+                          ? 'Receive Bitcoin'
+                          : tab === 'wallet'
+                            ? 'From a wallet'
+                            : 'Convert from balance'}
                       </Text>
                     </TouchableOpacity>
                   );
@@ -2523,6 +2530,47 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   ) : (
                     <ActivityIndicator color={colors.ark?.light ?? colors.pink.default} style={{ marginVertical: 24 }} />
                   )}
+                </>
+              )}
+
+              {fundingTab === 'wallet' && (
+                <>
+                  <Text style={{ fontSize: 12, color: '#CCC', marginBottom: 12, lineHeight: 17 }}>
+                    Send {exitFeeShortfallSats.toLocaleString()} sats on-chain from one of your
+                    wallets. The address is filled in for you.
+                  </Text>
+                  {/* Sources that cannot be used are listed too, dimmed and with
+                      a reason. Hiding them makes the feature look broken to
+                      someone expecting their wallet to appear. */}
+                  <ExitFundingSourceList
+                    shortfallSats={exitFeeShortfallSats}
+                    sources={buildExitFundingSources({
+                      coinos: { connected: !!isAuth },
+                      strike: { connected: !!isStrikeAuth },
+                      hotVault: { walletID: walletID ?? null },
+                      coldVault: { walletID: coldStorageWalletID ?? null },
+                      shortfallSats: exitFeeShortfallSats,
+                    })}
+                    onSelect={(id) => {
+                      // Only CoinOS has a provider today. The others stay in the
+                      // list so the roadmap is visible, but must not pretend to
+                      // work.
+                      if (id !== 'coinos') {
+                        SimpleToast.show('Coming soon for this wallet', SimpleToast.SHORT);
+                        return;
+                      }
+                      setExitFundingOpen(false);
+                      (navigation as any).navigate('ArkExitFundingConfirmScreen', {
+                        sourceId: 'coinos',
+                        sourceLabel: 'CoinOS',
+                        shortfallSats: exitFeeShortfallSats,
+                        // Balance is read on the confirm screen; null means
+                        // "unknown", which plans for the full shortfall rather
+                        // than refusing.
+                        availableSats: null,
+                      });
+                    }}
+                  />
                 </>
               )}
 

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -60,7 +60,7 @@ import {
   writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
 } from "@Cypher/services/ark";
-import type { ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
+import type { ExitEconomicPolicy, ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
 import Share from "react-native-share";
 import { BlueStorageContext } from "../../../../blue_modules/storage-context";
@@ -1229,7 +1229,18 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     return /^(bc1|tb1|bcrt1|[13]|[mn2])[a-zA-Z0-9]+$/.test(t);
   };
 
-  const startExitWithAddress = async (destLabel: string, address: string) => {
+  /**
+   * `economicPolicy` is how far past the economics the user has agreed to go.
+   * It only ever moves off the default by the user tapping through the
+   * override prompt below, which states the loss in sats first. Never raise it
+   * silently: the whole point of spec principle 4 is that overspending is a
+   * choice, and a choice nobody was offered is not one.
+   */
+  const startExitWithAddress = async (
+    destLabel: string,
+    address: string,
+    economicPolicy: ExitEconomicPolicy = 'default',
+  ) => {
     setExitPickerOpen(false);
     setExitStarting(true);
     // Triage NOW, not at screen mount: fee rates and the chain tip both move
@@ -1240,7 +1251,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     let plan: ExitTriageResult | null = null;
     let freshRecommended = recommendedReserveSats ?? 0;
     try {
-      plan = await computeArkExitPlan();
+      plan = await computeArkExitPlan({ economicPolicy });
       if (plan) {
         freshRecommended = plan.reserveSats;
         setRecommendedReserveSats(plan.reserveSats);
@@ -1261,22 +1272,54 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       return;
     }
 
-    // Nothing survived triage. Say why rather than starting an exit that would
-    // spend the reserve and return nothing.
-    if (plan.selectedIds.length === 0) {
+    // The override, offered only where it would change something. Re-planning
+    // with 'recover-everything' is what actually applies it, so the figures in
+    // the confirm dialog afterwards are the forced ones, not these.
+    const forcePrompt = (bodyPrefix: string) => {
       setExitStarting(false);
       Alert.alert(
         'Emergency Exit',
-        plan.excluded.length === 0
-          ? 'There are no capsules to exit.'
-          : `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
-            plan.excluded
-              .map(
-                (e) =>
-                  `${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`,
-              )
-              .join('\n') +
-            '\n\nThey stay in your vault and stay spendable.',
+        bodyPrefix +
+          `\n\nYou can exit ${plan!.overridableCount === 1 ? 'it' : 'them'} anyway. ` +
+          'That is sometimes worth it, for instance to get your funds out of a server you no longer trust, ' +
+          'but it costs more in miner fees than the funds are worth.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Exit anyway',
+            style: 'destructive',
+            onPress: () => {
+              void startExitWithAddress(destLabel, address, 'recover-everything');
+            },
+          },
+        ],
+      );
+    };
+
+    // Nothing survived triage. Say why rather than starting an exit that would
+    // spend the reserve and return nothing.
+    if (plan.selectedIds.length === 0) {
+      const list = plan.excluded
+        .map((e) => `  ${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`)
+        .join('\n');
+      if (plan.excluded.length === 0) {
+        setExitStarting(false);
+        Alert.alert('Emergency Exit', 'There are no capsules to exit.');
+        return;
+      }
+      if (plan.overridableCount === plan.excluded.length) {
+        forcePrompt(
+          `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} ` +
+            `can be recovered economically right now:\n${list}`,
+        );
+        return;
+      }
+      setExitStarting(false);
+      Alert.alert(
+        'Emergency Exit',
+        `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
+          list +
+          '\n\nThey stay in your vault and stay spendable.',
       );
       return;
     }
@@ -1302,7 +1345,14 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     // Principle: never silently spend more than the funds are worth. The
     // reserve sits next to what comes back, so a reserve larger than the value
     // is impossible to miss.
-    const costNotice = `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n`;
+    const costNotice =
+      `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n` +
+      // The loss, in sats, whenever the exit spends more than it returns. This
+      // is the sentence that makes an overridden exit a choice rather than a
+      // surprise, so it is not conditional on how the policy got here.
+      (plan.netLossSats > 0
+        ? `That is about ${plan.netLossSats.toLocaleString()} sats MORE in fees than the funds are worth.\n\n`
+        : '');
 
     const shortfall = Math.max(0, freshRecommended - onchainReserveSats);
     const underfunded = freshRecommended > 0 && shortfall > 0;
@@ -1325,6 +1375,20 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             style: 'cancel',
             onPress: () => setExitStarting(false),
           },
+          // Partial case: some capsules are worth exiting and some are being
+          // left behind on cost alone. Naming them without offering the choice
+          // would satisfy principle 3 and quietly ignore principle 4.
+          ...(plan.overridableCount > 0
+            ? [
+                {
+                  text: `Include all ${(plan.selected.length + plan.overridableCount)}`,
+                  style: 'destructive' as const,
+                  onPress: () => {
+                    void startExitWithAddress(destLabel, address, 'recover-everything');
+                  },
+                },
+              ]
+            : []),
           {
             text: 'Start exit',
             style: 'destructive',

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1912,13 +1912,30 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // persisted at-start snapshot, so the amount survives
                 // reloads and closed-handle windows.
                 //
-                // `null` (no live read yet) is the ONLY case the snapshot
-                // should cover. The old form fell back to it whenever the
-                // live figure was 0 too, so once every capsule was claimed
-                // the panel re-displayed the original at-start total and kept
-                // showing it for the rest of the exit (observed live: 3671
-                // sats pinned on screen with 0 actually pending).
-                const shownSats = pendingExitSats ?? arkExitStartedSats;
+                // Three sources, best first. Getting this ladder wrong is
+                // what made the panel lie in two different ways.
+                //
+                // 1. `pendingExitSats`, the live per-VTXO poll above.
+                // 2. the store's `pendingExitSats`, refreshed by useArkSync's
+                //    exit drive and persisted (the store has no partialize, so
+                //    it survives a cold launch). This rung is why the panel
+                //    stops quoting a stale total: the local poll calls
+                //    fetchArkExitVtxos, which THROWS while the wallet handle
+                //    is closed, and the effect swallows it, so on a cold
+                //    launch with the vault still locked the local value stays
+                //    null for as long as the user takes to authenticate.
+                // 3. `arkExitStartedSats`, the at-start snapshot, only when
+                //    nothing better has ever been recorded.
+                //
+                // Rung 3 must never outrank rung 2, because the snapshot is
+                // fixed at exit start and does NOT decrement as capsules are
+                // claimed. Observed live: 1801 of 3671 sats already recovered
+                // and confirmed on chain, vault locked after a relaunch, and
+                // the panel still reading "3671 sats pending exit".
+                const shownSats =
+                  pendingExitSats ??
+                  arkBalanceDetail?.pendingExitSats ??
+                  arkExitStartedSats;
                 return shownSats == null || shownSats <= 0
                   ? 'Broadcasting exit transactions…'
                   : `${shownSats.toLocaleString()} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.`;

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -353,6 +353,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     arkExitStartedSats,
     setArkExitStartedSats,
     setArkExitFeeReserveSats,
+    setArkExitRecommendedReserveSats,
   } = useAuthStore() as any;
   const arkIosBackupReminderActive = useAuthStore((s) => s.arkIosBackupReminderActive);
   const setArkIosBackupReminderActive = useAuthStore((s) => s.setArkIosBackupReminderActive);
@@ -993,7 +994,13 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     (async () => {
       try {
         const r = await computeExitFeeReserveSats();
-        if (!cancelled) setRecommendedReserveSats(r.recommendedSats);
+        if (!cancelled) {
+          setRecommendedReserveSats(r.recommendedSats);
+          // Persist it: auto-board runs in the sync loop with no access to this
+          // screen, and without the estimate it would hold only the armed
+          // reserve and board the rest away.
+          setArkExitRecommendedReserveSats(r.recommendedSats);
+        }
       } catch (err) {
         // Leave any prior recommendation in place; a transient failure
         // shouldn't flip a gated wallet to ungated.

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -31,6 +31,7 @@ import styles from "./styles";
 import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods, revokeStrikeToken } from "@Cypher/api/strikeAPIs";
 import {
   AUTO_BACKUP_PATH,
+  areBgNotificationsEnabled,
   computeExitFeeReserveSats,
   connectGoogleDrive,
   convertToExitFees,
@@ -440,6 +441,56 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   //   user's signal, and the OS prompt fires on enable).
   // - [DEMO] Fire refresh alarm now button (Play submission demo).
 
+  /**
+   * Whether the OS will actually deliver a notification, as opposed to whether
+   * the user has asked us to send them.
+   *
+   * These are two different facts and the screen used to show only the second.
+   * `arkBgRefreshEnabled` defaults to true, and iOS resets notification
+   * permission on every install, so after any reinstall or recovery the switch
+   * came back green while nothing could be delivered. Permission is only
+   * requested inside setArkBackgroundRefreshEnabled(true), which runs when the
+   * switch is FLIPPED, so a switch that was already on never asked.
+   *
+   * That is the worst failure available to this particular control: its own
+   * subtext promises five reminders and warns that recovery is not guaranteed
+   * once a capsule expires, so a user reading it has affirmative evidence of
+   * protection they do not have.
+   *
+   * null while the first probe is in flight; treated as "not blocked" so the
+   * UI does not flash a warning before it knows anything.
+   */
+  const [osNotifPermission, setOsNotifPermission] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const probe = () => {
+      areBgNotificationsEnabled()
+        .then((ok) => {
+          if (!cancelled) setOsNotifPermission(ok);
+        })
+        .catch(() => {
+          // A failed probe is not evidence of a revoked permission. Assume
+          // granted rather than accuse the OS of blocking us.
+          if (!cancelled) setOsNotifPermission(true);
+        });
+    };
+    probe();
+    // Re-probe on foreground: granting permission happens in iOS Settings,
+    // outside this app, so returning is the only moment we learn about it.
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') probe();
+    });
+    return () => {
+      cancelled = true;
+      sub.remove();
+    };
+  }, []);
+
+  /** The user asked for reminders but the OS will not deliver them. */
+  const remindersBlockedByOs = arkBgRefreshEnabled && osNotifPermission === false;
+  /** What the control should SAY, which is whether reminders can arrive. */
+  const remindersEffectivelyOn = arkBgRefreshEnabled && osNotifPermission !== false;
+
   const handleToggleBgRefresh = async (next: boolean) => {
     if (togglingBgRefresh) return;
     setTogglingBgRefresh(true);
@@ -450,6 +501,23 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
         // into a background-readable Keychain entry for headless wakes;
         // that machinery is gone.
         await setArkBackgroundRefreshEnabled(true);
+        // Did the OS actually agree? iOS prompts at most once per install, so
+        // a user who declined earlier gets no prompt and no permission, and
+        // reporting "Reminders enabled" there would be the same lie in a
+        // different place. Send them where they can actually grant it.
+        const granted = await areBgNotificationsEnabled();
+        setOsNotifPermission(granted);
+        if (!granted) {
+          Alert.alert(
+            "Reminders need notification permission",
+            "Cypher Box cannot warn you before a capsule expires until notifications are allowed for it in system settings.",
+            [
+              { text: "Not now", style: "cancel" },
+              { text: "Open Settings", onPress: () => void Linking.openSettings() },
+            ],
+          );
+          return;
+        }
         SimpleToast.show("Reminders enabled", SimpleToast.SHORT);
       } else {
         await setArkBackgroundRefreshEnabled(false);
@@ -1867,7 +1935,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 Notify me before capsules expire
               </RNText>
               <Switch
-                value={arkBgRefreshEnabled}
+                // The EFFECTIVE state, not the stored preference. A green
+                // switch has to mean "a reminder will reach you".
+                value={remindersEffectivelyOn}
                 onValueChange={handleToggleBgRefresh}
                 disabled={togglingBgRefresh}
                 trackColor={{ false: '#3a3a3a', true: colors.green }}
@@ -1877,14 +1947,19 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             <Text
               style={{
                 fontSize: 12,
-                color: arkBgRefreshEnabled ? '#888' : colors.redLight,
+                color: remindersEffectivelyOn ? '#888' : colors.redLight,
                 marginTop: 6,
                 lineHeight: 16,
               }}
             >
-              {arkBgRefreshEnabled
-                ? 'Cypher Box sends 5 reminders before any capsule expires (4 days, 2 days, 24 hours, 12 hours, and 6 hours before). Without a refresh, recovery is not guaranteed once a capsule expires.'
-                : '⚠ Reminders are OFF. You must open Cypher Box yourself and refresh capsules before they expire. Once a capsule expires, recovery is not guaranteed.'}
+              {/* Three states, because "the user wants reminders" and
+                  "reminders can arrive" are different facts and only the
+                  second one protects anybody. COPY: Bam finalizes. */}
+              {remindersBlockedByOs
+                ? '⚠ Reminders are blocked. You turned them on, but notifications are not allowed for Cypher Box in system settings, so none will arrive. Tap the switch to fix this.'
+                : remindersEffectivelyOn
+                  ? 'Cypher Box sends 5 reminders before any capsule expires (4 days, 2 days, 24 hours, 12 hours, and 6 hours before). Without a refresh, recovery is not guaranteed once a capsule expires.'
+                  : '⚠ Reminders are OFF. You must open Cypher Box yourself and refresh capsules before they expire. Once a capsule expires, recovery is not guaranteed.'}
             </Text>
 
           </View>

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -31,10 +31,12 @@ import styles from "./styles";
 import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods, revokeStrikeToken } from "@Cypher/api/strikeAPIs";
 import {
   AUTO_BACKUP_PATH,
+  computeArkExitPlan,
   computeExitFeeReserveSats,
   connectGoogleDrive,
   convertToExitFees,
   disconnectGoogleDrive,
+  describeExitExclusion,
   estimateExitFeeConvert,
   estimateArkOnchainRecover,
   recoverArkOnchainBoard,
@@ -58,7 +60,7 @@ import {
   writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
 } from "@Cypher/services/ark";
-import type { ExitFeeConvertEstimate } from "@Cypher/services/ark";
+import type { ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
 import Share from "react-native-share";
 import { BlueStorageContext } from "../../../../blue_modules/storage-context";
@@ -1230,19 +1232,78 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const startExitWithAddress = async (destLabel: string, address: string) => {
     setExitPickerOpen(false);
     setExitStarting(true);
-    // Re-estimate the exit-fee cost NOW: fee rates move between screen mount and
-    // this tap, so the warning must reflect the current shortfall rather than a
-    // stale mount-time number. If the on-chain fee wallet is short, advise the
-    // user to top up. It's a stall warning, not a hard block (progressExits
-    // resumes the moment fees are added).
+    // Triage NOW, not at screen mount: fee rates and the chain tip both move
+    // between mount and this tap, and both change which capsules are worth
+    // exiting. The plan decides the exit set AND sizes the reserve over that
+    // set, so the shortfall quoted below is for the capsules actually being
+    // exited rather than for every capsule in the wallet.
+    let plan: ExitTriageResult | null = null;
     let freshRecommended = recommendedReserveSats ?? 0;
     try {
-      const fresh = await computeExitFeeReserveSats();
-      freshRecommended = fresh.recommendedSats;
-      setRecommendedReserveSats(fresh.recommendedSats);
+      plan = await computeArkExitPlan();
+      if (plan) {
+        freshRecommended = plan.reserveSats;
+        setRecommendedReserveSats(plan.reserveSats);
+      }
     } catch {
       // Keep the last computed recommendation on a transient failure.
     }
+
+    // The capsule read failed, so there is no exit set to hand the SDK. Say
+    // that, rather than letting startArkEmergencyExit reject an empty list with
+    // copy that would read as "you have nothing worth exiting".
+    if (!plan) {
+      setExitStarting(false);
+      Alert.alert(
+        'Emergency Exit',
+        "Couldn't read your capsules just now, so the exit wasn't started. Try again in a moment.",
+      );
+      return;
+    }
+
+    // Nothing survived triage. Say why rather than starting an exit that would
+    // spend the reserve and return nothing.
+    if (plan.selectedIds.length === 0) {
+      setExitStarting(false);
+      Alert.alert(
+        'Emergency Exit',
+        plan.excluded.length === 0
+          ? 'There are no capsules to exit.'
+          : `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
+            plan.excluded
+              .map(
+                (e) =>
+                  `${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`,
+              )
+              .join('\n') +
+            '\n\nThey stay in your vault and stay spendable.',
+      );
+      return;
+    }
+
+    // Narrowed alias: `plan` is a let, so the null checks above do not survive
+    // into the Alert's onPress closure.
+    const exitPlan = plan;
+
+    // Principle: never silently abandon funds. Every capsule left behind is
+    // named, with its amount and the reason, BEFORE the user commits.
+    const exclusionNotice =
+      plan.excluded.length > 0
+        ? `${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} holding ${plan.excludedSats.toLocaleString()} sats will NOT be exited:\n` +
+          plan.excluded
+            .map(
+              (e) =>
+                `  ${e.sats.toLocaleString()} sats: ${describeExitExclusion(e.reason)}`,
+            )
+            .join('\n') +
+          '\n\nThey stay in your vault and stay spendable. Sending them, or combining them, recovers more than an exit would.\n\n'
+        : '';
+
+    // Principle: never silently spend more than the funds are worth. The
+    // reserve sits next to what comes back, so a reserve larger than the value
+    // is impossible to miss.
+    const costNotice = `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n`;
+
     const shortfall = Math.max(0, freshRecommended - onchainReserveSats);
     const underfunded = freshRecommended > 0 && shortfall > 0;
     const underfundedPrefix = underfunded
@@ -1251,7 +1312,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     try {
       Alert.alert(
         'Emergency Exit',
-        underfundedPrefix +
+        exclusionNotice +
+          costNotice +
+          underfundedPrefix +
           `Forces your VTXO capsules onto the Bitcoin chain. Funds arrive at your ${destLabel} after a ~24-hour wait set by Bitcoin. Once you start, this can't be cancelled.\n\n` +
           'Only start this if your soonest capsule is at least 1 day from expiry. The exit txs must confirm on-chain before then, so it is not a last-minute rescue.\n\n' +
           `${address}\n\n` +
@@ -1267,7 +1330,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             style: 'destructive',
             onPress: async () => {
               try {
-                await startArkEmergencyExit();
+                await startArkEmergencyExit(exitPlan.selectedIds);
                 setArkExitDestinationAddress(address);
                 setArkExitStartedAt(Date.now());
                 // Fresh exit: clear any stale "drained" flag from a prior exit
@@ -1278,7 +1341,10 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // txs broadcast and any live read needs an open handle, so
                 // this persisted figure is what the status panel falls back
                 // to across reloads.
-                const startedSats = Number(arkBalanceDetail?.spendableSats ?? 0);
+                // The exit set, not the wallet: triage may have left capsules
+                // behind, and quoting the whole spendable balance here would
+                // report a total the exit can never deliver.
+                const startedSats = exitPlan.selectedSats;
                 setArkExitStartedSats(startedSats > 0 ? startedSats : null);
                 setArkExitInProgress(true);
                 // Activity log: read pending sats fresh — the exit just

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -38,6 +38,7 @@ import {
   disconnectGoogleDrive,
   describeExitExclusion,
   estimateExitFeeConvert,
+  getLastExitFeeDeadlineHeight,
   estimateArkOnchainRecover,
   recoverArkOnchainBoard,
   fetchArkExitVtxos,
@@ -354,6 +355,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     arkExitStartedSats,
     setArkExitStartedSats,
     setArkExitFeeReserveSats,
+    setArkExitFeeDeadlineHeight,
   } = useAuthStore() as any;
   const arkIosBackupReminderActive = useAuthStore((s) => s.arkIosBackupReminderActive);
   const setArkIosBackupReminderActive = useAuthStore((s) => s.setArkIosBackupReminderActive);
@@ -1395,6 +1397,9 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             onPress: async () => {
               try {
                 await startArkEmergencyExit(exitPlan.selectedIds);
+                // Persist what the reserve was priced against, so the drive can
+                // re-derive its bid each tick as the runway shrinks.
+                setArkExitFeeDeadlineHeight(getLastExitFeeDeadlineHeight());
                 setArkExitDestinationAddress(address);
                 setArkExitStartedAt(Date.now());
                 // Fresh exit: clear any stale "drained" flag from a prior exit

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -48,6 +48,7 @@ import {
   getICloudBackupPath,
   getICloudBackupPathForFingerprint,
   getLastLocalBackupNote,
+  isActiveExit,
   isGoogleDriveConnected,
   isICloudBackupAvailable,
   probeAspReachable,
@@ -957,12 +958,18 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
         // phases), which left this panel blank mid-exit. Derive the figure
         // from the per-VTXO exit records and keep the SDK total as a
         // lower bound for whatever later phase it does count.
+        //
+        // Liveness goes through isActiveExit, NOT a regex on String(v.state):
+        // bark 0.6.1 made `state` a tagged-enum object, so the old
+        // /^(Processing|Awaiting)/ test matched "[object Object]" never,
+        // activeSats was always 0, and this fell back to the exact SDK quirk
+        // the code above exists to work around.
         const [vtxos, pendingTotal] = await Promise.all([
           fetchArkExitVtxos(),
           fetchPendingExitsTotalSats(),
         ]);
         const activeSats = vtxos
-          .filter((v) => /^(Processing|Awaiting)/.test(String(v.state)) || v.isClaimable)
+          .filter((v) => isActiveExit(v))
           .reduce((acc, v) => acc + Number(v.amountSats), 0);
         if (!cancelled) setPendingExitSats(Math.max(activeSats, pendingTotal));
       } catch {
@@ -1904,10 +1911,14 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // Live per-VTXO read when the handle is open; otherwise the
                 // persisted at-start snapshot, so the amount survives
                 // reloads and closed-handle windows.
-                const shownSats =
-                  pendingExitSats && pendingExitSats > 0
-                    ? pendingExitSats
-                    : (arkExitStartedSats ?? pendingExitSats);
+                //
+                // `null` (no live read yet) is the ONLY case the snapshot
+                // should cover. The old form fell back to it whenever the
+                // live figure was 0 too, so once every capsule was claimed
+                // the panel re-displayed the original at-start total and kept
+                // showing it for the rest of the exit (observed live: 3671
+                // sats pinned on screen with 0 actually pending).
+                const shownSats = pendingExitSats ?? arkExitStartedSats;
                 return shownSats == null || shownSats <= 0
                   ? 'Broadcasting exit transactions…'
                   : `${shownSats.toLocaleString()} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.`;

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -32,6 +32,7 @@ import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods, revokeStrikeT
 import {
   AUTO_BACKUP_PATH,
   computeExitFeeReserveSats,
+  resolveExitReserveTarget,
   connectGoogleDrive,
   convertToExitFees,
   disconnectGoogleDrive,
@@ -913,13 +914,18 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const [reserveTargetInput, setReserveTargetInput] = useState('');
 
   const onchainReserveSats: number = arkBalanceDetail?.onchainBoardingSats ?? 0;
-  // Reserve target: the user's chosen hold amount if they've set/armed one
-  // (persisted), otherwise the computed recommendation. Drives the gate, the
-  // funded state, and (via arkExitFeeReserveSats) how much auto-board keeps
-  // on-chain. While recommended is still null (first compute) and nothing is
+  // Reserve target: the GREATER of what the user armed and what an exit is
+  // currently estimated to cost. Drives the gate, the funded state and the
+  // shortfall. While recommended is still null (first compute) and nothing is
   // armed, the target is 0 so we don't gate; the button shows "checking".
-  const reserveTargetSats: number =
-    (arkExitFeeReserveSats ?? 0) > 0 ? arkExitFeeReserveSats : (recommendedReserveSats ?? 0);
+  //
+  // This used to be `armed > 0 ? armed : recommended`, which let a stale armed
+  // figure declare the reserve funded no matter how far the estimate had moved.
+  // See resolveExitReserveTarget for the device case that exposed it.
+  const reserveTargetSats: number = resolveExitReserveTarget({
+    armedSats: arkExitFeeReserveSats,
+    recommendedSats: recommendedReserveSats,
+  });
   const exitFeeGated = reserveTargetSats > 0 && onchainReserveSats < reserveTargetSats;
   const exitFeeShortfallSats = Math.max(0, reserveTargetSats - onchainReserveSats);
   // The user armed a target below the recommended safe amount (warn them).

--- a/src/services/ark/autoBoardDecision.ts
+++ b/src/services/ark/autoBoardDecision.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helper: should the on-chain (BDK) balance be boarded into Ark, and how
+ * much must stay behind.
+ *
+ * Deliberately free of imports beyond the sibling pure helper, so it stays
+ * unit-testable without the native bark module.
+ *
+ * Why this exists as a decision function rather than inline in sync.ts: the
+ * on-chain wallet is where unilateral-exit CPFP fees are paid from, so boarding
+ * the wrong amount does not merely misplace funds, it disarms the exit. Two
+ * separate defects lived in the inline version:
+ *
+ *   1. The hold target was the ARMED reserve only. A user who funds toward a
+ *      recommendation far above what they armed (the recommendation moves with
+ *      exit depth and was measured at 233,120 against an armed 3,654) would
+ *      have the difference boarded straight back into Ark, undoing the top-up
+ *      they had just made specifically to enable the exit.
+ *   2. The unarmed path called boardAll with NO board-minimum guard, while the
+ *      armed path guarded correctly. A sub-minimum on-chain balance can never
+ *      board, so it retried every sync tick forever. The asymmetry was
+ *      acknowledged in the old comment as "the exact old boardAll behavior".
+ */
+import { resolveExitReserveTarget } from './exitReserveTarget';
+
+export type AutoBoardDecision =
+    | { action: 'skip'; reason: 'exit-in-progress' | 'nothing-onchain' | 'board-in-flight' }
+    | { action: 'hold'; reason: 'below-board-minimum'; surplusSats: number; holdSats: number }
+    | { action: 'board-amount'; sats: number; holdSats: number }
+    | { action: 'board-all'; holdSats: 0 };
+
+export type AutoBoardInput = {
+    confirmedSats: number;
+    pendingBoardSats: number;
+    exitInProgress: boolean;
+    /** What the user armed, if anything. */
+    armedReserveSats: number | null | undefined;
+    /** Last computed exit-cost estimate, if one has been persisted. */
+    recommendedReserveSats: number | null | undefined;
+    /** Server board minimum. Below this a board can never succeed. */
+    minBoardSats: number;
+    /** Slack so boardAmount's own fee cannot dip the leftover below the hold. */
+    boardFeeHeadroomSats: number;
+};
+
+export function decideAutoBoard(input: AutoBoardInput): AutoBoardDecision {
+    // An exit in progress means every VTXO is already committed and the whole
+    // on-chain balance is fee money. Board nothing, whatever the numbers say.
+    if (input.exitInProgress) return { action: 'skip', reason: 'exit-in-progress' };
+
+    const confirmed = Math.max(0, Math.floor(input.confirmedSats || 0));
+    if (confirmed <= 0) return { action: 'skip', reason: 'nothing-onchain' };
+
+    // bark has not yet observed the previous board consuming its input; firing
+    // again here double-boards.
+    if ((input.pendingBoardSats || 0) > 0) return { action: 'skip', reason: 'board-in-flight' };
+
+    const holdSats = resolveExitReserveTarget({
+        armedSats: input.armedReserveSats,
+        recommendedSats: input.recommendedReserveSats,
+    });
+    const minBoard = Math.max(0, Math.floor(input.minBoardSats || 0));
+
+    if (holdSats <= 0) {
+        // Nothing to protect, so boardAll keeps its original semantics and
+        // leaves no dust behind. The minimum guard is new: without it this
+        // retried forever on a balance that could never board.
+        if (confirmed >= minBoard) return { action: 'board-all', holdSats: 0 };
+        return { action: 'hold', reason: 'below-board-minimum', surplusSats: confirmed, holdSats: 0 };
+    }
+
+    const surplusSats = confirmed - holdSats - Math.max(0, Math.floor(input.boardFeeHeadroomSats || 0));
+    if (surplusSats >= minBoard) return { action: 'board-amount', sats: surplusSats, holdSats };
+    return { action: 'hold', reason: 'below-board-minimum', surplusSats, holdSats };
+}

--- a/src/services/ark/backgroundRefresh.ts
+++ b/src/services/ark/backgroundRefresh.ts
@@ -10,6 +10,7 @@ import {
     writeBackgroundArkSeed,
 } from './backgroundKeychain';
 import { getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
+import { hasActiveArkExitRecords } from './exit';
 import { maintenanceArkDelegated } from './refresh';
 import { syncArkWallet } from './sync';
 import { AVG_BLOCK_MINUTES, fetchChainTipHeight } from './chainTip';
@@ -160,6 +161,25 @@ export async function runArkBackgroundMaintenance(
 
     useAuthStore.getState().setArkBgRefreshLastAttempt(Date.now());
     console.log('[Ark bg-refresh] maintenance start, trigger=', trigger);
+
+    // Never run a cooperative round while a unilateral exit is in flight: it
+    // would spend a coin that is already committed on-chain. maintenanceArkDelegated
+    // enforces this too, but bail here so a deliberate skip is recorded as such
+    // rather than surfacing as an 'error' and feeding the consecutive-failure
+    // escalation. Checked after the seed read because the handle may not exist
+    // until openArkWallet runs below; hasActiveArkExitRecords returns false on
+    // a missing handle, and the in-call guard catches that case.
+    if (await hasActiveArkExitRecords()) {
+        console.log('[Ark bg-refresh] skipped: unilateral exit in progress');
+        void recordTelemetry({
+            at: startedAt,
+            trigger,
+            outcome: 'exit_in_progress',
+            elapsedMs: Date.now() - startedAt,
+        });
+        return;
+    }
+
     try {
         // Reuse a live handle if the process is already resident; otherwise open
         // from the background-readable seed (no biometric prompt).

--- a/src/services/ark/backgroundTelemetry.ts
+++ b/src/services/ark/backgroundTelemetry.ts
@@ -25,6 +25,10 @@ export type ArkBgRefreshOutcome =
     | 'dust_stranded'
     | 'no_seed'
     | 'disabled'
+    // Deliberately skipped because a unilateral exit is in flight: a
+    // cooperative round would commit the same coin twice. Not a failure, and
+    // must not count toward the consecutive-failure escalation.
+    | 'exit_in_progress'
     | 'error';
 
 export type ArkBgRefreshTelemetryEntry = {

--- a/src/services/ark/backup.ts
+++ b/src/services/ark/backup.ts
@@ -1152,15 +1152,28 @@ export async function writeArkAutoBackup(
         );
     }
 
+    // Per-destination outcomes. Every channel below is deliberately
+    // silent-fail, which is right for an every-tick background write, but it
+    // means "this function resolved" is NOT evidence that anything was stored.
+    // Two things downstream depend on knowing the difference:
+    //   1. the legacy-backup cleanup, which DELETES the previous snapshot and
+    //      must not run unless a current one demonstrably exists somewhere;
+    //   2. `arkLastBackupAt`, which drives the "Backed up" state in the capsule
+    //      UI and must not be stamped for a tick that wrote nothing.
+    let wroteLocal = localWrite.ok;
+    let wroteICloud = false;
+    let wroteDrive = false;
+    let wroteSaf = false;
+
     // iCloud mirror — silent-fail per the auto-backup contract (next sync
-    // tick retries). The local copy already succeeded so the wallet is
-    // recoverable from this device regardless of iCloud outcome.
+    // tick retries).
     let iCloudPath: string | null = null;
     if (Platform.OS === 'ios') {
         try {
             iCloudPath = await getICloudBackupPathForFingerprint(fingerprint);
             if (iCloudPath) {
                 await atomicWriteFile(iCloudPath, blob, 'utf8');
+                wroteICloud = true;
             }
         } catch (err: any) {
             if (__DEV__) {
@@ -1188,6 +1201,7 @@ export async function writeArkAutoBackup(
     try {
         if (await isGoogleDriveConnected()) {
             await uploadArkBackupToDrive(blob, fingerprint);
+            wroteDrive = true;
             if (__DEV__) console.log('[Ark auto-backup] Drive upload OK');
         }
     } catch (err: any) {
@@ -1208,6 +1222,7 @@ export async function writeArkAutoBackup(
         const saved = await getSavedSafBackupFolder();
         if (saved) {
             await writeArkBackupToSaf(blob, fingerprint);
+            wroteSaf = true;
             if (__DEV__) console.log('[Ark auto-backup] SAF folder write OK');
         }
     } catch (err: any) {
@@ -1229,6 +1244,25 @@ export async function writeArkAutoBackup(
     // files are gone (existence checks short-circuit fast). Best-effort
     // — errors swallowed inside the helper so the auto-backup tick
     // never breaks on a stale legacy file.
+    //
+    // GATED on at least one destination having actually taken this tick's
+    // snapshot. Every channel above is silent-fail, so without this gate a tick
+    // where the local write AND every mirror failed still deleted the previous
+    // good backup, and could leave the wallet with no `.cbark` anywhere. For a
+    // Bark vault that file carries the pre-signed exit chain, so losing every
+    // copy also loses the ability to exit unilaterally.
+    const wroteSomewhere = wroteLocal || wroteICloud || wroteDrive || wroteSaf;
+
+    if (!wroteSomewhere) {
+        // Nothing was stored. Do NOT delete the legacy snapshot, and do NOT
+        // resolve: callers stamp `arkLastBackupAt` (and the capsule UI reads
+        // "Backed up") off a successful resolve. Every call site already has a
+        // .catch, so throwing here is contained and simply skips the stamp.
+        throw new Error(
+            'Ark auto-backup wrote nothing: local, iCloud, Drive and SAF all failed or were unavailable',
+        );
+    }
+
     try {
         await migrateLegacyBackupsForActiveWallet(mnemonic);
     } catch (err: any) {

--- a/src/services/ark/cancellingState.ts
+++ b/src/services/ark/cancellingState.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import useAuthStore from '@Cypher/stores/authStore';
 
+import { sumMidRoundVtxos } from './vtxos';
+
 /**
  * Global "cancel-in-flight" state for the Ark capsule refresh UI.
  *
@@ -34,11 +36,12 @@ let storeUnsub: (() => void) | null = null;
 let safetyTimer: ReturnType<typeof setTimeout> | null = null;
 
 function pendingRoundSatsFromStore(): number {
-    const arkVtxos = useAuthStore.getState().arkVtxos;
-    return arkVtxos.reduce(
-        (sum, v) => (v.state.toLowerCase() === 'locked' ? sum + v.sats : sum),
-        0,
-    );
+    const s = useAuthStore.getState();
+    // Must count delegated refreshes too. This value is the signal for "the
+    // round has let go of the funds", so counting only `Locked` made it read 0
+    // for the entire life of a delegated round and cleared the cancelling gate
+    // immediately. See isVtxoMidRound.
+    return sumMidRoundVtxos(s.arkVtxos, s.arkRefreshingVtxoIds).sats;
 }
 
 function notify(): void {

--- a/src/services/ark/config.ts
+++ b/src/services/ark/config.ts
@@ -1,5 +1,7 @@
 import { Config, Network } from '@secondts/bark-react-native';
 
+import { ESPLORA_FALLBACK_URLS } from './esploraProviders';
+
 /**
  * Master kill-switch for the Ark feature.
  *
@@ -148,7 +150,12 @@ export const ESPLORA_URL = 'https://blockstream.info/api';
  * targets the same datadir (BarkError.Database or worse). A hang behaves
  * exactly as it did before this list existed.
  */
-export const ESPLORA_URLS = [ESPLORA_URL, 'https://mempool.space/api'];
+/**
+ * Rotation list for the open-with-retry loop. The list, the attempt count and
+ * the invariant tying them together live in ./esploraProviders, which is pure
+ * and therefore unit-testable; config.ts cannot be imported under jest.
+ */
+export const ESPLORA_URLS: string[] = [...ESPLORA_FALLBACK_URLS];
 
 export function createArkConfig(overrides?: Partial<Parameters<typeof Config.create>[0]>) {
     return Config.create({

--- a/src/services/ark/esploraProviders.ts
+++ b/src/services/ark/esploraProviders.ts
@@ -1,0 +1,62 @@
+/**
+ * The chain sources the wallet falls back through, and the invariant that
+ * makes the list actually work.
+ *
+ * Pure and import-free so it stays unit-testable without the native bark
+ * module, matching exitTriage.ts, refreshBatch.ts and the other decision
+ * helpers. It lived in config.ts, which cannot be imported under jest because
+ * config.ts pulls in the SDK, so the list's invariants were unenforceable.
+ *
+ * WHY THIS MATTERS
+ *
+ * The list held two entries. On 2026-08-21 one of them was down for an entire
+ * session while the other rate-limited the device, so there was nowhere to
+ * rotate to: five open attempts alternating between a 429 and a dead host,
+ * for hours, and the wallet simply would not open. A unilateral exit that was
+ * already in flight stalled with it, because the drive cannot advance an exit
+ * tree without a chain source, and the UI showed nothing wrong the whole time.
+ *
+ * Two entries is not redundancy. It is a single point of failure with a spare
+ * that has to be perfect.
+ */
+
+/**
+ * Providers in rotation order.
+ *
+ * Ordered by OPERATOR INDEPENDENCE rather than preference. The first two are
+ * what we already relied on; the community mirror sits between the two
+ * mempool.space entries so one operator's outage cannot take out consecutive
+ * attempts, which is precisely the failure that happened. The regional
+ * mempool.space node is last because it stayed up while the apex did not,
+ * making it the useful backstop rather than a first choice.
+ *
+ * Verified 2026-08-21: each answered `/blocks/tip/hash` with a valid 64-char
+ * hash and served `/fee-estimates`.
+ *
+ * PRIVACY: rotation only happens once the provider before it has FAILED, and
+ * the wallet still opens against the first entry alone. A healthy wallet talks
+ * to exactly one provider, as it always did. These extra entries change who
+ * sees an address only in the case where the alternative is not working at all.
+ */
+export const ESPLORA_FALLBACK_URLS = [
+    'https://blockstream.info/api',
+    'https://mempool.space/api',
+    'https://mempool.emzy.de/api',
+    'https://mempool.va1.mempool.space/api',
+] as const;
+
+/**
+ * Attempts the open-with-retry loop makes.
+ *
+ * MUST be >= the provider count, or the last entries are never reached and
+ * adding a provider silently does nothing. That is the trap this module exists
+ * to make visible: the old list had no such check, so its second entry being
+ * dead was invisible until it mattered.
+ */
+export const ESPLORA_OPEN_ATTEMPTS = 5;
+
+/** Operator for a provider URL, used to keep same-operator entries apart. */
+export function esploraOperator(url: string): string {
+    const host = url.replace(/^https?:\/\//, '').split('/')[0];
+    return host.split('.').slice(-2).join('.');
+}

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -38,6 +38,7 @@ import type { ExitClaimTransaction, ExitVtxo } from '@secondts/bark-react-native
 
 import useAuthStore from '@Cypher/stores/authStore';
 
+import { isActiveExit } from './barkState';
 import { ensureArkOnchainHandle, getArkWalletHandle } from './walletHandle';
 
 /**
@@ -163,6 +164,15 @@ export async function fetchArkExitVtxos(): Promise<ExitVtxo[]> {
  * the ~24h AwaitingDelta CSV wait), or claimable. Matching only Processing
  * would report "no exit" for most of the exit's life.
  *
+ * Liveness MUST go through isActiveExit. This function used to regex
+ * `String(v.state)` for /^(Processing|Awaiting)/, which bark 0.6.1 broke when
+ * it turned `state` into a tagged-enum object: `String({tag:'AwaitingDelta'})`
+ * is "[object Object]", the regex never matched, and the whole check collapsed
+ * to `v.isClaimable`. Verified live on 2026-08-18 against an exit with 2794
+ * sats in flight (three AwaitingDelta, one ClaimInProgress, all
+ * isClaimable=false): this returned FALSE, so the guard it feeds was open for
+ * essentially the entire exit.
+ *
  * Returns false when the handle is unavailable or the read throws: callers use
  * this to BLOCK an action, and a failed read is not evidence of an exit. The
  * sync-flag check in `assertNoActiveArkExit` remains the first line of defence.
@@ -172,9 +182,7 @@ export async function hasActiveArkExitRecords(): Promise<boolean> {
         const handle = getArkWalletHandle();
         if (!handle) return false;
         const exits = await handle.getExitVtxos();
-        return (exits ?? []).some(
-            (v) => /^(Processing|Awaiting)/.test(String(v.state)) || v.isClaimable,
-        );
+        return (exits ?? []).some((v) => isActiveExit(v));
     } catch {
         return false;
     }

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -10,8 +10,11 @@
  *
  * Phase contract (matches the Bark SDK shape):
  *
- *   1. `startArkEmergencyExit()` → `wallet.startExitForEntireWallet()`
- *      Marks every VTXO for exit. No on-chain txs broadcast yet.
+ *   1. `startArkEmergencyExit(ids)` → `wallet.startExitForVtxos(ids)`
+ *      Marks the triaged VTXO set for exit. No on-chain txs broadcast yet.
+ *      The set comes from `computeArkExitPlan` in ./exitFunding, which drops
+ *      capsules that cannot be exited, cannot clear their timelock before
+ *      expiry, or would cost more reserve than they can ever return.
  *
  *   2. `progressArkExits()` → `wallet.progressExits(onchain, feeRate?)`
  *      Builds + broadcasts the actual on-chain exit txs as inputs become
@@ -74,17 +77,35 @@ function requireWallet() {
 }
 
 /**
- * Kick off unilateral exit for ALL VTXOs in this wallet. No destination is
- * needed yet — the destination is supplied at `claimArkExitsToAddress` time
- * (we save it in zustand at start so the auto-claim loop has it).
+ * Kick off a unilateral exit for a CHOSEN set of VTXOs. No destination is
+ * needed yet: it is supplied at `claimArkExitsToAddress` time (we save it in
+ * zustand at start so the auto-claim loop has it).
+ *
+ * Takes ids rather than exiting the whole wallet. `startExitForEntireWallet()`
+ * marks every VTXO, dust included, and the on-chain reserve is then sized over
+ * all of it. Measured on the QA wallet 2026-08-20 at 1 sat/vB: two 400-sat
+ * capsules on deep exit trees were 10,656 of the 16,060 vB the exit would cost,
+ * 66% of the reserve for 16% of the value, and neither could ever return more
+ * than it consumed. The reserve that dust eats is the reserve the healthy
+ * capsules need, so it does not merely waste money, it decides which capsules
+ * get stranded when the reserve runs dry.
+ *
+ * Callers pass `computeArkExitPlan().selectedIds` (see ./exitFunding), and must
+ * have shown the user every excluded capsule by name and amount first. Refuses
+ * an empty set rather than falling back to the whole wallet: a silent fallback
+ * would reintroduce exactly the behaviour this replaces.
  */
-export async function startArkEmergencyExit(): Promise<void> {
+export async function startArkEmergencyExit(vtxoIds: readonly string[]): Promise<void> {
     const handle = requireWallet();
+    const ids = (vtxoIds ?? []).filter((id) => !!id);
+    if (ids.length === 0) {
+        throw new Error('No capsules can be exited right now.');
+    }
     // Spawn the onchain wallet eagerly — progressExits() needs it on the very
     // next tick. Catching here surfaces a clean error to the UI rather than
     // letting the first sync-cycle progress call fail with "not initialized".
     await ensureArkOnchainHandle();
-    await handle.startExitForEntireWallet();
+    await handle.startExitForVtxos([...ids]);
 }
 
 /**

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -152,6 +152,52 @@ export async function fetchArkExitVtxos(): Promise<ExitVtxo[]> {
 }
 
 /**
+ * Does bark's own DB hold any NON-TERMINAL exit record?
+ *
+ * The authoritative "is an exit live" signal, and deliberately independent of
+ * zustand: the background-refresh wake runs headless and can execute before the
+ * store has rehydrated, at which point `arkExitInProgress` reads its default
+ * `false` and the sync guard silently passes. This one asks bark.
+ *
+ * Non-terminal means Processing (broadcasting), any Awaiting* phase (including
+ * the ~24h AwaitingDelta CSV wait), or claimable. Matching only Processing
+ * would report "no exit" for most of the exit's life.
+ *
+ * Returns false when the handle is unavailable or the read throws: callers use
+ * this to BLOCK an action, and a failed read is not evidence of an exit. The
+ * sync-flag check in `assertNoActiveArkExit` remains the first line of defence.
+ */
+export async function hasActiveArkExitRecords(): Promise<boolean> {
+    try {
+        const handle = getArkWalletHandle();
+        if (!handle) return false;
+        const exits = await handle.getExitVtxos();
+        return (exits ?? []).some(
+            (v) => /^(Processing|Awaiting)/.test(String(v.state)) || v.isClaimable,
+        );
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Async companion to `assertNoActiveArkExit` for paths that can run before the
+ * store is hydrated (background wake) or that are about to hand VTXOs to the
+ * ASP for a cooperative round.
+ *
+ * Checks the cheap sync signals first, then bark's DB.
+ */
+export async function assertNoActiveArkExitAsync(action = 'This action'): Promise<void> {
+    const s = useAuthStore.getState();
+    const exitingVtxo = (s.arkVtxos ?? []).some((v) => (v as { exiting?: boolean }).exiting);
+    if (s.arkExitInProgress || exitingVtxo || (await hasActiveArkExitRecords())) {
+        throw new Error(
+            `${action} is unavailable while an Emergency Exit is in progress.`,
+        );
+    }
+}
+
+/**
  * Subset of `getExitVtxos` filtered to only those whose CSV timelock has
  * matured AND whose on-chain confirmations are sufficient for `drainExits`
  * to succeed. Empty until the first exit ripens (~24h post-start on

--- a/src/services/ark/exitClaimBatch.ts
+++ b/src/services/ark/exitClaimBatch.ts
@@ -1,0 +1,67 @@
+/**
+ * When should the exit claim sweep fire?
+ *
+ * `drainExits([])` already sweeps every currently-claimable capsule into ONE
+ * transaction, so cost is per-claim, not per-capsule. Claiming the moment the
+ * first capsule ripens therefore pays a separate fee for every one of them.
+ * Seen on a five-capsule exit: 225 sats to move 877, with four more queued
+ * behind it, on a fee wallet that had already fallen from 3654 to 699 sats.
+ *
+ * Capsules ripen apart because each has its own exit branch and its own CSV,
+ * timed from when THAT branch's transaction confirmed. One block between two
+ * confirmations is enough to split the batch.
+ *
+ * Waiting is safe: past its CSV a claimable exit output is an ordinary UTXO
+ * that only this wallet can spend, with no deadline and nobody to race. What is
+ * NOT safe is waiting forever, so a wedged capsule cannot hold the rest hostage.
+ *
+ * Lives here rather than inline in useArkSync so the rule can be tested without
+ * standing up the sync loop.
+ */
+
+export type ExitClaimBatchInput = {
+    /** Capsules ready to sweep right now. */
+    claimableCount: number;
+    /** Active exits NOT yet claimable, i.e. stragglers still worth waiting for. */
+    stillProgressingCount: number;
+    /** Epoch ms when the first capsule became claimable, null before that. */
+    batchSince: number | null;
+    /** Current epoch ms. */
+    now: number;
+    /** How long to wait for stragglers before sweeping without them. */
+    maxWaitMs: number;
+};
+
+export type ExitClaimBatchDecision = {
+    /** Sweep now. */
+    claim: boolean;
+    /** Start (or keep) the batching window at this epoch ms, null to clear it. */
+    batchSince: number | null;
+    /** Why, for the drive log. */
+    reason: 'nothing-claimable' | 'all-ready' | 'window-expired' | 'waiting';
+};
+
+export function decideExitClaimBatch(input: ExitClaimBatchInput): ExitClaimBatchDecision {
+    const { claimableCount, stillProgressingCount, batchSince, now, maxWaitMs } = input;
+
+    if (claimableCount <= 0) {
+        // Nothing to sweep. Clear the window so a future capsule starts a fresh
+        // one instead of inheriting stale elapsed time from a previous batch.
+        return { claim: false, batchSince: null, reason: 'nothing-claimable' };
+    }
+
+    // First capsule of this batch: the window opens now.
+    const since = batchSince ?? now;
+
+    // Nothing else is coming, so batching can only cost time.
+    if (stillProgressingCount === 0) {
+        return { claim: true, batchSince: since, reason: 'all-ready' };
+    }
+
+    // A straggler is wedged or simply slow. Bounded wait, then go without it.
+    if (now - since >= maxWaitMs) {
+        return { claim: true, batchSince: since, reason: 'window-expired' };
+    }
+
+    return { claim: false, batchSince: since, reason: 'waiting' };
+}

--- a/src/services/ark/exitClaimBatch.ts
+++ b/src/services/ark/exitClaimBatch.ts
@@ -2,10 +2,12 @@
  * When should the exit claim sweep fire?
  *
  * `drainExits([])` already sweeps every currently-claimable capsule into ONE
- * transaction, so cost is per-claim, not per-capsule. Claiming the moment the
- * first capsule ripens therefore pays a separate fee for every one of them.
- * Seen on a five-capsule exit: 225 sats to move 877, with four more queued
- * behind it, on a fee wallet that had already fallen from 3654 to 699 sats.
+ * transaction, so cost is per-claim, not per-capsule, and the whole exit can
+ * land as a single UTXO at the destination. Claiming the moment the first
+ * capsule ripens instead pays a separate fee for every one of them and
+ * fragments the result. Seen on a five-capsule exit: 225 sats to move 877, with
+ * four more queued behind it, on a fee wallet that had already fallen from 3654
+ * to 699 sats, and 2,961 recovered sats delivered as five separate UTXOs.
  *
  * Capsules ripen apart because each has its own exit branch and its own CSV,
  * timed from when THAT branch's transaction confirmed. One block between two
@@ -14,6 +16,27 @@
  * Waiting is safe: past its CSV a claimable exit output is an ordinary UTXO
  * that only this wallet can spend, with no deadline and nobody to race. What is
  * NOT safe is waiting forever, so a wedged capsule cannot hold the rest hostage.
+ *
+ * BLOCKS, NOT A TIMER. The ripening schedule is known in advance:
+ * `ExitState.AwaitingDelta.inner.claimableHeight` is populated the moment a
+ * leaf confirms, and it does not move. So "has everything ripened" is a
+ * question about the chain tip, not about elapsed time, and answering it with a
+ * clock gets it wrong in exactly the case that matters.
+ *
+ * Measured on the 2026-08-17/20 exit, the three capsules still in flight
+ * reported claimableHeight 963101, 963142 and 963145. That is a 44-block spread,
+ * about 7.3 hours. Against a 6-hour wall-clock ceiling the window expires
+ * roughly 80 minutes BEFORE the last capsule ripens, with one of the three
+ * claimable, so the sweep fires early and the exit lands as two UTXOs instead
+ * of one. No ceiling tuned in hours fixes this in general: block intervals are
+ * stochastic, and the spread is a property of when each branch confirmed.
+ *
+ * So: when every straggler's ripening height is known, hold until the tip
+ * reaches the last of them. That wait provably terminates, because the heights
+ * are fixed and the chain only moves forward. The wall-clock backstop stays for
+ * the case it is actually good for, a straggler whose ripening height we do NOT
+ * know (still broadcasting, or the tip is unreadable), where there is no
+ * schedule to wait on and something has to bound the wait.
  *
  * Lives here rather than inline in useArkSync so the rule can be tested without
  * standing up the sync loop.
@@ -28,8 +51,25 @@ export type ExitClaimBatchInput = {
     batchSince: number | null;
     /** Current epoch ms. */
     now: number;
-    /** How long to wait for stragglers before sweeping without them. */
+    /** How long to wait for stragglers whose ripening height is UNKNOWN. */
     maxWaitMs: number;
+    /**
+     * Current chain tip, or null when every provider failed. A null tip means
+     * the schedule cannot be evaluated at all, so the wall-clock backstop
+     * governs.
+     */
+    tipHeight?: number | null;
+    /**
+     * Known `claimableHeight` of each straggler, from
+     * `ExitState.AwaitingDelta.inner.claimableHeight`. Stragglers with no known
+     * height are counted in `unknownScheduleCount` instead.
+     */
+    pendingClaimableHeights?: readonly number[];
+    /**
+     * Stragglers with no readable ripening height, e.g. still Processing so no
+     * leaf has confirmed yet. These are what the wall-clock backstop is for.
+     */
+    unknownScheduleCount?: number;
 };
 
 export type ExitClaimBatchDecision = {
@@ -38,7 +78,17 @@ export type ExitClaimBatchDecision = {
     /** Start (or keep) the batching window at this epoch ms, null to clear it. */
     batchSince: number | null;
     /** Why, for the drive log. */
-    reason: 'nothing-claimable' | 'all-ready' | 'window-expired' | 'waiting';
+    reason:
+        | 'nothing-claimable'
+        | 'all-ready'
+        | 'window-expired'
+        | 'waiting'
+        | 'waiting-for-schedule';
+    /**
+     * Blocks until the last straggler ripens, when the schedule is known. Feeds
+     * an honest "2 blocks to go" countdown instead of a fake seconds timer.
+     */
+    blocksUntilAllReady?: number;
 };
 
 export function decideExitClaimBatch(input: ExitClaimBatchInput): ExitClaimBatchDecision {
@@ -58,7 +108,39 @@ export function decideExitClaimBatch(input: ExitClaimBatchInput): ExitClaimBatch
         return { claim: true, batchSince: since, reason: 'all-ready' };
     }
 
-    // A straggler is wedged or simply slow. Bounded wait, then go without it.
+    const tip =
+        typeof input.tipHeight === 'number' && Number.isFinite(input.tipHeight)
+            ? Math.floor(input.tipHeight)
+            : null;
+    const heights = (input.pendingClaimableHeights ?? []).filter(
+        (h) => typeof h === 'number' && Number.isFinite(h) && h > 0,
+    );
+    const unknownSchedule = Math.max(
+        0,
+        input.unknownScheduleCount ?? stillProgressingCount - heights.length,
+    );
+
+    // Every straggler's ripening height is known and the tip is readable, so
+    // the wait has a definite end. Hold for it however long the chain takes.
+    if (tip != null && unknownSchedule === 0 && heights.length > 0) {
+        const lastHeight = Math.max(...heights);
+        const blocksUntilAllReady = lastHeight - tip;
+        if (blocksUntilAllReady > 0) {
+            return {
+                claim: false,
+                batchSince: since,
+                reason: 'waiting-for-schedule',
+                blocksUntilAllReady,
+            };
+        }
+        // The tip has passed every scheduled height but the stragglers still
+        // are not claimable, so they need confirmations bark has not seen yet,
+        // or they are wedged. There is no schedule left to wait on; fall
+        // through to the bounded wait.
+    }
+
+    // Either a straggler has no known ripening height, or the schedule has run
+    // out and something is stuck. Bounded wait, then go without it.
     if (now - since >= maxWaitMs) {
         return { claim: true, batchSince: since, reason: 'window-expired' };
     }

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -99,6 +99,58 @@ export type ExitFeeConvertEstimate = {
  * mempool.space rather than the configured esplora (blockstream), which the
  * codebase repeatedly notes bot-blocks bark's client.
  */
+/** Claim-fee bounds. The claim is NOT the exit-tree CPFP and must not be priced
+ *  like it: see fetchClaimFeeRateSatPerVb. Floor 1 because anything below the
+ *  relay minimum is unrelayable; ceiling because an unbounded spike would
+ *  reproduce the exact bug this exists to prevent. */
+const CLAIM_RATE_MIN = 1;
+const CLAIM_RATE_MAX = 5;
+
+/**
+ * Fee rate for the exit CLAIM, which is a different problem from the exit-tree
+ * CPFP that `fetchFastFeeRateSatPerVb` prices.
+ *
+ * The CPFP children are time-critical: the exit tree has to confirm before the
+ * VTXO expires, so paying for speed there is buying something real, and it is
+ * paid out of the on-chain reserve.
+ *
+ * A claim is the opposite. It spends an output whose CSV has already matured,
+ * it races nothing, and its fee comes out of the claimed value itself. Paying
+ * a "fastest" rate there buys no safety and directly destroys small claims.
+ *
+ * Observed live 2026-08-19 on a real mainnet exit: with no rate passed, bark
+ * priced a single-capsule claim at 779 sats against a 698 sat output and
+ * refused to build it ("Claim Fee Exceeds Output: Cost to claim exits was
+ * 0.00000779 BTC, but the total output was 0.00000698 BTC"). That is ~6.6
+ * sat/vB over the measured 117.5 vB claim, at a moment when the mempool wanted
+ * 1. The two claims that had already succeeded went at 1.1 and 1.9 sat/vB. The
+ * failure is caught and retried every drive tick, so the exit sat in an
+ * infinite retry loop that could never succeed.
+ *
+ * So: take the 1-hour rate, not the fastest, and clamp it.
+ */
+export async function fetchClaimFeeRateSatPerVb(): Promise<number> {
+    const clamp = (n: number) =>
+        Math.min(CLAIM_RATE_MAX, Math.max(CLAIM_RATE_MIN, Math.ceil(n)));
+    try {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 4000);
+        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
+            signal: controller.signal,
+        });
+        clearTimeout(t);
+        if (!res.ok) return CLAIM_RATE_MIN;
+        const rec = await res.json();
+        const raw = Number(rec?.hourFee ?? rec?.economyFee);
+        if (!isFinite(raw) || raw <= 0) return CLAIM_RATE_MIN;
+        return clamp(raw);
+    } catch {
+        // Unreachable fee API. Floor rather than the reserve's congestion hedge:
+        // an over-priced claim does not fail slowly, it fails permanently.
+        return CLAIM_RATE_MIN;
+    }
+}
+
 export async function fetchFastFeeRateSatPerVb(): Promise<number> {
     try {
         const controller = new AbortController();

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -22,8 +22,19 @@ import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
 import { assertNoActiveArkExit } from './exit';
-import type { ExitEconomicPolicy, ExitTriageResult, ExitTriageVtxo } from './exitTriage';
-import { RESERVE_FLOOR_SATS, SPIKE_MULT, triageArkExit } from './exitTriage';
+import type {
+    ExitEconomicPolicy,
+    ExitFeeUrgency,
+    ExitTriageResult,
+    ExitTriageVtxo,
+} from './exitTriage';
+import {
+    RESERVE_FLOOR_SATS,
+    SPIKE_MULT,
+    exitFeeUrgency,
+    triageArkExit,
+    urgencyFromSlackBlocks,
+} from './exitTriage';
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
 import { getArkWalletHandle } from './walletHandle';
@@ -81,6 +92,80 @@ export type ExitFeeConvertEstimate = {
  * mempool.space rather than the configured esplora (blockstream), which the
  * codebase repeatedly notes bot-blocks bark's client.
  */
+/**
+ * Which mempool.space rate each urgency band bids at. See ExitFeeUrgency for
+ * why the exit tree is not always in a hurry.
+ *
+ * `minimumFee` is deliberately absent. It is the relay floor, not a target, and
+ * an exit tx that fails to confirm does not merely arrive late, it can leave the
+ * capsule to be swept.
+ */
+const URGENCY_RATE_FIELD: Record<ExitFeeUrgency, string> = {
+    relaxed: 'economyFee',
+    moderate: 'hourFee',
+    soon: 'halfHourFee',
+    urgent: 'fastestFee',
+};
+
+/**
+ * Fee rate for the exit-tree CPFP children, at the urgency the capsules
+ * actually have.
+ *
+ * Falls back to the fastest rate present in the response, and then to the
+ * congestion-hedge constant, so a malformed or partial response bids HIGH.
+ * Under-bidding here risks the capsule; over-bidding only parks sats on-chain
+ * that stay the user's own.
+ */
+export type ExitFeeRateTable = Record<ExitFeeUrgency, number>;
+
+/**
+ * All four bands in ONE fetch.
+ *
+ * Fetched together because pricing the exit takes two passes (see
+ * computeArkExitPlan) and a second call between them would let the market move
+ * underneath the comparison, as well as costing a round trip on the exit path.
+ *
+ * Every fallback bids HIGH: a missing field falls back to the fastest rate in
+ * the response, an unusable response to the congestion hedge. Under-bidding
+ * risks the capsule, over-bidding only parks sats that stay the user's own.
+ */
+export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
+    const flat = (r: number): ExitFeeRateTable => ({
+        relaxed: r, moderate: r, soon: r, urgent: r,
+    });
+    try {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 4000);
+        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
+            signal: controller.signal,
+        });
+        clearTimeout(t);
+        if (!res.ok) return flat(RESERVE_FEE_FALLBACK_RATE);
+        const rec = await res.json();
+        const fastest = Number(rec?.fastestFee);
+        if (!isFinite(fastest) || fastest <= 0) return flat(RESERVE_FEE_FALLBACK_RATE);
+        const pick = (band: ExitFeeUrgency) => {
+            const v = Number(rec?.[URGENCY_RATE_FIELD[band]]);
+            return Math.max(1, Math.ceil(isFinite(v) && v > 0 ? v : fastest));
+        };
+        return {
+            relaxed: pick('relaxed'),
+            moderate: pick('moderate'),
+            soon: pick('soon'),
+            urgent: pick('urgent'),
+        };
+    } catch {
+        return flat(RESERVE_FEE_FALLBACK_RATE);
+    }
+}
+
+/** One band, for callers that already know their urgency (the exit drive). */
+export async function fetchExitTreeFeeRateSatPerVb(
+    urgency: ExitFeeUrgency,
+): Promise<number> {
+    return (await fetchExitFeeRates())[urgency];
+}
+
 export async function fetchFastFeeRateSatPerVb(): Promise<number> {
     try {
         const controller = new AbortController();
@@ -147,23 +232,64 @@ async function readExitCandidates(): Promise<ExitTriageVtxo[] | null> {
  *
  * Returns null only when there is no wallet handle or the VTXO read failed.
  */
+/**
+ * Deadline height from the most recent plan, for the caller to persist when it
+ * actually starts an exit. Module-level rather than on the result so the plan
+ * type stays a pure description of the exit set.
+ */
+let lastExitFeeDeadlineHeight: number | null = null;
+
+/** Deadline height the last computed plan was priced against. */
+export function getLastExitFeeDeadlineHeight(): number | null {
+    return lastExitFeeDeadlineHeight;
+}
+
 export async function computeArkExitPlan(
     opts?: { economicPolicy?: ExitEconomicPolicy },
 ): Promise<ExitTriageResult | null> {
     const vtxos = await readExitCandidates();
     if (!vtxos) return null;
 
-    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
     const s = useAuthStore.getState();
+    const chainTipHeight = s.arkChainTipHeight ?? null;
+    const vtxoExitDeltaBlocks = s.arkVtxoExitDeltaBlocks ?? null;
 
-    const plan = triageArkExit({
-        vtxos,
-        feeRateSatPerVb,
-        chainTipHeight: s.arkChainTipHeight ?? null,
-        vtxoExitDeltaBlocks: s.arkVtxoExitDeltaBlocks ?? null,
-        maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
-        economicPolicy: opts?.economicPolicy,
-    });
+    const rates = await fetchExitFeeRates();
+    const runTriage = (feeRateSatPerVb: number) =>
+        triageArkExit({
+            vtxos,
+            feeRateSatPerVb,
+            chainTipHeight,
+            vtxoExitDeltaBlocks,
+            maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
+            economicPolicy: opts?.economicPolicy,
+        });
+
+    // Pricing and selection depend on each other: the rate decides which
+    // capsules are worth exiting, and which capsules are being exited decides
+    // how urgent the rate has to be. Resolved in two passes rather than a fixed
+    // point, because the first pass IS the old behaviour and is therefore always
+    // a safe answer to fall back to.
+    //
+    // Pass 1 prices at the fastest rate, unconditionally, exactly as before. Its
+    // selection is what reveals the real urgency.
+    const urgentPlan = runTriage(rates.urgent);
+    let urgency = exitFeeUrgency(urgentPlan.selected);
+    let plan = urgentPlan;
+
+    if (rates[urgency.urgency] < rates.urgent) {
+        // Pass 2 at the rate the runway actually justifies. A cheaper rate can
+        // only ADD capsules, so re-read the urgency of that larger set: if a
+        // newcomer is tighter than anything in pass 1, the cheaper rate was not
+        // justified after all and pass 1 stands.
+        const relaxedPlan = runTriage(rates[urgency.urgency]);
+        const recheck = exitFeeUrgency(relaxedPlan.selected);
+        if (rates[recheck.urgency] <= rates[urgency.urgency]) {
+            plan = relaxedPlan;
+            urgency = recheck;
+        }
+    }
+    lastExitFeeDeadlineHeight = urgency.deadlineHeight;
 
     if (__DEV__) {
         console.log(
@@ -174,6 +300,8 @@ export async function computeArkExitPlan(
             'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
             'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
             '); policy=', plan.economicPolicy,
+            '; urgency=', urgency.urgency, 'slack=', urgency.tightestSlackBlocks, 'blocks',
+            '; rates=', JSON.stringify(rates),
             '; netLoss=', plan.netLossSats, '; overridable=', plan.overridableCount,
             plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
         );
@@ -266,6 +394,39 @@ export async function fetchArkExitParams(): Promise<void> {
     } catch (err) {
         if (__DEV__) console.warn('[Ark exit-funding] arkInfo (exit params) threw:', err);
     }
+}
+
+/**
+ * Fee rate the exit drive should bid for its CPFP children RIGHT NOW.
+ *
+ * `progressExits` used to be called with no rate at all, so bark chose one and
+ * whatever it chose had nothing to do with the reserve the user had been asked
+ * to fund. That was survivable only because the reserve was sized at the
+ * fastest rate and therefore almost always generous. Now that the reserve is
+ * priced to the runway, the bid has to be priced the same way or the two can
+ * disagree in the dangerous direction.
+ *
+ * Re-derived every tick from the persisted deadline height and the current tip,
+ * so a capsule drifting toward its expiry starts bidding harder on its own.
+ * Costs one small fee-API call and no wallet read.
+ *
+ * Returns undefined when there is no deadline to price against, which leaves
+ * the SDK's own choice in place rather than inventing one.
+ */
+export async function fetchArkExitDriveFeeRate(): Promise<bigint | undefined> {
+    const s = useAuthStore.getState();
+    const deadline = s.arkExitFeeDeadlineHeight;
+    const tip = s.arkChainTipHeight;
+    if (typeof deadline !== 'number' || typeof tip !== 'number') return undefined;
+    const urgency = urgencyFromSlackBlocks(deadline - tip);
+    const rate = await fetchExitTreeFeeRateSatPerVb(urgency);
+    if (__DEV__) {
+        console.log(
+            '[Ark exit-drive] bidding', rate, 'sat/vB;',
+            'urgency=', urgency, 'slack=', deadline - tip, 'blocks',
+        );
+    }
+    return BigInt(Math.max(1, Math.ceil(rate)));
 }
 
 /**

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -22,7 +22,7 @@ import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
 import { assertNoActiveArkExit } from './exit';
-import type { ExitTriageResult, ExitTriageVtxo } from './exitTriage';
+import type { ExitEconomicPolicy, ExitTriageResult, ExitTriageVtxo } from './exitTriage';
 import { RESERVE_FLOOR_SATS, SPIKE_MULT, triageArkExit } from './exitTriage';
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
@@ -141,9 +141,15 @@ async function readExitCandidates(): Promise<ExitTriageVtxo[] | null> {
  * axis assume the worst rather than skip (see ./exitTriage). That is the whole
  * point: the exit path has to work against a server that is gone.
  *
+ * `economicPolicy` is how far past the economics the user has chosen to go.
+ * Callers must leave it at the default until the user has been shown the loss
+ * in sats and asked (spec principle 4); it is not a retry knob.
+ *
  * Returns null only when there is no wallet handle or the VTXO read failed.
  */
-export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
+export async function computeArkExitPlan(
+    opts?: { economicPolicy?: ExitEconomicPolicy },
+): Promise<ExitTriageResult | null> {
     const vtxos = await readExitCandidates();
     if (!vtxos) return null;
 
@@ -156,6 +162,7 @@ export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
         chainTipHeight: s.arkChainTipHeight ?? null,
         vtxoExitDeltaBlocks: s.arkVtxoExitDeltaBlocks ?? null,
         maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
+        economicPolicy: opts?.economicPolicy,
     });
 
     if (__DEV__) {
@@ -166,6 +173,8 @@ export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
             'excluded', plan.excluded.length, 'holding', plan.excludedSats, 'sats;',
             'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
             'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
+            '); policy=', plan.economicPolicy,
+            '; netLoss=', plan.netLossSats, '; overridable=', plan.overridableCount,
             plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
         );
         for (const e of plan.excluded) {

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -18,48 +18,24 @@
  * of this reserve.
  */
 
+import useAuthStore from '@Cypher/stores/authStore';
+
 import { barkStateTag } from './barkState';
 import { assertNoActiveArkExit } from './exit';
+import type { ExitTriageResult, ExitTriageVtxo } from './exitTriage';
+import { RESERVE_FLOOR_SATS, SPIKE_MULT, triageArkExit } from './exitTriage';
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
 import { getArkWalletHandle } from './walletHandle';
 
 // --- Tunable sizing constants ----------------------------------------------
 //
-// The reserve is grounded in the SDK's own per-VTXO exit-cost data
-// (`Vtxo.exitTxWeightWu` = weight of the full unilateral exit tx chain, and
-// `Vtxo.exitDepth` = number of levels in that chain), so it tracks real exit
-// cost rather than a blind guess. The multipliers add headroom for the
-// multi-block window an exit spans (a fee spike mid-exit is its weak spot, and
-// per Bark's Peter you want runway to "refill the onchain wallet if you run
-// out"). All values are intentionally conservative: over-reserving is
-// harmless (the extra sats stay the user's own on-chain, and the auto-board
-// pipeline boards any excess above the reserve back into Ark later), while
-// under-reserving stalls the exit.
+// The per-capsule cost model (CPFP_CHILD_VB, FALLBACK_VB_PER_VTXO, SPIKE_MULT,
+// RESERVE_FLOOR_SATS) moved to ./exitTriage, which is the module that decides
+// which capsules the reserve is FOR. Keeping two copies would let the number
+// the user is asked to fund drift from the set it was sized over. Only the
+// fee-rate fallback, which is about fetching rather than costing, stays here.
 
-/** Per exit-tree level: the CPFP child (anchor input + funding input + change)
- *  that bumps that level. Upper-bounded; matches RECOVER_EST_VSIZE in
- *  ./recoverOnchainBoard.ts. Applied `exitDepth` times per VTXO. */
-const CPFP_CHILD_VB = 150;
-/** Headroom multiplier over the current fee rate, for a fee spike during the
- *  (multi-block) exit window. */
-const SPIKE_MULT = 2.0;
-/** Lower bound whenever there is anything to exit, so a low fee rate (or a
- *  runtime `exitTxWeightWu` of 0) still reserves enough for at least one CPFP
- *  child at a moderate rate. Kept below the 50k board minimum so it doesn't
- *  over-hoard on-chain.
- *
- *  Sized to the stated rationale (one CPFP child ~150 vB at a moderate rate
- *  with the spike buffer), not a flat 10k. The old 10k floor over-reserved
- *  small exits by 2-4x their real cost and, combined with the (soft) fee gate,
- *  made a well-funded small vault look unfundable for exit. This is guidance
- *  only now: the exit stays startable via "Start exit anyway" whenever there
- *  is any on-chain balance, so the floor no longer blocks — it just sets the
- *  auto-board hold target. */
-const RESERVE_FLOOR_SATS = 5_000;
-/** Fallback per-VTXO vsize used only if the SDK returns `exitTxWeightWu === 0`
- *  at runtime (the type says it's populated; guard anyway). */
-const FALLBACK_VB_PER_VTXO = 200;
 /** Fee-rate fallback (sat/vB) when the mempool fetch fails. Deliberately not
  *  tiny, since an emergency exit may run during congestion, but not the old
  *  20 either: on a flaky network the fee fetch fails often, and 20 sat/vB
@@ -74,12 +50,18 @@ export type ExitFeeReserve = {
     /** Recommended sats to hold on-chain to fund the exit. 0 when nothing is
      *  exitable (so a nothing-to-exit wallet is never gated). */
     recommendedSats: number;
-    /** Count of VTXOs the reserve was sized over. */
+    /** Count of VTXOs the reserve was sized over: the SELECTED set, not the
+     *  wallet. */
     vtxoCount: number;
     /** Fee rate (sat/vB) the recommendation was computed at. */
     feeRateSatPerVb: number;
-    /** Summed exit vsize across the exitable VTXOs (pre-multiplier). */
+    /** Summed exit vsize across the SELECTED VTXOs (pre-multiplier). */
     totalExitVb: number;
+    /** Capsules triage dropped from the exit set. */
+    excludedCount: number;
+    /** Face value of those capsules, which is what the user is being asked to
+     *  give up. Never allow this to be non-zero without naming them. */
+    excludedSats: number;
 };
 
 export type ExitFeeConvertEstimate = {
@@ -118,16 +100,98 @@ export async function fetchFastFeeRateSatPerVb(): Promise<number> {
 }
 
 /**
- * Compute the recommended on-chain fee reserve for a full-wallet exit.
+ * Read every capsule the exit could touch, in the flat shape ./exitTriage
+ * wants.
  *
- * Reads `handle.allVtxos()` fresh (the store's `ArkVtxoView` drops
- * `exitTxWeightWu` / `exitDepth`, so the cached VTXO list can't be reused).
- * (allVtxos is a JS-thread-blocking UniFFI call; call this off the render
- * path.) Filters to non-spent VTXOs, mirroring the wallet-exit set that
- * `startExitForEntireWallet` marks.
+ * Reads `handle.allVtxos()` fresh: the store's `ArkVtxoView` drops
+ * `exitTxWeightWu` and `exitDepth`, which are exactly the two fields the whole
+ * cost model turns on, so the cached VTXO list cannot be reused. allVtxos is a
+ * JS-thread-blocking UniFFI call, so keep this off the render path.
+ */
+async function readExitCandidates(): Promise<ExitTriageVtxo[] | null> {
+    const handle = getArkWalletHandle();
+    if (!handle) return null;
+    try {
+        const vtxos = await handle.allVtxos();
+        return (vtxos ?? []).map((v) => ({
+            id: v.id,
+            sats: Number(v.amountSats ?? 0n),
+            exitDepth: Number(v.exitDepth ?? 0),
+            exitTxWeightWu: Number(v.exitTxWeightWu ?? 0n),
+            expiryHeight: Number(v.expiryHeight ?? 0),
+            // bark 0.6.1: `state` is a tagged-enum object; flatten to its
+            // variant string so triage can compare it.
+            stateTag: barkStateTag(v.state),
+            registered: v.registered,
+        }));
+    } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] allVtxos threw:', err);
+        return null;
+    }
+}
+
+/**
+ * Decide which capsules an emergency exit should actually exit, and what that
+ * costs. This is the function the exit-start path calls: its `selectedIds` go
+ * to `startExitForVtxos`, and its `excluded` list is what the user has to be
+ * shown before they commit.
  *
- * Returns `recommendedSats: 0` when the wallet handle is unset or there is
- * nothing exitable.
+ * Takes no ASP call. `vtxoExitDelta` comes from the persisted cache written
+ * while the server was last reachable, and a missing cache makes the temporal
+ * axis assume the worst rather than skip (see ./exitTriage). That is the whole
+ * point: the exit path has to work against a server that is gone.
+ *
+ * Returns null only when there is no wallet handle or the VTXO read failed.
+ */
+export async function computeArkExitPlan(): Promise<ExitTriageResult | null> {
+    const vtxos = await readExitCandidates();
+    if (!vtxos) return null;
+
+    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
+    const s = useAuthStore.getState();
+
+    const plan = triageArkExit({
+        vtxos,
+        feeRateSatPerVb,
+        chainTipHeight: s.arkChainTipHeight ?? null,
+        vtxoExitDeltaBlocks: s.arkVtxoExitDeltaBlocks ?? null,
+        maxVtxoExitDepth: s.arkMaxVtxoExitDepth ?? null,
+    });
+
+    if (__DEV__) {
+        console.log(
+            '[Ark exit-triage] selected', plan.selected.length, 'of',
+            plan.selected.length + plan.excluded.length, 'capsules;',
+            plan.selectedSats, 'sats in,', plan.netRecoverableSats, 'recoverable;',
+            'excluded', plan.excluded.length, 'holding', plan.excludedSats, 'sats;',
+            'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
+            'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
+            plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
+        );
+        for (const e of plan.excluded) {
+            console.log(
+                `[Ark exit-triage] excluded ${e.id} ${e.sats} sats depth=${e.exitDepth}`,
+                `perVtxoVb=${e.perVtxoVb} reason=${e.reason}`,
+            );
+        }
+    }
+
+    return plan;
+}
+
+/**
+ * Recommended on-chain fee reserve, sized over the capsules the exit will
+ * ACTUALLY exit.
+ *
+ * It used to sum every non-spent VTXO, which billed the user for two things
+ * they never get back. Measured on the QA wallet 2026-08-20: dust that triage
+ * now discards was 66% of the demanded reserve (32,120 down to 10,808), and ten
+ * already-`Exited` capsules, which bark keeps returning from `allVtxos()`
+ * forever, added another 14,504 sats of reserve for value that was already
+ * on-chain.
+ *
+ * Returns `recommendedSats: 0` when the wallet handle is unset or nothing
+ * survives triage, so a wallet with nothing worth exiting is never gated.
  */
 export async function computeExitFeeReserveSats(): Promise<ExitFeeReserve> {
     const empty: ExitFeeReserve = {
@@ -135,55 +199,64 @@ export async function computeExitFeeReserveSats(): Promise<ExitFeeReserve> {
         vtxoCount: 0,
         feeRateSatPerVb: 0,
         totalExitVb: 0,
+        excludedCount: 0,
+        excludedSats: 0,
     };
 
-    const handle = getArkWalletHandle();
-    if (!handle) return empty;
-
-    let vtxos;
-    try {
-        vtxos = await handle.allVtxos();
-    } catch (err) {
-        if (__DEV__) console.warn('[Ark exit-funding] allVtxos threw:', err);
-        return empty;
-    }
-
-    const exitable = (vtxos ?? []).filter(
-        // bark 0.6.1: `state` is a tagged-enum object; read its variant string.
-        // Same semantics as before: exclude already-spent vtxos from the
-        // exit-fee estimate.
-        (v) => barkStateTag(v.state).toLowerCase() !== 'spent',
-    );
-    if (exitable.length === 0) return empty;
-
-    let totalExitVb = 0;
-    for (const v of exitable) {
-        const chainVb = Math.ceil(Number(v.exitTxWeightWu ?? 0n) / 4);
-        const perVtxoVb =
-            Math.max(chainVb, FALLBACK_VB_PER_VTXO) +
-            Math.max(0, Number(v.exitDepth ?? 0)) * CPFP_CHILD_VB;
-        totalExitVb += perVtxoVb;
-    }
-
-    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
-    const computed = Math.ceil(totalExitVb * feeRateSatPerVb * SPIKE_MULT);
-    const recommendedSats = Math.max(RESERVE_FLOOR_SATS, computed);
+    const plan = await computeArkExitPlan();
+    if (!plan) return empty;
 
     if (__DEV__) {
         console.log(
             '[Ark exit-funding] reserve:',
-            recommendedSats, 'sats over', exitable.length, 'vtxos;',
-            'totalExitVb=', totalExitVb,
-            'feeRate=', feeRateSatPerVb, 'sat/vB; spikeMult=', SPIKE_MULT,
+            plan.reserveSats, 'sats over', plan.selected.length, 'selected vtxos;',
+            'totalExitVb=', plan.totalExitVb,
+            'feeRate=', plan.feeRateSatPerVb, 'sat/vB; spikeMult=', SPIKE_MULT,
+            '; floor=', RESERVE_FLOOR_SATS,
         );
     }
 
     return {
-        recommendedSats,
-        vtxoCount: exitable.length,
-        feeRateSatPerVb,
-        totalExitVb,
+        recommendedSats: plan.reserveSats,
+        vtxoCount: plan.selected.length,
+        feeRateSatPerVb: plan.feeRateSatPerVb,
+        totalExitVb: plan.totalExitVb,
+        excludedCount: plan.excluded.length,
+        excludedSats: plan.excludedSats,
     };
+}
+
+/**
+ * Cache the server's exit-relevant protocol constants so the exit path never
+ * has to ask for them.
+ *
+ * `vtxoExitDelta` is the CSV a broadcast exit output sits out before it can be
+ * claimed, and it is what exit triage measures a capsule's remaining runway
+ * against. The exit path is not allowed to call the ASP (a user who pressed the
+ * trustless button must get the trustless path, and the server may simply be
+ * gone), so this has to be fetched while the server is still reachable and
+ * persisted. A missing cache is handled, not fatal: triage assumes the worst
+ * plausible delta, which errs toward disclosing an exclusion rather than
+ * committing reserve to a capsule the server can sweep mid-exit.
+ *
+ * Called once per session from the sync loop, next to the round-interval
+ * fetch. Never throws.
+ */
+export async function fetchArkExitParams(): Promise<void> {
+    const handle = getArkWalletHandle();
+    if (!handle) return;
+    try {
+        const info = await handle.arkInfo();
+        if (!info) return;
+        const delta = Number(info.vtxoExitDelta);
+        const maxDepth = Number(info.maxVtxoExitDepth);
+        useAuthStore.getState().setArkExitParams({
+            vtxoExitDeltaBlocks: Number.isFinite(delta) && delta > 0 ? delta : null,
+            maxVtxoExitDepth: Number.isFinite(maxDepth) && maxDepth > 0 ? maxDepth : null,
+        });
+    } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] arkInfo (exit params) threw:', err);
+    }
 }
 
 /**

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -21,17 +21,22 @@
 import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
+import { ESPLORA_URLS } from './config';
 import { assertNoActiveArkExit } from './exit';
 import type {
     ExitEconomicPolicy,
+    ExitFeeRateTable,
     ExitFeeUrgency,
     ExitTriageResult,
     ExitTriageVtxo,
 } from './exitTriage';
 import {
+    EXIT_FEE_FALLBACK_RATES,
     RESERVE_FLOOR_SATS,
     SPIKE_MULT,
     exitFeeUrgency,
+    ratesFromEsploraEstimates,
+    ratesFromMempoolRecommended,
     triageArkExit,
     urgencyFromSlackBlocks,
 } from './exitTriage';
@@ -93,21 +98,6 @@ export type ExitFeeConvertEstimate = {
  * codebase repeatedly notes bot-blocks bark's client.
  */
 /**
- * Which mempool.space rate each urgency band bids at. See ExitFeeUrgency for
- * why the exit tree is not always in a hurry.
- *
- * `minimumFee` is deliberately absent. It is the relay floor, not a target, and
- * an exit tx that fails to confirm does not merely arrive late, it can leave the
- * capsule to be swept.
- */
-const URGENCY_RATE_FIELD: Record<ExitFeeUrgency, string> = {
-    relaxed: 'economyFee',
-    moderate: 'hourFee',
-    soon: 'halfHourFee',
-    urgent: 'fastestFee',
-};
-
-/**
  * Fee rate for the exit-tree CPFP children, at the urgency the capsules
  * actually have.
  *
@@ -116,50 +106,60 @@ const URGENCY_RATE_FIELD: Record<ExitFeeUrgency, string> = {
  * Under-bidding here risks the capsule; over-bidding only parks sats on-chain
  * that stay the user's own.
  */
-export type ExitFeeRateTable = Record<ExitFeeUrgency, number>;
-
 /**
- * All four bands in ONE fetch.
+ * All four bands, from the best source that answers.
  *
- * Fetched together because pricing the exit takes two passes (see
- * computeArkExitPlan) and a second call between them would let the market move
- * underneath the comparison, as well as costing a round trip on the exit path.
+ * Three sources, in order, because a single fee API is a single point of
+ * failure and it fired on the first day: mempool.space was unreachable from
+ * both the device and the dev machine on 2026-08-20, which collapsed every band
+ * to one constant and undid the runway pricing entirely.
  *
- * Every fallback bids HIGH: a missing field falls back to the fastest rate in
- * the response, an unusable response to the congestion hedge. Under-bidding
- * risks the capsule, over-bidding only parks sats that stay the user's own.
+ *   1. mempool.space named tiers, the richest signal
+ *   2. esplora /fee-estimates, keyed by confirmation target, across the same
+ *      providers the wallet already rotates (blockstream answered when
+ *      mempool.space did not)
+ *   3. band-aware constants, which still respect urgency rather than flattening
+ *
+ * Fetched as a table rather than one band at a time because pricing the exit
+ * takes more than one pass (see computeArkExitPlan) and refetching between them
+ * would let the market move underneath the comparison.
  */
 export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
-    const flat = (r: number): ExitFeeRateTable => ({
-        relaxed: r, moderate: r, soon: r, urgent: r,
-    });
-    try {
-        const controller = new AbortController();
-        const t = setTimeout(() => controller.abort(), 4000);
-        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
-            signal: controller.signal,
-        });
-        clearTimeout(t);
-        if (!res.ok) return flat(RESERVE_FEE_FALLBACK_RATE);
-        const rec = await res.json();
-        const fastest = Number(rec?.fastestFee);
-        if (!isFinite(fastest) || fastest <= 0) return flat(RESERVE_FEE_FALLBACK_RATE);
-        const pick = (band: ExitFeeUrgency) => {
-            const v = Number(rec?.[URGENCY_RATE_FIELD[band]]);
-            return Math.max(1, Math.ceil(isFinite(v) && v > 0 ? v : fastest));
-        };
-        return {
-            relaxed: pick('relaxed'),
-            moderate: pick('moderate'),
-            soon: pick('soon'),
-            urgent: pick('urgent'),
-        };
-    } catch {
-        return flat(RESERVE_FEE_FALLBACK_RATE);
+    const get = async (url: string): Promise<unknown | null> => {
+        try {
+            const controller = new AbortController();
+            const t = setTimeout(() => controller.abort(), 4000);
+            const res = await fetch(url, { signal: controller.signal });
+            clearTimeout(t);
+            if (!res.ok) return null;
+            return await res.json();
+        } catch {
+            return null;
+        }
+    };
+
+    const recommended = await get('https://mempool.space/api/v1/fees/recommended');
+    const fromMempool = ratesFromMempoolRecommended(recommended);
+    if (fromMempool) return fromMempool;
+
+    for (const base of ESPLORA_URLS) {
+        const est = await get(`${base}/fee-estimates`);
+        const fromEsplora = ratesFromEsploraEstimates(est);
+        if (fromEsplora) {
+            if (__DEV__) console.log('[Ark exit-funding] fee rates via esplora', base, fromEsplora);
+            return fromEsplora;
+        }
     }
+
+    if (__DEV__) {
+        console.warn(
+            '[Ark exit-funding] every fee source unreachable; using band-aware fallback',
+            EXIT_FEE_FALLBACK_RATES,
+        );
+    }
+    return EXIT_FEE_FALLBACK_RATES;
 }
 
-/** One band, for callers that already know their urgency (the exit drive). */
 export async function fetchExitTreeFeeRateSatPerVb(
     urgency: ExitFeeUrgency,
 ): Promise<number> {
@@ -267,25 +267,32 @@ export async function computeArkExitPlan(
 
     // Pricing and selection depend on each other: the rate decides which
     // capsules are worth exiting, and which capsules are being exited decides
-    // how urgent the rate has to be. Resolved in two passes rather than a fixed
-    // point, because the first pass IS the old behaviour and is therefore always
-    // a safe answer to fall back to.
-    //
-    // Pass 1 prices at the fastest rate, unconditionally, exactly as before. Its
-    // selection is what reveals the real urgency.
+    // how urgent the rate has to be. Resolved by probing rather than iterating
+    // to a fixed point, because the dearest pass IS the old behaviour and is
+    // therefore always a safe answer to fall back to.
     const urgentPlan = runTriage(rates.urgent);
-    let urgency = exitFeeUrgency(urgentPlan.selected);
     let plan = urgentPlan;
+    let urgency = exitFeeUrgency(urgentPlan.selected);
+
+    if (urgentPlan.selected.length === 0 && rates.relaxed < rates.urgent) {
+        // Nothing survives at the dearest rate, so there is no selection to read
+        // an urgency off, and taking the empty set's 'urgent' at face value
+        // pins the rate high and keeps the answer permanently empty. Probe the
+        // cheapest band: if anything IS exitable down there, its own runway
+        // decides the real rate below.
+        const cheapest = runTriage(rates.relaxed);
+        if (cheapest.selected.length > 0) urgency = exitFeeUrgency(cheapest.selected);
+    }
 
     if (rates[urgency.urgency] < rates.urgent) {
-        // Pass 2 at the rate the runway actually justifies. A cheaper rate can
-        // only ADD capsules, so re-read the urgency of that larger set: if a
-        // newcomer is tighter than anything in pass 1, the cheaper rate was not
-        // justified after all and pass 1 stands.
-        const relaxedPlan = runTriage(rates[urgency.urgency]);
-        const recheck = exitFeeUrgency(relaxedPlan.selected);
-        if (rates[recheck.urgency] <= rates[urgency.urgency]) {
-            plan = relaxedPlan;
+        // Price at what the runway justifies. A cheaper rate can only ADD
+        // capsules, so re-read the urgency of that larger set: if a newcomer is
+        // tighter than anything already counted, the cheaper rate was not
+        // justified after all and the dearest pass stands.
+        const cheaperPlan = runTriage(rates[urgency.urgency]);
+        const recheck = exitFeeUrgency(cheaperPlan.selected);
+        if (cheaperPlan.selected.length > 0 && rates[recheck.urgency] <= rates[urgency.urgency]) {
+            plan = cheaperPlan;
             urgency = recheck;
         }
     }

--- a/src/services/ark/exitFundingCoinos.ts
+++ b/src/services/ark/exitFundingCoinos.ts
@@ -1,0 +1,143 @@
+/**
+ * Fund the exit-fee reserve from a CoinOS balance.
+ *
+ * CoinOS is first of the wallet sources because it settles without a signing
+ * device and is where most spare sats sit. The send is an ordinary on-chain
+ * withdrawal to the Bark wallet's own on-chain address, so it needs no ASP and
+ * works during an outage, which is exactly when the reserve tends to be needed.
+ *
+ * Two ordering rules matter and neither is obvious:
+ *
+ *   1. ARM THE RESERVE FIRST. sync.ts boards confirmed on-chain funds into Ark
+ *      unless `arkExitFeeReserveSats` says to hold them. During an active exit
+ *      boarding is already off, but the precautionary case (topping up BEFORE
+ *      starting an exit) would otherwise quietly undo itself on the next tick.
+ *      Arming before sending means the sats are protected the moment they land.
+ *
+ *   2. CHECK FOR A DUPLICATE BEFORE SENDING. A previous attempt whose reply was
+ *      lost is already on its way, and sending again pays twice. See
+ *      services/coinos/withdrawGuard.
+ *
+ * Network calls are injected so this can be tested without standing up the API
+ * layer, and so the caller keeps control of the auth-bearing fetches.
+ */
+
+import {
+    findRecentMatchingWithdrawal,
+    isCoinosWithdrawIndeterminate,
+    type CoinosPaymentLike,
+} from '../coinos/withdrawGuard';
+
+import { planExitFunding } from './exitFundingPlan';
+
+export type CoinosExitFundingDeps = {
+    /** Bark's own on-chain address. Local BDK, no ASP. */
+    getOnchainAddress: () => Promise<string>;
+    /** Recent CoinOS payments, for the duplicate check. */
+    getRecentPayments: () => Promise<{ payments?: CoinosPaymentLike[] } | null>;
+    /** Estimated miner fee for this send, in sats. */
+    estimateFeeSats: (address: string, amountSats: number) => Promise<number>;
+    /** Perform the withdrawal. Should carry the idempotency key. */
+    send: (address: string, amountSats: number, idempotencyKey: string) => Promise<string>;
+    /** Persist the reserve so auto-board leaves the funds alone. */
+    armReserve: (sats: number) => void;
+    now?: () => number;
+};
+
+export type CoinosExitFundingRequest = {
+    shortfallSats: number;
+    availableSats: number | null;
+    /** Reserve already armed, so arming never lowers an existing floor. */
+    currentReserveSats?: number;
+    idempotencyKey: string;
+};
+
+export type CoinosExitFundingResult =
+    | { ok: true; txid: string | null; sentSats: number; feeSats: number; partial: boolean }
+    | { ok: false; reason: string; duplicate?: boolean; indeterminate?: boolean };
+
+export async function fundExitFeesFromCoinos(
+    req: CoinosExitFundingRequest,
+    deps: CoinosExitFundingDeps,
+): Promise<CoinosExitFundingResult> {
+    const now = deps.now ?? (() => Date.now());
+
+    const address = await deps.getOnchainAddress();
+    if (!address) {
+        return { ok: false, reason: 'Could not get the on-chain address for the fee reserve.' };
+    }
+
+    // Fee first: the plan cannot be sized without it, because the fee comes off
+    // the top of the source balance.
+    let feeSats = 0;
+    try {
+        feeSats = Math.max(0, Math.floor((await deps.estimateFeeSats(address, req.shortfallSats)) || 0));
+    } catch {
+        // An unavailable estimate must not block funding. planExitFunding
+        // handles fee 0 and the provider still charges what it charges.
+        feeSats = 0;
+    }
+
+    const plan = planExitFunding({
+        shortfallSats: req.shortfallSats,
+        availableSats: req.availableSats,
+        feeSats,
+    });
+    if (!plan.ok) return { ok: false, reason: plan.reason };
+
+    // Duplicate check before spending anything. A failed history read does NOT
+    // block: being unable to read history is not evidence of a duplicate.
+    try {
+        const recent = await deps.getRecentPayments();
+        const dupe = findRecentMatchingWithdrawal(recent?.payments, {
+            address,
+            amountSats: plan.sendSats,
+            now: now(),
+        });
+        if (dupe) {
+            return {
+                ok: false,
+                duplicate: true,
+                reason: 'A matching top-up already went out a moment ago. Check your CoinOS history rather than sending again.',
+            };
+        }
+    } catch {
+        // Continue: see above.
+    }
+
+    // Arm BEFORE sending, so the sats are protected the instant they confirm.
+    // Never lower an existing floor: a bigger reserve someone already chose is
+    // not ours to shrink.
+    const target = Math.max(req.currentReserveSats ?? 0, (req.currentReserveSats ?? 0) + plan.sendSats);
+    deps.armReserve(target);
+
+    try {
+        const raw = await deps.send(address, plan.sendSats, req.idempotencyKey);
+        // CoinOS answers with a JSON body on success and a bare string on
+        // refusal, the same shape the withdraw screen already contends with.
+        let txid: string | null = null;
+        if (typeof raw === 'string' && raw.trim().startsWith('{')) {
+            try {
+                txid = JSON.parse(raw)?.txid ?? null;
+            } catch {
+                txid = null;
+            }
+        } else if (typeof raw === 'string' && raw.trim()) {
+            return { ok: false, reason: raw.trim() };
+        }
+        return { ok: true, txid, sentSats: plan.sendSats, feeSats, partial: plan.partial };
+    } catch (err) {
+        if (isCoinosWithdrawIndeterminate(err)) {
+            // Outcome unknown. The reserve stays armed on purpose: if the send
+            // did go through, the sats must not be boarded away when they land.
+            return {
+                ok: false,
+                indeterminate: true,
+                reason:
+                    (err as Error)?.message ??
+                    'This top-up may already have been sent. Check your CoinOS history before trying again.',
+            };
+        }
+        return { ok: false, reason: (err as Error)?.message ?? 'The top-up could not be sent.' };
+    }
+}

--- a/src/services/ark/exitFundingPlan.ts
+++ b/src/services/ark/exitFundingPlan.ts
@@ -1,0 +1,97 @@
+/**
+ * How much to send when funding the exit-fee reserve from another wallet.
+ *
+ * Separated from the screen and from the provider because the arithmetic is
+ * where this goes wrong, and the failure is expensive in both directions:
+ * sending too little leaves the exit stalled after the user believed they had
+ * fixed it, and sending everything strips a wallet they may still need.
+ *
+ * The number that matters is what LANDS on-chain, not what leaves. The miner
+ * fee comes out on top, so a wallet holding exactly the shortfall cannot
+ * deliver the shortfall.
+ */
+
+import { MIN_USEFUL_FUNDING_SATS } from './exitFundingSources';
+
+export type ExitFundingPlanInput = {
+    /** Sats the reserve is short by. */
+    shortfallSats: number;
+    /** Spendable sats at the source, or null when unknown. */
+    availableSats: number | null;
+    /** Estimated miner fee for this send. */
+    feeSats: number;
+    /** Floor below which a contribution cannot pay its own way. */
+    minUsefulSats?: number;
+};
+
+export type ExitFundingPlan =
+    | {
+          ok: true;
+          /** Sats to hand the provider, i.e. what should land. */
+          sendSats: number;
+          /** Total leaving the source, send + fee. */
+          totalCostSats: number;
+          /** True when this does not close the whole shortfall. */
+          partial: boolean;
+      }
+    | { ok: false; reason: string };
+
+export function planExitFunding(input: ExitFundingPlanInput): ExitFundingPlan {
+    const minUseful = input.minUsefulSats ?? MIN_USEFUL_FUNDING_SATS;
+    const shortfall = Math.max(0, Math.floor(input.shortfallSats || 0));
+    const fee = Math.max(0, Math.floor(input.feeSats || 0));
+
+    if (shortfall <= 0) {
+        return { ok: false, reason: 'The exit-fee reserve is already funded.' };
+    }
+
+    // An unreadable balance is not a zero balance. Plan for the full shortfall
+    // and let the provider reject it if the funds are not there: refusing here
+    // would strand a user whose balance simply failed to load.
+    const available =
+        typeof input.availableSats === 'number' && Number.isFinite(input.availableSats)
+            ? Math.max(0, Math.floor(input.availableSats))
+            : null;
+
+    if (available == null) {
+        return {
+            ok: true,
+            sendSats: shortfall,
+            totalCostSats: shortfall + fee,
+            partial: false,
+        };
+    }
+
+    // The fee is charged on top, so the most that can LAND is balance - fee.
+    const maxLanding = available - fee;
+
+    if (maxLanding < minUseful) {
+        return {
+            ok: false,
+            // Name the fee explicitly. "Insufficient balance" reads as a lie to
+            // someone looking at a balance larger than the amount they typed.
+            reason:
+                fee > 0
+                    ? `Not enough to cover the ${fee.toLocaleString()} sat network fee and a useful top-up.`
+                    : 'Balance is too small to be worth sending.',
+        };
+    }
+
+    if (maxLanding >= shortfall) {
+        return {
+            ok: true,
+            sendSats: shortfall,
+            totalCostSats: shortfall + fee,
+            partial: false,
+        };
+    }
+
+    // Partial funding is still progress: it can be the difference between an
+    // exit that finishes and one that stalls. Send what fits and say so.
+    return {
+        ok: true,
+        sendSats: maxLanding,
+        totalCostSats: available,
+        partial: true,
+    };
+}

--- a/src/services/ark/exitFundingSources.ts
+++ b/src/services/ark/exitFundingSources.ts
@@ -1,0 +1,123 @@
+/**
+ * Which wallets can top up the exit-fee reserve, and which cannot right now.
+ *
+ * The funding sheet's "Receive Bitcoin" tab hands the user an address and
+ * leaves them to find some bitcoin. That is the ASP-independent path and it
+ * always works, but it is also the least helpful thing to show someone whose
+ * exit has stalled and who already holds sats in this very app.
+ *
+ * This builds the list behind "Fund from another wallet". It is pure: state in,
+ * sources out, so the ordering and the availability rules can be tested without
+ * a screen.
+ *
+ * DESIGN NOTES, because two of these are easy to get wrong.
+ *
+ * Unavailable sources are RETURNED, not filtered out, each carrying its reason.
+ * A user who cannot see their Hot Vault in the list concludes the feature is
+ * broken; one who sees it greyed out with "no spendable capsules" has learned
+ * something. Callers render them disabled.
+ *
+ * Cold Vault is ordered LAST and flagged slow. It needs a PSBT round-trip
+ * through an airgapped signer, which is minutes to hours. Offering it as a peer
+ * of Hot Vault to someone in a degraded exit invites the worst choice on the
+ * list.
+ */
+
+export type ExitFundingSourceId = 'coinos' | 'strike' | 'hot-vault' | 'cold-vault';
+
+export type ExitFundingSource = {
+    id: ExitFundingSourceId;
+    label: string;
+    /** Selectable right now. */
+    available: boolean;
+    /** Why not, when `available` is false. Shown to the user verbatim. */
+    unavailableReason?: string;
+    /** Spendable sats this source could contribute, when known. */
+    balanceSats?: number;
+    /** Needs a hardware signing round-trip, so it is slow. */
+    slow?: boolean;
+};
+
+export type ExitFundingSourceState = {
+    coinos?: { connected: boolean; balanceSats?: number | null } | null;
+    strike?: { connected: boolean; balanceSats?: number | null } | null;
+    hotVault?: { walletID: string | null; balanceSats?: number | null } | null;
+    coldVault?: { walletID: string | null; balanceSats?: number | null } | null;
+    /** Sats still needed. Sources holding less than this are still offered. */
+    shortfallSats?: number;
+};
+
+/** Below this a contribution cannot cover its own on-chain fee. */
+export const MIN_USEFUL_FUNDING_SATS = 1_000;
+
+function sats(v: number | null | undefined): number | undefined {
+    return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : undefined;
+}
+
+function custodial(
+    id: 'coinos' | 'strike',
+    label: string,
+    entry: { connected: boolean; balanceSats?: number | null } | null | undefined,
+): ExitFundingSource {
+    if (!entry?.connected) {
+        return { id, label, available: false, unavailableReason: `Not connected` };
+    }
+    const balanceSats = sats(entry.balanceSats);
+    if (balanceSats != null && balanceSats < MIN_USEFUL_FUNDING_SATS) {
+        return {
+            id,
+            label,
+            available: false,
+            balanceSats,
+            // Naming the floor beats "insufficient balance", which leaves the
+            // user guessing how much would be enough.
+            unavailableReason: `Balance below ${MIN_USEFUL_FUNDING_SATS.toLocaleString()} sats`,
+        };
+    }
+    return { id, label, available: true, balanceSats };
+}
+
+function vault(
+    id: 'hot-vault' | 'cold-vault',
+    label: string,
+    entry: { walletID: string | null; balanceSats?: number | null } | null | undefined,
+    opts: { slow?: boolean } = {},
+): ExitFundingSource {
+    const base = { id, label, slow: opts.slow } as ExitFundingSource;
+    if (!entry?.walletID) {
+        return { ...base, available: false, unavailableReason: 'No vault on this device' };
+    }
+    const balanceSats = sats(entry.balanceSats);
+    if (balanceSats != null && balanceSats < MIN_USEFUL_FUNDING_SATS) {
+        return {
+            ...base,
+            available: false,
+            balanceSats,
+            unavailableReason: 'No spendable capsules',
+        };
+    }
+    return { ...base, available: true, balanceSats };
+}
+
+/**
+ * Ordered list of funding sources.
+ *
+ * Custodial wallets first: they hold most users' spare sats and settle without
+ * a signing device. Hot Vault next. Cold Vault last, always, because it is the
+ * slow one.
+ */
+export function buildExitFundingSources(
+    state: ExitFundingSourceState = {},
+): ExitFundingSource[] {
+    return [
+        custodial('coinos', 'CoinOS', state.coinos),
+        custodial('strike', 'Strike', state.strike),
+        vault('hot-vault', 'Hot Vault', state.hotVault),
+        vault('cold-vault', 'Cold Vault', state.coldVault, { slow: true }),
+    ];
+}
+
+/** True when at least one source can actually be used. */
+export function hasUsableExitFundingSource(sources: readonly ExitFundingSource[]): boolean {
+    return sources.some((s) => s.available);
+}

--- a/src/services/ark/exitReserveTarget.ts
+++ b/src/services/ark/exitReserveTarget.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helper: which reserve figure the exit-fee gate measures against.
+ *
+ * Deliberately free of imports so it stays unit-testable without the native
+ * bark module, matching exitFundingPlan.ts and refreshBatch.ts.
+ */
+
+/**
+ * Which reserve figure the exit-fee gate, the shortfall and all the funding
+ * copy should measure against.
+ *
+ * `arkExitFeeReserveSats` is the amount the user armed, and it is a snapshot of
+ * a decision made at one moment. `computeExitFeeReserveSats` is what an exit is
+ * estimated to cost RIGHT NOW, and it moves with the wallet: capsule count, and
+ * far more sharply, exit depth, which is linear in the reserve and was measured
+ * varying 25x inside a single wallet.
+ *
+ * The screen used to let an armed value REPLACE the recommendation outright:
+ *
+ *     armed > 0 ? armed : recommended
+ *
+ * so an armed figure silently went stale as the wallet grew. Observed on device
+ * 2026-08-20: armed 3,654, on-chain 6,259, recommendation 233,120. The gate
+ * reported the reserve fully funded and the shortfall as 0, on the same screen
+ * that recommended 233,120, leaving the user 227k short of the app's own
+ * estimate while being told they were ready. `reserveBelowRecommended` already
+ * detected exactly this and only produced a warning the gate ignored.
+ *
+ * Taking the greater of the two keeps user agency in the safe direction (arming
+ * MORE than recommended is a deliberate fee-spike buffer and is honoured) and
+ * removes it in the dangerous one (an armed value can no longer claim the exit
+ * is funded when the estimate says otherwise).
+ *
+ * Returns 0 when neither is known, which is the pre-compute state: callers gate
+ * on `> 0` so a 0 target means "do not gate yet", not "nothing needed".
+ */
+export function resolveExitReserveTarget(input: {
+    armedSats: number | null | undefined;
+    recommendedSats: number | null | undefined;
+}): number {
+    const armed = Math.max(0, Math.floor(input.armedSats ?? 0));
+    const recommended = Math.max(0, Math.floor(input.recommendedSats ?? 0));
+    return Math.max(armed, recommended);
+}

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -1,0 +1,483 @@
+/**
+ * Which capsules a unilateral exit should actually exit, and what that costs.
+ *
+ * Pure and import-free on purpose, so it stays unit-testable without the native
+ * bark module, matching exitFundingPlan.ts, refreshBatch.ts, exitReserveTarget.ts
+ * and autoBoardDecision.ts.
+ *
+ * WHY THIS EXISTS
+ *
+ * `startExitForEntireWallet()` marks every VTXO and `computeExitFeeReserveSats`
+ * sums every non-spent VTXO, so an exit chases capsules it can never recover and
+ * bills the user for the privilege. Measured 2026-08-20 on the QA wallet at
+ * 1 sat/vB: exiting all 8 live capsules costs 16,060 sats of exit-tree fees to
+ * rescue 4,990 sats of value, and two 400-sat capsules are 10,656 of that (66%)
+ * while holding 16% of the value. Excluding those two takes the demanded reserve
+ * from 32,120 to 10,808.
+ *
+ * The failure mode is not the claim. `drainExits` batches, so a small capsule
+ * adds roughly one input (~76 vB) and returns its value; it pays for itself at
+ * claim time. The damage is that dust silently consumes the CPFP reserve the
+ * healthy capsules need, and with no ordering policy, which capsules get
+ * stranded when the reserve runs dry is undefined.
+ *
+ * THE THRESHOLD IS NOT A SAT AMOUNT
+ *
+ * A 400-sat capsule at exitDepth 17 costs 5,645 vB and is hopeless. A 400 at
+ * depth 2 costs 632 vB and is merely marginal. The rule is computed per capsule
+ * from `exitDepth` and `exitTxWeightWu`. ARK_REFRESH_MIN_SATS (500) is the
+ * REFRESH floor and is the wrong tool here.
+ *
+ * TWO POTS, NEVER ONE THRESHOLD
+ *
+ * The exit-tree cost is charged to the on-chain reserve the user funds
+ * separately. The claim cost comes out of the capsule itself. Summing them into
+ * a single number would misprice both, so they are tracked separately all the
+ * way through.
+ */
+
+// --- Cost model ------------------------------------------------------------
+//
+// Single source of truth for per-capsule exit cost. exitFunding.ts imports
+// these rather than keeping its own copy, so the reserve the user is asked to
+// fund and the triage that decides what the reserve is for can never disagree.
+
+/** Per exit-tree level: the CPFP child (anchor input + funding input + change)
+ *  that bumps that level. Upper-bounded; matches RECOVER_EST_VSIZE in
+ *  ./recoverOnchainBoard.ts. Applied `exitDepth` times per capsule. */
+export const CPFP_CHILD_VB = 150;
+
+/** Fallback per-capsule vsize used only when the SDK reports
+ *  `exitTxWeightWu === 0`. Measured across 196 capsules on 2026-08-19: zero
+ *  report 0, including all 117 unregistered ones. Guard anyway. */
+export const FALLBACK_VB_PER_VTXO = 200;
+
+/** Headroom multiplier over the current fee rate, for a fee spike during the
+ *  multi-block exit window. */
+export const SPIKE_MULT = 2.0;
+
+/** Lower bound whenever there is anything to exit, so a low fee rate still
+ *  reserves enough for at least one CPFP child at a moderate rate. Kept below
+ *  the 50k board minimum so it does not over-hoard on-chain. */
+export const RESERVE_FLOOR_SATS = 5_000;
+
+/** Marginal vsize one more capsule adds to a batched `drainExits` claim.
+ *  Measured 2026-08-19/20: a standalone 1-in-1-out claim is 117.5 vB
+ *  (224 bytes, 470 wu) and each extra input adds ~76. The marginal figure is
+ *  the right one because the app always claims through one batched
+ *  `drainExits`, so the transaction overhead is paid once for the whole exit,
+ *  not once per capsule. */
+export const CLAIM_INPUT_VB = 76;
+
+/** Blocks of confirmation runway assumed per exit-tree level.
+ *
+ *  MODELLED, not measured. Each level spends the level above it, so a level
+ *  cannot be broadcast until its parent confirms, and the drive that broadcasts
+ *  them is foreground-only and rate-limited by the chain source. One block per
+ *  level would assume every CPFP child lands in the next block with the app
+ *  open throughout, which the 2026-08-17/20 exit did not manage. Six blocks
+ *  (about an hour) per level keeps the temporal axis conservative in the safe
+ *  direction: it excludes a capsule slightly too early rather than committing
+ *  reserve to one the server can sweep mid-exit. */
+export const BLOCKS_PER_EXIT_LEVEL = 6;
+
+/** Floor on the confirmation budget, so a shallow tree still gets real runway. */
+export const MIN_CONFIRMATION_BUDGET_BLOCKS = 6;
+
+/** CSV delta assumed when `ArkInfo.vtxoExitDelta` was never cached.
+ *
+ *  The exit path must not call the ASP (spec principle 2), so a missing cache
+ *  cannot be resolved at exit time. Observed mainnet value is 144. Assuming the
+ *  worst plausible delta rather than skipping the check means doubling it, the
+ *  same 2x posture SPIKE_MULT takes toward fee rates. A capsule excluded on the
+ *  assumed delta is named to the user, so the cost of being wrong here is a
+ *  disclosed exclusion, not a silent loss. */
+export const ASSUMED_EXIT_DELTA_BLOCKS = 288;
+
+/** How far under water a capsule may be and still be worth exiting.
+ *
+ *  A capsule is worth exiting outright when the reserve it consumes is less
+ *  than what it returns. Almost nothing clears that bar: at 1 sat/vB, in the
+ *  cheapest fee market in years, the BEST capsule in the measured wallet (698
+ *  sats, depth 2) spends 632 of reserve to return 622. So a strict
+ *  cost-under-value rule would exclude the entire wallet and the emergency exit
+ *  would do nothing.
+ *
+ *  The honest line is degree, not sign. Refusing to exit a capsule that spends
+ *  632 to return 622 abandons 622 sats to the server to save 10 sats of
+ *  reserve, which is worse for the user in every direction. Refusing one that
+ *  spends 5,645 to return 324 saves seventeen times what it costs. This
+ *  multiple is where those two cases separate: spend up to twice what comes
+ *  back, never seventeen times.
+ *
+ *  It is scale-aware without being fee-rate-blind, because both sides move with
+ *  the fee rate and the claim side eats the value: the same 698 at depth 2 is
+ *  1.0x under water at 1 sat/vB, 9.9x at 5, and returns nothing at all at 20. */
+export const MAX_RESERVE_MULTIPLE = 2;
+
+/** VTXO states that hold nothing to exit. `Exited` matters as much as `Spent`
+ *  here: bark keeps returning a completed exit's VTXO from `allVtxos()` as
+ *  `Exited` forever, and the reserve calc used to filter only `spent`, so ten
+ *  finished exits on the measured wallet added 7,252 vB (14,504 sats of
+ *  demanded reserve, 31% of the total) for capsules whose value is already
+ *  on-chain. */
+const TERMINAL_STATE_TAGS = new Set(['spent', 'exited']);
+
+// --- Types -----------------------------------------------------------------
+
+/** One capsule, flattened from the SDK's `Vtxo` at the call boundary so this
+ *  module never touches bigint or the native module. */
+export type ExitTriageVtxo = {
+    id: string;
+    sats: number;
+    /** Genesis chain length. Dominates cost: measured min 2, median 9, max 49. */
+    exitDepth: number;
+    /** Weight units of the unilateral exit transaction chain. */
+    exitTxWeightWu: number;
+    /** Absolute block height the capsule expires at. 0 when unknown. */
+    expiryHeight: number;
+    /** `Vtxo.state` flattened to its variant name (see ./barkState). */
+    stateTag: string;
+    /** Server recovery-mailbox flag. Does NOT affect exitability: measured
+     *  2026-08-19, all 117 unregistered capsules carry a full exit chain. */
+    registered?: boolean;
+};
+
+/** Why a capsule holding value is not in the exit set. Every one of these is
+ *  surfaced to the user by name and amount before they commit (spec principle
+ *  3). Terminal capsules are deliberately NOT in this union: they hold nothing,
+ *  the user has never seen them, and listing them would bury the exclusions
+ *  that matter. The measured wallet carries 188 of them against 8 live ones. */
+export type ExitExclusionReason =
+    /** Structural: the SDK reports no exit chain for this capsule. */
+    | 'no-exit-chain'
+    /** Temporal: the server can sweep it before the exit clears its CSV. */
+    | 'too-close-to-expiry'
+    /** Economic: its own claim fee is at least its whole value. */
+    | 'returns-nothing'
+    /** Economic: the reserve it consumes dwarfs what it returns. */
+    | 'reserve-dwarfs-value';
+
+/** Disclosures that do not change the decision but the user should still see. */
+export type ExitTriageNote =
+    /** Chain tip or expiry height unknown, so runway could not be checked. */
+    | 'expiry-unknown'
+    /** Past `ArkInfo.maxVtxoExitDepth`: the server will not cosign further
+     *  arkoor spends, so exit or refresh are the only remaining moves. */
+    | 'beyond-server-depth-cap'
+    /** Included despite costing more reserve than it returns. */
+    | 'under-water';
+
+export type ExitEconomicVerdict = 'profitable' | 'marginal' | 'uneconomic';
+
+export type ExitTriageEntry = {
+    id: string;
+    sats: number;
+    exitDepth: number;
+    /** Exit-tree vsize for this capsule alone. */
+    perVtxoVb: number;
+    /** Reserve this capsule consumes at the given fee rate, priced at the bare
+     *  rate. The SPIKE_MULT headroom is deliberately NOT applied here: it is
+     *  volatility cover for the exit as a whole, and charging it per capsule
+     *  inside the profitability test would double-penalise every capsule and
+     *  exclude a wallet that is merely fee-sensitive. Sum over the selected set
+     *  times SPIKE_MULT is `reserveSats`. */
+    exitTreeCostSats: number;
+    /** Fee this capsule adds to the batched claim, paid out of its own value. */
+    marginalClaimSats: number;
+    /** What actually reaches the user's address: value minus its claim fee. */
+    netRecoveredSats: number;
+    economic: ExitEconomicVerdict;
+    /** Blocks until expiry, or null when the tip or expiry height is unknown. */
+    blocksUntilExpiry: number | null;
+    /** Blocks of runway this capsule needs: confirmation budget + CSV delta. */
+    requiredRunwayBlocks: number;
+    included: boolean;
+    reason?: ExitExclusionReason;
+    notes: ExitTriageNote[];
+};
+
+export type TriageArkExitInput = {
+    vtxos: readonly ExitTriageVtxo[];
+    /** Rate the exit-tree CPFP children are priced at (the fast rate). */
+    feeRateSatPerVb: number;
+    /** Rate the claim is priced at. A claim races nothing and its fee comes out
+     *  of the claimed value, so it is a genuinely different rate from the
+     *  time-critical CPFP one. Defaults to `claimRateFromExitRate`, which is
+     *  what the app actually pays; a default of the raw fast rate would have
+     *  triage condemn capsules the claim path would have recovered fine. */
+    claimFeeRateSatPerVb?: number;
+    /** Current tip. null when every chain-source provider failed. */
+    chainTipHeight: number | null;
+    /** Cached `ArkInfo.vtxoExitDelta`. null falls back to
+     *  ASSUMED_EXIT_DELTA_BLOCKS rather than skipping the temporal axis. */
+    vtxoExitDeltaBlocks: number | null;
+    /** Cached `ArkInfo.maxVtxoExitDepth`, for the disclosure note only. */
+    maxVtxoExitDepth?: number | null;
+    /** Whether capsules that cost more reserve than they return, but by less
+     *  than MAX_RESERVE_MULTIPLE, are exited. Default true: excluding them
+     *  abandons real value to save a trivial amount of reserve. Exposed so the
+     *  UI can offer the opt-out spec principle 4 calls for. */
+    includeMarginal?: boolean;
+};
+
+export type ExitTriageResult = {
+    /** Ids to hand `startExitForVtxos`, ordered most net-recoverable first so a
+     *  reserve that runs dry strands the least valuable capsules (spec 4.4). */
+    selectedIds: string[];
+    selected: ExitTriageEntry[];
+    /** Capsules that hold value and are being left behind, largest first, so
+     *  disclosure leads with the biggest amount the user is giving up. */
+    excluded: ExitTriageEntry[];
+    /** Spent / already-Exited capsules skipped before triage. Counted rather
+     *  than listed: they hold nothing, so they are a reserve-sizing concern,
+     *  not a disclosure one. */
+    skippedTerminalCount: number;
+    /** Face value of the selected capsules. */
+    selectedSats: number;
+    /** What the selected capsules actually deliver, after their claim fees. */
+    netRecoverableSats: number;
+    /** Face value the user is being asked to abandon. */
+    excludedSats: number;
+    /** Summed exit vsize over the SELECTED capsules only (spec 4.3). */
+    totalExitVb: number;
+    /** Recommended on-chain reserve for the selected set. 0 when nothing is
+     *  selected, so a nothing-to-exit wallet is never gated. */
+    reserveSats: number;
+    /** Selected capsules that cost more reserve than they return. */
+    underWaterCount: number;
+    feeRateSatPerVb: number;
+    claimFeeRateSatPerVb: number;
+    /** True when the temporal axis ran on ASSUMED_EXIT_DELTA_BLOCKS. */
+    usedAssumedExitDelta: boolean;
+};
+
+// --- Cost model helpers ----------------------------------------------------
+
+/**
+ * Exit-tree vsize for one capsule: the chain itself plus a CPFP child per
+ * level. This is the term that varies 25x inside a single wallet, and it is why
+ * a sat-denominated dust threshold cannot express the rule.
+ */
+export function perVtxoExitVb(v: Pick<ExitTriageVtxo, 'exitDepth' | 'exitTxWeightWu'>): number {
+    const chainVb = Math.ceil(Math.max(0, Number(v.exitTxWeightWu) || 0) / 4);
+    const depth = Math.max(0, Math.floor(Number(v.exitDepth) || 0));
+    return Math.max(chainVb, FALLBACK_VB_PER_VTXO) + depth * CPFP_CHILD_VB;
+}
+
+/**
+ * Reserve for a given total exit vsize. Zero vsize means nothing to exit and
+ * must return 0, NOT the floor, or a wallet with nothing exitable would be
+ * gated on a 5,000 sat reserve it has no use for.
+ */
+export function reserveSatsForExitVb(totalExitVb: number, feeRateSatPerVb: number): number {
+    if (totalExitVb <= 0) return 0;
+    const rate = Math.max(0, Number(feeRateSatPerVb) || 0);
+    return Math.max(RESERVE_FLOOR_SATS, Math.ceil(totalExitVb * rate * SPIKE_MULT));
+}
+
+/**
+ * Blocks a capsule needs between now and its expiry for an exit to be safe:
+ * long enough for its tree to confirm, and then to sit out the CSV delta. Below
+ * this the server can sweep the capsule while the exit is still timelocked, so
+ * the user loses both the capsule and the reserve spent chasing it.
+ */
+export function requiredRunwayBlocks(exitDepth: number, exitDeltaBlocks: number): number {
+    const depth = Math.max(0, Math.floor(Number(exitDepth) || 0));
+    const confirmationBudget = Math.max(
+        MIN_CONFIRMATION_BUDGET_BLOCKS,
+        depth * BLOCKS_PER_EXIT_LEVEL,
+    );
+    return confirmationBudget + Math.max(0, Math.floor(exitDeltaBlocks));
+}
+
+/** Bounds on the CLAIM fee rate, which is a different problem from the exit-tree
+ *  CPFP rate the reserve is sized at.
+ *
+ *  The CPFP children are time-critical: the tree has to confirm before the
+ *  capsule expires, so paying for speed there buys something real, out of the
+ *  reserve. A claim is the opposite. It spends an output whose CSV has already
+ *  matured, it races nothing, and its fee comes out of the claimed value. Worse,
+ *  an over-priced claim does not fail slowly, it fails permanently: bark refuses
+ *  to build a claim whose fee exceeds its output, and the drive rebuilds the
+ *  same doomed claim forever. Observed live 2026-08-19 at 779 sats against a
+ *  698 sat output, at a moment when the mempool wanted 1. */
+const CLAIM_RATE_MIN = 1;
+const CLAIM_RATE_MAX = 5;
+
+/**
+ * Claim rate to price the economic axis at, derived from the exit-tree rate.
+ * Clamped, because triage that prices claims at the fastest rate would call a
+ * healthy capsule unrecoverable during any fee spike.
+ */
+export function claimRateFromExitRate(feeRateSatPerVb: number): number {
+    const rate = Math.ceil(Math.max(0, Number(feeRateSatPerVb) || 0));
+    return Math.min(CLAIM_RATE_MAX, Math.max(CLAIM_RATE_MIN, rate));
+}
+
+// --- Triage ----------------------------------------------------------------
+
+/**
+ * Partition every capsule on the three axes of spec 4.2 and size the reserve to
+ * what survives. Pure: no IO, no store reads, no SDK calls. The caller reads
+ * `allVtxos()`, flattens, and threads through the cached chain tip and ArkInfo
+ * deltas.
+ */
+export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
+    const feeRate = Math.max(0, Number(input.feeRateSatPerVb) || 0);
+    const claimRate =
+        input.claimFeeRateSatPerVb == null
+            ? claimRateFromExitRate(feeRate)
+            : Math.max(0, Number(input.claimFeeRateSatPerVb) || 0);
+    const includeMarginal = input.includeMarginal !== false;
+
+    const usedAssumedExitDelta =
+        input.vtxoExitDeltaBlocks == null || !Number.isFinite(input.vtxoExitDeltaBlocks);
+    const exitDelta = usedAssumedExitDelta
+        ? ASSUMED_EXIT_DELTA_BLOCKS
+        : Math.max(0, Math.floor(input.vtxoExitDeltaBlocks as number));
+
+    const tip =
+        typeof input.chainTipHeight === 'number' && Number.isFinite(input.chainTipHeight)
+            ? Math.floor(input.chainTipHeight)
+            : null;
+
+    const maxDepth =
+        typeof input.maxVtxoExitDepth === 'number' && input.maxVtxoExitDepth > 0
+            ? input.maxVtxoExitDepth
+            : null;
+
+    const selected: ExitTriageEntry[] = [];
+    const excluded: ExitTriageEntry[] = [];
+    let skippedTerminalCount = 0;
+
+    for (const v of input.vtxos ?? []) {
+        const sats = Math.max(0, Math.floor(Number(v.sats) || 0));
+        const perVb = perVtxoExitVb(v);
+        const marginalClaimSats = Math.ceil(CLAIM_INPUT_VB * claimRate);
+        const netRecoveredSats = sats - marginalClaimSats;
+        const exitTreeCostSats = Math.ceil(perVb * feeRate);
+
+        const notes: ExitTriageNote[] = [];
+        if (maxDepth != null && v.exitDepth > maxDepth) notes.push('beyond-server-depth-cap');
+
+        const blocksUntilExpiry =
+            tip != null && v.expiryHeight > 0 ? v.expiryHeight - tip : null;
+        const runway = requiredRunwayBlocks(v.exitDepth, exitDelta);
+
+        const economic: ExitEconomicVerdict =
+            netRecoveredSats <= 0
+                ? 'uneconomic'
+                : exitTreeCostSats <= netRecoveredSats
+                  ? 'profitable'
+                  : exitTreeCostSats <= netRecoveredSats * MAX_RESERVE_MULTIPLE
+                    ? 'marginal'
+                    : 'uneconomic';
+
+        const base = {
+            id: v.id,
+            sats,
+            exitDepth: Math.max(0, Math.floor(Number(v.exitDepth) || 0)),
+            perVtxoVb: perVb,
+            exitTreeCostSats,
+            marginalClaimSats,
+            netRecoveredSats,
+            economic,
+            blocksUntilExpiry,
+            requiredRunwayBlocks: runway,
+        };
+
+        const exclude = (reason: ExitExclusionReason) => {
+            excluded.push({ ...base, included: false, reason, notes });
+        };
+
+        // Structural. A terminal capsule holds nothing, so it is dropped before
+        // triage rather than reported as an exclusion. It still matters: the
+        // old reserve calc filtered only `spent`, so ten finished exits on the
+        // measured wallet added 7,252 vB of demanded reserve for value already
+        // sitting on-chain.
+        if (TERMINAL_STATE_TAGS.has(String(v.stateTag ?? '').toLowerCase())) {
+            skippedTerminalCount++;
+            continue;
+        }
+        if (perVb <= 0 || (Number(v.exitTxWeightWu) <= 0 && Number(v.exitDepth) <= 0)) {
+            exclude('no-exit-chain');
+            continue;
+        }
+
+        // Temporal. A hard exclusion, not a warning: an exit that does not clear
+        // its CSV before expiry loses the capsule AND the reserve spent on it.
+        if (blocksUntilExpiry != null) {
+            if (blocksUntilExpiry <= runway) {
+                exclude('too-close-to-expiry');
+                continue;
+            }
+        } else {
+            // Unknown runway is not evidence of a problem, and refusing to exit
+            // on a failed tip read would disarm the emergency button for a
+            // network fault. Include and disclose.
+            notes.push('expiry-unknown');
+        }
+
+        // Economic.
+        if (economic === 'uneconomic') {
+            exclude(
+                netRecoveredSats <= 0 ? 'returns-nothing' : 'reserve-dwarfs-value',
+            );
+            continue;
+        }
+        if (economic === 'marginal') {
+            if (!includeMarginal) {
+                exclude('reserve-dwarfs-value');
+                continue;
+            }
+            notes.push('under-water');
+        }
+
+        selected.push({ ...base, included: true, notes });
+    }
+
+    // Most net-recoverable first. If the reserve runs dry mid-exit the capsules
+    // that got furthest are the ones worth the most, rather than whichever the
+    // iterator happened to reach first.
+    selected.sort((a, b) => b.netRecoveredSats - a.netRecoveredSats || a.id.localeCompare(b.id));
+    excluded.sort((a, b) => b.sats - a.sats || a.id.localeCompare(b.id));
+
+    const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
+
+    return {
+        selectedIds: selected.map((e) => e.id),
+        selected,
+        excluded,
+        skippedTerminalCount,
+        selectedSats: selected.reduce((acc, e) => acc + e.sats, 0),
+        netRecoverableSats: selected.reduce((acc, e) => acc + e.netRecoveredSats, 0),
+        excludedSats: excluded.reduce((acc, e) => acc + e.sats, 0),
+        totalExitVb,
+        reserveSats: reserveSatsForExitVb(totalExitVb, feeRate),
+        underWaterCount: selected.filter((e) => e.economic === 'marginal').length,
+        feeRateSatPerVb: feeRate,
+        claimFeeRateSatPerVb: claimRate,
+        usedAssumedExitDelta,
+    };
+}
+
+/**
+ * One-line reason text per exclusion, for the confirm dialog. Wording is the
+ * product owner's to change; the contract this satisfies is that no capsule is
+ * ever dropped without the user being told which one and why.
+ */
+export function describeExitExclusion(reason: ExitExclusionReason | undefined): string {
+    switch (reason) {
+        case 'no-exit-chain':
+            return 'no exit chain available';
+        case 'too-close-to-expiry':
+            return 'too close to expiry to exit safely';
+        case 'returns-nothing':
+            return 'network fee is more than it holds';
+        case 'reserve-dwarfs-value':
+            return 'costs far more in fees than it holds';
+        default:
+            return 'cannot be exited';
+    }
+}

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -220,6 +220,9 @@ export type ExitTriageEntry = {
     blocksUntilExpiry: number | null;
     /** Blocks of runway this capsule needs: confirmation budget + CSV delta. */
     requiredRunwayBlocks: number;
+    /** Absolute height the capsule expires at, so callers can turn slack back
+     *  into a fixed deadline that stays valid as the chain advances. */
+    expiryHeight: number;
     included: boolean;
     reason?: ExitExclusionReason;
     notes: ExitTriageNote[];
@@ -356,6 +359,115 @@ export function claimRateFromExitRate(feeRateSatPerVb: number): number {
     return Math.min(CLAIM_RATE_MAX, Math.max(CLAIM_RATE_MIN, rate));
 }
 
+/**
+ * How much of a hurry the exit tree is actually in.
+ *
+ * The reserve used to be priced at the mempool's "fastest" rate unconditionally.
+ * That is the wrong question. The exit tree is not racing the next block, it is
+ * racing the capsule's EXPIRY, because a capsule the server sweeps before its
+ * exit clears the CSV is lost. A capsule with weeks of runway has no reason to
+ * bid for next-block confirmation, and paying for it inflates the reserve the
+ * user is asked to fund by several times.
+ *
+ * Measured 2026-08-20: the live wallet's capsules sat about 3,700 blocks clear
+ * of the runway they needed, roughly 26 days, while the app priced their exit at
+ * a fastestFee of 7 against an economyFee of 2. That is a 3.5x over-demand for
+ * urgency that did not exist.
+ *
+ * This is the same mistake #187 fixed for the claim, in the other direction:
+ * there, a rate chosen for speed made a claim impossible to build. Here it makes
+ * a reserve impossible to fund.
+ *
+ * Bands are deliberately conservative and the drive re-evaluates on every tick,
+ * so a capsule that drifts toward its expiry climbs the bands and starts bidding
+ * harder well before it is in trouble.
+ */
+export type ExitFeeUrgency = 'relaxed' | 'moderate' | 'soon' | 'urgent';
+
+/** Spare blocks ABOVE the runway a capsule needs, per band. */
+export const URGENCY_RELAXED_BLOCKS = 1008; // ~1 week
+export const URGENCY_MODERATE_BLOCKS = 288; // ~2 days
+export const URGENCY_SOON_BLOCKS = 144; // ~1 day
+
+export type ExitFeeUrgencyResult = {
+    urgency: ExitFeeUrgency;
+    /** Spare blocks the tightest exitable capsule has, null when unknowable. */
+    tightestSlackBlocks: number | null;
+    /**
+     * Block height by which the tightest capsule's exit must have cleared.
+     * Fixed, unlike the slack, so persisting THIS lets the drive re-derive
+     * urgency each tick against the current tip without another wallet read,
+     * and without the band going stale as the exit runs for days.
+     */
+    deadlineHeight: number | null;
+    /** Capsules the band was derived from. */
+    consideredCount: number;
+};
+
+/**
+ * Band for a given slack. Split out so the exit drive can re-derive urgency
+ * from a persisted deadline height and the current tip, using the same
+ * thresholds the reserve was sized with.
+ */
+export function urgencyFromSlackBlocks(slackBlocks: number | null): ExitFeeUrgency {
+    if (slackBlocks == null || !Number.isFinite(slackBlocks)) return 'urgent';
+    if (slackBlocks >= URGENCY_RELAXED_BLOCKS) return 'relaxed';
+    if (slackBlocks >= URGENCY_MODERATE_BLOCKS) return 'moderate';
+    if (slackBlocks >= URGENCY_SOON_BLOCKS) return 'soon';
+    return 'urgent';
+}
+
+/**
+ * Urgency for an exit set, from the tightest slack in it.
+ *
+ * Takes triaged ENTRIES, not raw capsules, and that is the whole point. An
+ * earlier version read the candidate list and got it backwards on the first
+ * real wallet it saw: two dust capsules 22 blocks from their runway priced the
+ * entire exit as urgent, when neither was going to be exited at all. Pricing
+ * has to follow selection, or capsules the exit is abandoning still get to
+ * decide what it pays.
+ *
+ * Entries already carry `blocksUntilExpiry` and `requiredRunwayBlocks`, so this
+ * is a min over their difference and nothing more.
+ *
+ * An empty set, or one whose runway cannot be read, yields 'urgent'.
+ * Over-reserving parks sats the user still owns; under-reserving stalls the
+ * exit and can cost the capsule, so unknown resolves toward paying more.
+ */
+export function exitFeeUrgency(
+    entries: readonly ExitTriageEntry[],
+): ExitFeeUrgencyResult {
+    let tightest: number | null = null;
+    let deadlineHeight: number | null = null;
+    let consideredCount = 0;
+
+    for (const e of entries ?? []) {
+        if (e.blocksUntilExpiry == null) continue;
+        const slack = e.blocksUntilExpiry - e.requiredRunwayBlocks;
+        consideredCount++;
+        if (tightest == null || slack < tightest) tightest = slack;
+    }
+
+    if (tightest != null && entries.length > 0) {
+        // Recover the absolute height the tightest capsule must clear by, so
+        // the drive can re-derive urgency later against a fresh tip.
+        for (const e of entries) {
+            if (e.blocksUntilExpiry == null) continue;
+            if (e.blocksUntilExpiry - e.requiredRunwayBlocks === tightest) {
+                deadlineHeight = e.expiryHeight - e.requiredRunwayBlocks;
+                break;
+            }
+        }
+    }
+
+    return {
+        urgency: urgencyFromSlackBlocks(tightest),
+        tightestSlackBlocks: tightest,
+        deadlineHeight,
+        consideredCount,
+    };
+}
+
 // --- Triage ----------------------------------------------------------------
 
 /**
@@ -426,6 +538,7 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
             economic,
             blocksUntilExpiry,
             requiredRunwayBlocks: runway,
+            expiryHeight: Math.max(0, Math.floor(Number(v.expiryHeight) || 0)),
         };
 
         const exclude = (reason: ExitExclusionReason) => {

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -417,6 +417,131 @@ export function urgencyFromSlackBlocks(slackBlocks: number | null): ExitFeeUrgen
     return 'urgent';
 }
 
+export type ExitFeeRateTable = Record<ExitFeeUrgency, number>;
+
+/**
+ * Last-resort rate per band, used only when every fee source is unreachable.
+ *
+ * NOT a flat constant, and that distinction is the whole point. The first
+ * version of this fell back to a single congestion hedge for every band, which
+ * quietly undid the runway pricing at exactly the moment it could not be
+ * checked: observed live 2026-08-20 with mempool.space down, a wallet with 26
+ * days of runway was priced at 10 sat/vB and its forced exit demanded 120,720
+ * sats instead of about 24,000.
+ *
+ * The hedge exists because we cannot see the market, so it should scale with
+ * how little time we have to correct a bad guess. With weeks of runway an
+ * under-bid is recoverable, since the drive re-prices every tick and the band
+ * climbs as the runway shrinks. An over-bid is not recoverable in the same way:
+ * it is charged immediately, as a reserve the user has to go and fund.
+ */
+export const EXIT_FEE_FALLBACK_RATES: ExitFeeRateTable = {
+    relaxed: 2,
+    moderate: 5,
+    soon: 8,
+    urgent: 10,
+};
+
+/**
+ * Confirmation target, in blocks, that each band asks an esplora
+ * `/fee-estimates` map for. Esplora keys targets directly, which fits the bands
+ * better than a provider's named tiers do.
+ */
+export const ESPLORA_TARGET_FOR_BAND: Record<ExitFeeUrgency, number> = {
+    urgent: 1,
+    soon: 3,
+    moderate: 6,
+    relaxed: 144,
+};
+
+const BANDS: ExitFeeUrgency[] = ['relaxed', 'moderate', 'soon', 'urgent'];
+
+/**
+ * Fill gaps and force the table to be non-decreasing from relaxed to urgent.
+ *
+ * A fee source is not obliged to be sane. Providers have been seen returning
+ * equal tiers, missing fields, and occasionally an inverted pair, and an
+ * inverted table would have a RELAXED exit bidding more than an urgent one,
+ * which is the exact failure this whole path exists to prevent. Missing entries
+ * inherit the next band up, so a gap always resolves toward paying more.
+ */
+export function normaliseExitFeeRates(
+    partial: Partial<Record<ExitFeeUrgency, number>>,
+): ExitFeeRateTable | null {
+    const clean = (n: unknown): number | null => {
+        const v = Number(n);
+        return Number.isFinite(v) && v > 0 ? Math.max(1, Math.ceil(v)) : null;
+    };
+    const out: Partial<ExitFeeRateTable> = {};
+    for (const b of BANDS) {
+        const v = clean(partial[b]);
+        if (v != null) out[b] = v;
+    }
+    if (Object.keys(out).length === 0) return null;
+
+    // Fill downward from urgent so a missing band inherits the dearer neighbour.
+    let carry: number | null = null;
+    for (let i = BANDS.length - 1; i >= 0; i--) {
+        const b = BANDS[i];
+        if (out[b] == null) out[b] = carry ?? undefined;
+        else carry = out[b] as number;
+    }
+    // Anything still unset sits below every known band; take the cheapest known.
+    const known = BANDS.map((b) => out[b]).filter((v): v is number => v != null);
+    const cheapest = Math.min(...known);
+    for (const b of BANDS) if (out[b] == null) out[b] = cheapest;
+
+    // Monotonic: a cheaper band may never exceed a dearer one.
+    for (let i = BANDS.length - 2; i >= 0; i--) {
+        const b = BANDS[i];
+        const next = BANDS[i + 1];
+        if ((out[b] as number) > (out[next] as number)) out[b] = out[next];
+    }
+    return out as ExitFeeRateTable;
+}
+
+/** Bands from mempool.space's named tiers. Null when the shape is unusable. */
+export function ratesFromMempoolRecommended(rec: unknown): ExitFeeRateTable | null {
+    const r = rec as Record<string, unknown> | null | undefined;
+    if (!r) return null;
+    return normaliseExitFeeRates({
+        relaxed: r.economyFee as number,
+        moderate: r.hourFee as number,
+        soon: r.halfHourFee as number,
+        urgent: r.fastestFee as number,
+    });
+}
+
+/**
+ * Bands from an esplora `/fee-estimates` map of confirmation target to sat/vB.
+ *
+ * For a band's target, take the largest available target at or below it. Longer
+ * targets carry lower fees, so rounding DOWN the target rounds the fee up,
+ * which is the safe direction when the exact target is missing.
+ */
+export function ratesFromEsploraEstimates(estimates: unknown): ExitFeeRateTable | null {
+    const m = estimates as Record<string, unknown> | null | undefined;
+    if (!m || typeof m !== 'object') return null;
+    const targets = Object.keys(m)
+        .map((k) => ({ blocks: Number(k), rate: Number(m[k]) }))
+        .filter((t) => Number.isFinite(t.blocks) && t.blocks > 0 && Number.isFinite(t.rate) && t.rate > 0)
+        .sort((a, b) => a.blocks - b.blocks);
+    if (targets.length === 0) return null;
+
+    const pick = (band: ExitFeeUrgency) => {
+        const want = ESPLORA_TARGET_FOR_BAND[band];
+        let best = targets[0];
+        for (const t of targets) if (t.blocks <= want) best = t;
+        return best.rate;
+    };
+    return normaliseExitFeeRates({
+        relaxed: pick('relaxed'),
+        moderate: pick('moderate'),
+        soon: pick('soon'),
+        urgent: pick('urgent'),
+    });
+}
+
 /**
  * Urgency for an exit set, from the tightest slack in it.
  *

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -84,6 +84,38 @@ export const BLOCKS_PER_EXIT_LEVEL = 6;
 /** Floor on the confirmation budget, so a shallow tree still gets real runway. */
 export const MIN_CONFIRMATION_BUDGET_BLOCKS = 6;
 
+/**
+ * Minimum remaining life, in blocks, for a capsule to be worth exiting.
+ * 4 days at 10 minute blocks.
+ *
+ * This is an ECONOMIC floor, not a safety one. The temporal axis above already
+ * refuses capsules that cannot clear their timelock in time; those are unsafe.
+ * A capsule with three days left is perfectly safe to exit, and still a bad
+ * idea, because of what a short remaining life usually means about how it got
+ * there.
+ *
+ * Capsules do not arrive near expiry in good condition. They get there by
+ * failing to refresh, repeatedly: a cancelled round, a server that would not
+ * cosign, an app that was never opened. Every one of those failures leaves the
+ * capsule where it was and lets the clock run, and the ones that involve
+ * out-of-round spending push `exitDepth` up as well. So the population of
+ * nearly-expired capsules is disproportionately the deep, expensive ones, which
+ * is exactly the population an exit handles worst: cost is linear in depth and
+ * the value is unchanged.
+ *
+ * Refreshing one resets BOTH the depth and the expiry clock, for about a sat.
+ * That is worth an order of magnitude more than exiting it, so the honest
+ * advice is to refresh first and exit later.
+ *
+ * The obvious objection is that refreshing needs the ASP, and a user reaching
+ * for a unilateral exit may have no ASP to reach. That is real, and it is why
+ * this is a default rather than a law: 'recover-everything' includes these
+ * capsules, so a user facing a genuinely dead server can still take them, with
+ * the cost stated. What this stops is the common case, where an exit quietly
+ * spends a fortune dragging out stragglers the user could have refreshed.
+ */
+export const MIN_FRESHNESS_BLOCKS = 4 * 24 * 6;
+
 /** CSV delta assumed when `ArkInfo.vtxoExitDelta` was never cached.
  *
  *  The exit path must not call the ASP (spec principle 2), so a missing cache
@@ -153,6 +185,9 @@ export type ExitExclusionReason =
     | 'no-exit-chain'
     /** Temporal: the server can sweep it before the exit clears its CSV. */
     | 'too-close-to-expiry'
+    /** Temporal/economic: safe to exit, but too near expiry to be worth it.
+     *  Refreshing resets its depth and its clock for a fraction of the cost. */
+    | 'refresh-before-exiting'
     /** Economic: its own claim fee is at least its whole value. */
     | 'returns-nothing'
     /** Economic: the reserve it consumes dwarfs what it returns. */
@@ -718,6 +753,22 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
             notes.push('under-water');
         }
 
+        // Freshness, last, so a capsule that is ALSO uneconomic is reported as
+        // uneconomic. Ordering here is not cosmetic, it is the advice: telling
+        // someone to refresh a 400-sat capsule is useless, because it is below
+        // the per-input round minimum and cannot be refreshed alone. "Costs
+        // more than it holds" is the true and actionable reason for that one.
+        // This exclusion is for capsules that are worth exiting on the numbers
+        // and are merely stale, where refreshing genuinely is the better move.
+        if (
+            blocksUntilExpiry != null &&
+            blocksUntilExpiry < MIN_FRESHNESS_BLOCKS &&
+            policy !== 'recover-everything'
+        ) {
+            exclude('refresh-before-exiting');
+            continue;
+        }
+
         selected.push({ ...base, included: true, notes });
     }
 
@@ -730,7 +781,9 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
     const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
     const reserveSats = reserveSatsForExitVb(totalExitVb, feeRate);
     const netRecoverableSats = selected.reduce((acc, e) => acc + e.netRecoveredSats, 0);
-    const overridable = excluded.filter((e) => e.reason === 'reserve-dwarfs-value');
+    const overridable = excluded.filter(
+        (e) => e.reason === 'reserve-dwarfs-value' || e.reason === 'refresh-before-exiting',
+    );
 
     return {
         selectedIds: selected.map((e) => e.id),
@@ -764,6 +817,8 @@ export function describeExitExclusion(reason: ExitExclusionReason | undefined): 
             return 'no exit chain available';
         case 'too-close-to-expiry':
             return 'too close to expiry to exit safely';
+        case 'refresh-before-exiting':
+            return 'expiring soon, refresh it instead of exiting it';
         case 'returns-nothing':
             return 'network fee is more than it holds';
         case 'reserve-dwarfs-value':

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -170,6 +170,34 @@ export type ExitTriageNote =
 
 export type ExitEconomicVerdict = 'profitable' | 'marginal' | 'uneconomic';
 
+/**
+ * How far past the economics the user has chosen to go.
+ *
+ * The economic axis is the only one with an override, and that is deliberate.
+ * The other two exclusions are not judgement calls the user can overrule:
+ * a structurally unexitable capsule has nothing to broadcast, and a capsule
+ * inside its expiry runway loses BOTH itself and the reserve spent on it when
+ * the server sweeps it mid-exit. Neither is a trade the user could want.
+ *
+ * Within the economic axis there is still one hard floor. A capsule whose own
+ * claim fee is at least its whole value ('returns-nothing') cannot deliver
+ * anything at any price: bark refuses to build a claim whose fee exceeds its
+ * output, and the drive then rebuilds that same doomed claim forever. Forcing
+ * one in does not cost the user money to rescue funds, it wedges the batch and
+ * rescues nothing. So no policy includes it.
+ *
+ *   'profitable-only'     only capsules whose reserve cost comes back
+ *   'default'             the above, plus capsules under water by less than
+ *                         MAX_RESERVE_MULTIPLE
+ *   'recover-everything'  the above, plus capsules whose reserve cost dwarfs
+ *                         what they return. This is spec principle 4: the user
+ *                         may knowingly spend more than the funds are worth,
+ *                         for instance to deny a hostile server a hostage.
+ *                         Callers MUST state the loss in sats before applying
+ *                         it, or the "knowingly" is a fiction.
+ */
+export type ExitEconomicPolicy = 'profitable-only' | 'default' | 'recover-everything';
+
 export type ExitTriageEntry = {
     id: string;
     sats: number;
@@ -214,11 +242,9 @@ export type TriageArkExitInput = {
     vtxoExitDeltaBlocks: number | null;
     /** Cached `ArkInfo.maxVtxoExitDepth`, for the disclosure note only. */
     maxVtxoExitDepth?: number | null;
-    /** Whether capsules that cost more reserve than they return, but by less
-     *  than MAX_RESERVE_MULTIPLE, are exited. Default true: excluding them
-     *  abandons real value to save a trivial amount of reserve. Exposed so the
-     *  UI can offer the opt-out spec principle 4 calls for. */
-    includeMarginal?: boolean;
+    /** How far past the economics the user has chosen to go. Defaults to
+     *  'default'. See ExitEconomicPolicy. */
+    economicPolicy?: ExitEconomicPolicy;
 };
 
 export type ExitTriageResult = {
@@ -246,6 +272,21 @@ export type ExitTriageResult = {
     reserveSats: number;
     /** Selected capsules that cost more reserve than they return. */
     underWaterCount: number;
+    /**
+     * Sats the selected set spends beyond what it recovers, 0 when it is not
+     * under water. This is the number the user has to be shown before a
+     * 'recover-everything' exit, since it IS the loss they are accepting.
+     */
+    netLossSats: number;
+    /**
+     * Capsules excluded purely on the economic ratio, which a
+     * 'recover-everything' policy would bring back. Lets the UI offer the
+     * override only when it would actually change something.
+     */
+    overridableCount: number;
+    /** Face value of those capsules. */
+    overridableSats: number;
+    economicPolicy: ExitEconomicPolicy;
     feeRateSatPerVb: number;
     claimFeeRateSatPerVb: number;
     /** True when the temporal axis ran on ASSUMED_EXIT_DELTA_BLOCKS. */
@@ -329,7 +370,7 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         input.claimFeeRateSatPerVb == null
             ? claimRateFromExitRate(feeRate)
             : Math.max(0, Number(input.claimFeeRateSatPerVb) || 0);
-    const includeMarginal = input.includeMarginal !== false;
+    const policy: ExitEconomicPolicy = input.economicPolicy ?? 'default';
 
     const usedAssumedExitDelta =
         input.vtxoExitDeltaBlocks == null || !Number.isFinite(input.vtxoExitDeltaBlocks);
@@ -419,15 +460,20 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
             notes.push('expiry-unknown');
         }
 
-        // Economic.
-        if (economic === 'uneconomic') {
-            exclude(
-                netRecoveredSats <= 0 ? 'returns-nothing' : 'reserve-dwarfs-value',
-            );
+        // Economic. The only axis the user can overrule, and even here a
+        // capsule that cannot return anything at all is never included.
+        if (netRecoveredSats <= 0) {
+            exclude('returns-nothing');
             continue;
         }
-        if (economic === 'marginal') {
-            if (!includeMarginal) {
+        if (economic === 'uneconomic') {
+            if (policy !== 'recover-everything') {
+                exclude('reserve-dwarfs-value');
+                continue;
+            }
+            notes.push('under-water');
+        } else if (economic === 'marginal') {
+            if (policy === 'profitable-only') {
                 exclude('reserve-dwarfs-value');
                 continue;
             }
@@ -444,6 +490,9 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
     excluded.sort((a, b) => b.sats - a.sats || a.id.localeCompare(b.id));
 
     const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
+    const reserveSats = reserveSatsForExitVb(totalExitVb, feeRate);
+    const netRecoverableSats = selected.reduce((acc, e) => acc + e.netRecoveredSats, 0);
+    const overridable = excluded.filter((e) => e.reason === 'reserve-dwarfs-value');
 
     return {
         selectedIds: selected.map((e) => e.id),
@@ -451,11 +500,15 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         excluded,
         skippedTerminalCount,
         selectedSats: selected.reduce((acc, e) => acc + e.sats, 0),
-        netRecoverableSats: selected.reduce((acc, e) => acc + e.netRecoveredSats, 0),
+        netRecoverableSats,
         excludedSats: excluded.reduce((acc, e) => acc + e.sats, 0),
         totalExitVb,
-        reserveSats: reserveSatsForExitVb(totalExitVb, feeRate),
-        underWaterCount: selected.filter((e) => e.economic === 'marginal').length,
+        reserveSats,
+        underWaterCount: selected.filter((e) => e.economic !== 'profitable').length,
+        netLossSats: Math.max(0, reserveSats - netRecoverableSats),
+        overridableCount: overridable.length,
+        overridableSats: overridable.reduce((acc, e) => acc + e.sats, 0),
+        economicPolicy: policy,
         feeRateSatPerVb: feeRate,
         claimFeeRateSatPerVb: claimRate,
         usedAssumedExitDelta,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -209,3 +209,5 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export { resolveExitReserveTarget } from './exitReserveTarget';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -172,6 +172,7 @@ export {
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
 export { describeExitExclusion, triageArkExit } from './exitTriage';
 export type {
+    ExitEconomicPolicy,
     ExitExclusionReason,
     ExitTriageEntry,
     ExitTriageResult,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -161,13 +161,22 @@ export {
 export { estimateArkOffboardFee, offboardArkVtxos } from './offboard';
 export type { ArkOffboardFeeView } from './offboard';
 export {
+    computeArkExitPlan,
     computeExitFeeReserveSats,
     convertToExitFees,
     estimateExitFeeConvert,
+    fetchArkExitParams,
     fetchFastFeeRateSatPerVb,
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
+export { describeExitExclusion, triageArkExit } from './exitTriage';
+export type {
+    ExitExclusionReason,
+    ExitTriageEntry,
+    ExitTriageResult,
+    ExitTriageVtxo,
+} from './exitTriage';
 export type { ArkRefreshFeeView, ArkRefreshResult, ArkDelegatedRefreshResult } from './refresh';
 
 export { setArkBackgroundRefreshEnabled } from './backgroundRefresh';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -201,6 +201,7 @@ export {
     classifyArkDestination,
     estimateArkSendFee,
     executeArkSend,
+    isArkSendIndeterminate,
     labelForDestinationKind,
 } from './send';
 export type {

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -209,3 +209,6 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export { decideExitClaimBatch } from './exitClaimBatch';
+export type { ExitClaimBatchInput, ExitClaimBatchDecision } from './exitClaimBatch';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -162,6 +162,7 @@ export { estimateArkOffboardFee, offboardArkVtxos } from './offboard';
 export type { ArkOffboardFeeView } from './offboard';
 export {
     computeExitFeeReserveSats,
+    fetchClaimFeeRateSatPerVb,
     convertToExitFees,
     estimateExitFeeConvert,
     fetchFastFeeRateSatPerVb,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -165,15 +165,20 @@ export {
     computeExitFeeReserveSats,
     convertToExitFees,
     estimateExitFeeConvert,
+    fetchArkExitDriveFeeRate,
     fetchArkExitParams,
+    fetchExitFeeRates,
+    fetchExitTreeFeeRateSatPerVb,
     fetchFastFeeRateSatPerVb,
+    getLastExitFeeDeadlineHeight,
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
-export { describeExitExclusion, triageArkExit } from './exitTriage';
+export { describeExitExclusion, exitFeeUrgency, triageArkExit, urgencyFromSlackBlocks } from './exitTriage';
 export type {
     ExitEconomicPolicy,
     ExitExclusionReason,
+    ExitFeeUrgency,
     ExitTriageEntry,
     ExitTriageResult,
     ExitTriageVtxo,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -209,3 +209,14 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export {
+    MIN_USEFUL_FUNDING_SATS,
+    buildExitFundingSources,
+    hasUsableExitFundingSource,
+} from './exitFundingSources';
+export type {
+    ExitFundingSource,
+    ExitFundingSourceId,
+    ExitFundingSourceState,
+} from './exitFundingSources';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -43,7 +43,7 @@ export type { ArkBalanceSummary } from './balance';
 export { estimateArkOnchainRecover, recoverArkOnchainBoard } from './recoverOnchainBoard';
 export type { ArkOnchainRecoverEstimate, ArkOnchainRecoverResult } from './recoverOnchainBoard';
 
-export { fetchArkVtxos } from './vtxos';
+export { fetchArkVtxos, isVtxoMidRound, sumMidRoundVtxos } from './vtxos';
 export type { ArkVtxoView, ArkVtxoList } from './vtxos';
 
 export { tryClaimArkLightningReceives, fetchArkPendingLightningReceives, driveArkPendingLightningSends } from './lightning';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -174,10 +174,19 @@ export {
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
-export { describeExitExclusion, exitFeeUrgency, triageArkExit, urgencyFromSlackBlocks } from './exitTriage';
+export {
+    describeExitExclusion,
+    exitFeeUrgency,
+    normaliseExitFeeRates,
+    ratesFromEsploraEstimates,
+    ratesFromMempoolRecommended,
+    triageArkExit,
+    urgencyFromSlackBlocks,
+} from './exitTriage';
 export type {
     ExitEconomicPolicy,
     ExitExclusionReason,
+    ExitFeeRateTable,
     ExitFeeUrgency,
     ExitTriageEntry,
     ExitTriageResult,

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -8,6 +8,7 @@ export {
     ARK_EXIT_RUNWAY_HOURS,
     ARK_SWEEP_MAX_RUNWAY_HOURS,
     ESPLORA_URL,
+    ESPLORA_URLS,
     createArkConfig,
 } from './config';
 
@@ -209,3 +210,10 @@ export type {
     ArkSendFeeView,
     ArkSendResult,
 } from './send';
+
+export {
+    arkErrorText,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+} from './networkFault';
+export type { ArkNetworkFault } from './networkFault';

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -220,3 +220,12 @@ export type {
     ExitFundingSourceId,
     ExitFundingSourceState,
 } from './exitFundingSources';
+
+export { planExitFunding } from './exitFundingPlan';
+export type { ExitFundingPlan, ExitFundingPlanInput } from './exitFundingPlan';
+export { fundExitFeesFromCoinos } from './exitFundingCoinos';
+export type {
+    CoinosExitFundingDeps,
+    CoinosExitFundingRequest,
+    CoinosExitFundingResult,
+} from './exitFundingCoinos';

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -1,0 +1,99 @@
+/**
+ * Which side of the network is unreachable, and what to tell the user.
+ *
+ * The Bark Vault talks to two independent services and a failure in either
+ * surfaces to the user as the same shrug of a raw SDK error string. They need
+ * opposite responses:
+ *
+ *   - CHAIN SOURCE (esplora): the wallet cannot read the chain. Observed on
+ *     device when Blockstream served its Cloudflare bot-block page and
+ *     mempool.space TCP-timed out from the same Wi-Fi, while both answered
+ *     instantly from a browser on the same network. Switching to mobile data
+ *     fixed it. So here, suggesting a network change is genuinely useful.
+ *
+ *   - ARK SERVER (the ASP): rounds, sends and Lightning invoices need it.
+ *     Changing network will not help if the server itself is down, and telling
+ *     someone to fiddle with Wi-Fi while their funds look stuck is worse than
+ *     saying nothing. What matters here is the reassurance: the unilateral exit
+ *     does not need this server.
+ *
+ * DISCRIMINATION IS BY HOSTNAME, deliberately. The tempting shortcut, matching
+ * `BarkError.ServerConnection`, is wrong: our own config notes that exact tag
+ * appearing for an esplora 429 during recovery, so it does not identify a side.
+ * Hostnames do. Phrase matching is only a fallback for errors that name no host.
+ *
+ * Returns 'unknown' rather than guessing. A wrong suggestion (telling someone to
+ * switch networks when the server is down) costs more than no suggestion.
+ */
+
+export type ArkNetworkFault = 'chain-source' | 'ark-server' | 'unknown';
+
+/** Flatten a thrown value into searchable text. BarkError hides detail in `inner`. */
+export function arkErrorText(err: unknown): string {
+    if (err == null) return '';
+    if (typeof err === 'string') return err;
+    const e = err as {
+        tag?: unknown;
+        message?: unknown;
+        inner?: { errorMessage?: unknown; message?: unknown };
+    };
+    return [
+        e.tag,
+        e.message,
+        e.inner?.errorMessage,
+        e.inner?.message,
+    ]
+        .filter((p) => typeof p === 'string')
+        .join(' ');
+}
+
+function hostOf(url: string): string | null {
+    // Deliberately not `new URL()`: it is available in Hermes but throws on the
+    // malformed values that can reach here from user-supplied endpoints, and a
+    // classifier must never throw on the error path.
+    const m = /^[a-z]+:\/\/([^/:?#]+)/i.exec(url.trim());
+    return m ? m[1].toLowerCase() : null;
+}
+
+/** Phrases only ever produced by the chain-data client. */
+const CHAIN_SOURCE_PHRASES =
+    /not a blockhash|failed to parse hex|esplora|chain source|Sync failed/i;
+
+export function classifyArkNetworkFault(
+    err: unknown,
+    endpoints: { chainUrls?: readonly string[]; arkUrl?: string | null } = {},
+): ArkNetworkFault {
+    const text = arkErrorText(err);
+    if (!text) return 'unknown';
+    const haystack = text.toLowerCase();
+
+    // Hostname match first: unambiguous, and survives SDK wording changes.
+    for (const url of endpoints.chainUrls ?? []) {
+        const host = hostOf(url);
+        if (host && haystack.includes(host)) return 'chain-source';
+    }
+    const arkHost = endpoints.arkUrl ? hostOf(endpoints.arkUrl) : null;
+    if (arkHost && haystack.includes(arkHost)) return 'ark-server';
+
+    if (CHAIN_SOURCE_PHRASES.test(text)) return 'chain-source';
+
+    return 'unknown';
+}
+
+/**
+ * User-facing sentence for a fault, or null when we do not know enough to say
+ * anything useful. Callers append this to their own context rather than
+ * replacing it, so the user still learns which action failed.
+ */
+export function arkNetworkFaultMessage(fault: ArkNetworkFault): string | null {
+    switch (fault) {
+        case 'chain-source':
+            return "Can't reach the Bitcoin network data provider. If you're on Wi-Fi, try mobile data, then try again.";
+        case 'ark-server':
+            // No network advice: if the server is down, switching networks
+            // achieves nothing and wastes the user's time.
+            return 'The Ark server is not responding right now. Your funds are safe, and an emergency exit does not need this server.';
+        default:
+            return null;
+    }
+}

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -1,4 +1,5 @@
 import { getArkWalletHandle, getCachedArkMnemonic } from './walletHandle';
+import { assertNoActiveArkExitAsync } from './exit';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
 import { writeArkAutoBackup } from './backup';
@@ -83,6 +84,16 @@ export async function refreshArkVtxos(
     totalSats?: number,
 ): Promise<ArkRefreshResult> {
     const handle = requireHandle();
+
+    // A refresh is a COOPERATIVE round: it spends the VTXO and hands the ASP a
+    // new one. Running it against a coin that is mid-unilateral-exit commits
+    // the same coin twice, once cooperatively and once on-chain, and one of the
+    // two loses. bark does not protect against this (confirmed with Second
+    // 2026-08-13: "we allow VTXOs to be marked for exit and for the user to
+    // still spend them"), and the lock/unlock API they suggest is not exposed
+    // in bark-react-native 0.16.1, so the client is the only thing standing
+    // here.
+    await assertNoActiveArkExitAsync('Refreshing capsules');
 
     // Serialize rounds: one refresh at a time, per wallet. The in-process
     // flag catches same-process races; the pendingRoundStates probe catches
@@ -240,6 +251,10 @@ export async function refreshArkVtxosDelegated(
 ): Promise<ArkDelegatedRefreshResult> {
     const handle = requireHandle();
 
+    // Same exit guard as the self-signed path: a delegated round is still a
+    // cooperative spend of the VTXO. See refreshArkVtxos.
+    await assertNoActiveArkExitAsync('Refreshing capsules');
+
     // Cross-caller submission guard. `refreshSubmissionInFlight` is shared
     // with the self-signed path and now also with delegated maintenance, so
     // an arkoor auto-refresh, a Capsules tap-refresh, and a background wake
@@ -375,6 +390,15 @@ export async function refreshArkVtxosDelegatedAndSync(
  */
 export async function maintenanceArkDelegated(): Promise<void> {
     const handle = requireHandle();
+
+    // The highest-risk caller of the exit guard. `maintenanceDelegated()`
+    // chooses its own VTXOs inside bark, so there is no input list to filter:
+    // the only lever is whether to call it at all. It also runs headless from a
+    // silent-push wake, outside useArkSync's exit early-return, which is why
+    // the guard is the async one that asks bark's DB rather than trusting a
+    // possibly-unhydrated store.
+    await assertNoActiveArkExitAsync('Background refresh');
+
     // Same cross-caller guard as refreshArkVtxosDelegated: the background wake
     // must not submit a maintenance round while another submission is mid-
     // flight or a round is already ongoing (previously this path had no check

--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -2,6 +2,7 @@ import RNFS from 'react-native-fs';
 import * as Keychain from 'react-native-keychain';
 
 import { ESPLORA_URLS } from './config';
+import { ESPLORA_OPEN_ATTEMPTS } from './esploraProviders';
 import { ARK_DATADIR } from './datadir';
 import { cacheArkMnemonicForReopen, getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
 
@@ -17,7 +18,9 @@ const KEYCHAIN_SERVICE = 'ark-seed-phrase';
  * few times before giving up. Only transient connection errors are retried; a
  * genuine seed/datadir mismatch fails fast.
  */
-const OPEN_ATTEMPTS = 5;
+// Kept in ./esploraProviders alongside the list it has to outnumber: a count
+// below the provider count silently makes the last entries unreachable.
+const OPEN_ATTEMPTS = ESPLORA_OPEN_ATTEMPTS;
 const OPEN_RETRY_DELAY_MS = 6000;
 
 // Guards against two opens running against the same datadir at once — the

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -40,6 +40,27 @@ export type ArkSendFeeView = {
     vtxosSpent: string[];
 };
 
+/**
+ * Error thrown when a send's outcome is UNKNOWN rather than failed: the HTLC is
+ * still live and may yet settle.
+ *
+ * This is the single most dangerous state in the send path, because the natural
+ * UI response to a thrown error ("it failed, try again") is exactly the wrong
+ * one. Retrying an ln-address or ln-offer mints a fresh invoice with a new
+ * payment hash, so the retry can settle alongside the original and pay the
+ * recipient twice, irreversibly.
+ *
+ * Callers MUST use `isArkSendIndeterminate()` before reporting an error, and
+ * when it is true they MUST NOT claim the funds are safe and MUST NOT re-enable
+ * their send control.
+ */
+export type ArkSendIndeterminateError = Error & { arkSendIndeterminate: true };
+
+/** True when the send's outcome is unknown and retrying risks paying twice. */
+export function isArkSendIndeterminate(err: unknown): boolean {
+    return !!err && (err as { arkSendIndeterminate?: boolean }).arkSendIndeterminate === true;
+}
+
 export type ArkSendResult = {
     /** Kind of send that was executed — helps callers route to the right toast. */
     kind: ArkDestinationKind;
@@ -368,9 +389,21 @@ export async function executeArkSend(
             const outcome = await waitForArkLightningSettlement(handle, resolvedInvoice);
             if (outcome === 'settled') { settled = true; break; }
             if (outcome === 'pending') {
-                throw new Error(
-                    'Lightning payment is still confirming. Check Activity before retrying so you do not send twice.',
-                );
+                // INDETERMINATE, not a failure. The HTLC is still live and may
+                // yet settle. Retrying an ln-address or ln-offer mints a FRESH
+                // invoice with a new payment hash, so a retry can settle
+                // alongside this one and pay the recipient twice.
+                //
+                // Flagged rather than left to string-matching so callers can
+                // branch on it reliably. A caller MUST NOT tell the user their
+                // funds are safe, and MUST NOT re-arm its send control, when
+                // this flag is set.
+                const indeterminate = new Error(
+                    'This payment may still be in flight. Do not send it again: wait for your ' +
+                    'balance to settle, or confirm with the recipient before retrying.',
+                ) as ArkSendIndeterminateError;
+                indeterminate.arkSendIndeterminate = true;
+                throw indeterminate;
             }
             // outcome === 'failed' -> HTLC refunded, funds back. Retry if attempts remain.
             console.log(

--- a/src/services/ark/sync.ts
+++ b/src/services/ark/sync.ts
@@ -1,6 +1,6 @@
 import useAuthStore from '@Cypher/stores/authStore';
 
-import { getArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
+import { ensureArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
 
 // Flat board-fee headroom (sats) subtracted from the boardable surplus when an
 // exit-fee reserve is armed, so boardAmount's own fee can't erode the reserve
@@ -65,7 +65,20 @@ export async function syncArkWallet(): Promise<boolean> {
     if (!handle) return false;
     await handle.sync();
 
-    const onchain = getArkOnchainHandle();
+    // MUST be `ensure`, not `get`. `rotateArkOnchainEsplora()` nulls the handle
+    // so the next spawn picks a different esplora, but a bare
+    // `getArkOnchainHandle()` returns that null and the whole on-chain block
+    // below is skipped, silently and permanently: no sync, no balance, no
+    // error. One rotation killed the on-chain wallet for the rest of the
+    // process, `setLastOnchainBalanceSats` was never reached, and the exit-fee
+    // wallet read 0 sats so Emergency Exit stayed gated behind "Fund exit fees
+    // first" while the funds sat confirmed on-chain. Observed on device
+    // 2026-08-16; the rotate docstring already assumed this call site used
+    // `ensure`.
+    const onchain = await ensureArkOnchainHandle().catch((err) => {
+        console.warn('[Ark sync] onchain handle spawn failed:', err?.message ?? String(err));
+        return null;
+    });
     if (onchain) {
         try {
             const syncedSats = await onchain.sync();
@@ -149,15 +162,27 @@ export async function syncArkWallet(): Promise<boolean> {
             // nothing is in flight. Safe to call on every tick.
             await handle.syncPendingBoards();
         } catch (oncErr) {
-            console.warn('[Ark sync] onchain sync / board pipeline failed:', oncErr);
-            // If the pinned esplora is bot-blocking us (BarkError.Network /
-            // ServerConnection / the "not a blockhash" 338-byte block page),
-            // drop the handle and rotate providers so the next tick re-spawns
-            // against the alternate endpoint instead of failing forever.
+            // Stringify own properties. A BarkError carries its detail in
+            // `inner.errorMessage`, and passing the object straight to
+            // console.warn collapses it to a bare "Error", which is what made
+            // this failure undiagnosable on device (2026-08-16).
             const detail = `${(oncErr as any)?.tag ?? ''} ${(oncErr as any)?.message ?? ''} ${(oncErr as any)?.inner?.errorMessage ?? ''}`;
-            if (/Network|ServerConnection|blockhash|hex string|timeout|timed out/i.test(detail)) {
-                rotateArkOnchainEsplora();
-            }
+            console.warn(
+                '[Ark sync] onchain sync / board pipeline failed:',
+                detail.trim() || JSON.stringify(oncErr, Object.getOwnPropertyNames(oncErr ?? {})),
+            );
+            // Rotate on ANY failure, not only errors whose text matches a known
+            // network signature. The regex that used to gate this skipped
+            // errors that did not stringify the expected way, and the on-chain
+            // handle then retried the same dead provider every tick forever:
+            // `onchain.sync()` never succeeded, `setLastOnchainBalanceSats` was
+            // never reached, so the exit-fee wallet read 0 sats for the entire
+            // process lifetime and Emergency Exit stayed gated behind "Fund
+            // exit fees first" while the funds sat confirmed on-chain.
+            //
+            // Rotating on a non-network error is harmless: it just re-spawns
+            // the on-chain handle against the other esplora on the next tick.
+            rotateArkOnchainEsplora();
         }
     }
 

--- a/src/services/ark/sync.ts
+++ b/src/services/ark/sync.ts
@@ -1,5 +1,7 @@
 import useAuthStore from '@Cypher/stores/authStore';
 
+import { decideAutoBoard } from './autoBoardDecision';
+
 import { getArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
 
 // Flat board-fee headroom (sats) subtracted from the boardable surplus when an
@@ -99,41 +101,31 @@ export async function syncArkWallet(): Promise<boolean> {
             //      touched the exit-funding flow) keeps the exact old boardAll
             //      behavior.
             const authState = useAuthStore.getState();
-            const reserveSats = authState.arkExitFeeReserveSats ?? 0;
-            const canBoard =
-                !authState.arkExitInProgress &&
-                onchainBal.confirmedSats > 0n &&
-                arkBal.pendingBoardSats === 0n;
-            if (canBoard && reserveSats > 0) {
-                // Board only the surplus above the reserve. Subtract a flat
-                // board-fee headroom so boardAmount's own fee can't dip the
-                // leftover below the reserve. Only board when the surplus
-                // clears the server board minimum (a smaller surplus can never
-                // board and would retry-storm), otherwise hold it on-chain.
-                const confirmed = Number(onchainBal.confirmedSats);
-                const excess = confirmed - reserveSats - BOARD_FEE_HEADROOM_SATS;
-                if (excess >= MIN_BOARD_SATS) {
-                    console.log(
-                        '[Ark sync] auto-board (reserve armed): boarding surplus',
-                        excess, 'sats; keeping', reserveSats, 'on-chain for exit fees',
-                    );
-                    try {
-                        await handle.boardAmount(BigInt(excess));
-                        console.log('[Ark sync] auto-board: boardAmount initiated');
-                    } catch (boardErr) {
-                        console.warn('[Ark sync] auto-board: boardAmount failed:', boardErr);
-                    }
-                } else if (__DEV__) {
-                    console.log(
-                        '[Ark sync] auto-board held: surplus', excess,
-                        'below board minimum; keeping funds on-chain for exit fees',
-                    );
+            const boardDecision = decideAutoBoard({
+                confirmedSats: Number(onchainBal.confirmedSats),
+                pendingBoardSats: Number(arkBal.pendingBoardSats),
+                exitInProgress: authState.arkExitInProgress,
+                armedReserveSats: authState.arkExitFeeReserveSats,
+                recommendedReserveSats: authState.arkExitRecommendedReserveSats,
+                minBoardSats: MIN_BOARD_SATS,
+                boardFeeHeadroomSats: BOARD_FEE_HEADROOM_SATS,
+            });
+            if (boardDecision.action === 'board-amount') {
+                console.log(
+                    '[Ark sync] auto-board: boarding surplus', boardDecision.sats,
+                    'sats; keeping', boardDecision.holdSats, 'on-chain for exit fees',
+                );
+                try {
+                    await handle.boardAmount(BigInt(boardDecision.sats));
+                    console.log('[Ark sync] auto-board: boardAmount initiated');
+                } catch (boardErr) {
+                    console.warn('[Ark sync] auto-board: boardAmount failed:', boardErr);
                 }
-            } else if (canBoard) {
+            } else if (boardDecision.action === 'board-all') {
                 console.log(
                     '[Ark sync] auto-board: detected',
                     String(onchainBal.confirmedSats),
-                    'sats unboarded onchain, initiating boardAll',
+                    'sats unboarded onchain and nothing to hold, initiating boardAll',
                 );
                 try {
                     await handle.boardAll();
@@ -141,8 +133,14 @@ export async function syncArkWallet(): Promise<boolean> {
                 } catch (boardErr) {
                     console.warn('[Ark sync] auto-board: boardAll failed:', boardErr);
                 }
-            } else if (authState.arkExitInProgress && onchainBal.confirmedSats > 0n && __DEV__) {
-                console.log('[Ark sync] auto-board skipped: exit in progress, holding on-chain funds for exit fees');
+            } else if (boardDecision.action === 'hold' && __DEV__) {
+                console.log(
+                    '[Ark sync] auto-board held: surplus', boardDecision.surplusSats,
+                    'below board minimum; keeping', boardDecision.holdSats,
+                    'on-chain for exit fees',
+                );
+            } else if (boardDecision.action === 'skip' && __DEV__) {
+                console.log('[Ark sync] auto-board skipped:', boardDecision.reason);
             }
 
             // Progress any pending boards through their phases. No-op when

--- a/src/services/ark/vtxos.ts
+++ b/src/services/ark/vtxos.ts
@@ -37,6 +37,53 @@ export type ArkVtxoList = {
 };
 
 /**
+ * Is this VTXO committed to an in-flight round (refresh, send, board, offboard,
+ * lightning receive)?
+ *
+ * READ THIS BEFORE COMPARING `state` TO 'locked' ANYWHERE.
+ *
+ * `Locked` alone stopped being the answer at bark 0.6.0: a DELEGATED refresh
+ * leaves the VTXO `Spendable` for the whole round, so every surface that tested
+ * `state === 'locked'` to mean "refreshing" silently reported nothing in flight.
+ * That regression has now been fixed three separate times in three separate
+ * places (the refresh UI in 778e41d, then the home banners, then this sweep),
+ * which is why the predicate lives here instead of being re-derived per screen.
+ *
+ * `Locked` is still real: bark sets it for the pre-action subsystems (round,
+ * offboard, board, lightning receive). So this is a UNION, not a replacement.
+ * The client-tracked ids come from `arkRefreshingVtxoIds` in authStore, which
+ * the refresh paths maintain across the delegated round.
+ */
+export function isVtxoMidRound(
+    v: Pick<ArkVtxoView, 'id' | 'state'>,
+    refreshingIds: readonly string[] | ReadonlySet<string>,
+): boolean {
+    if (v.state.toLowerCase() === 'locked') return true;
+    return refreshingIds instanceof Set
+        ? refreshingIds.has(v.id)
+        : (refreshingIds as readonly string[]).includes(v.id);
+}
+
+/**
+ * Count and sats of everything mid-round. The headline balance excludes these,
+ * so a surface that under-reports here shows the user a balance drop with no
+ * explanation.
+ */
+export function sumMidRoundVtxos(
+    vtxos: readonly ArkVtxoView[] | null | undefined,
+    refreshingIds: readonly string[] | ReadonlySet<string>,
+): { count: number; sats: number } {
+    let count = 0;
+    let sats = 0;
+    for (const v of vtxos ?? []) {
+        if (!isVtxoMidRound(v, refreshingIds)) continue;
+        count++;
+        sats += v.sats;
+    }
+    return { count, sats };
+}
+
+/**
  * Fetch VTXO list from the local SQLite datadir.
  *
  * Returns null if the wallet handle isn't initialized. For a freshly-created

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -405,15 +405,28 @@ export function getArkOnchainHandle(): OnchainWalletInterface | null {
  * SQLite FDs before nulling the ref.
  */
 export function rotateArkOnchainEsplora(): void {
-    // The onchain sync failed on the current provider. We used to cycle to the
-    // NEXT provider in ESPLORA_URLS — but the only fallback is blockstream,
-    // which chronically bot-blocks bark's client and (with no SDK-side esplora
-    // timeout) hangs the onchain sync ~90s. Observed 2026-07-09: that hang
-    // froze the JS thread and starved a stuck fee estimate. So reset to the
-    // reliable primary (mempool) instead of rotating onto the bad endpoint. If
-    // we're already on the primary, a transient failure just retries it next
-    // tick rather than pinning us to a dead provider.
-    if (sessionEsploraUrl === ESPLORA_URL) return; // already on primary
+    // Advance to the NEXT provider in ESPLORA_URLS, wrapping at the end.
+    //
+    // This used to "reset to the reliable primary" instead of rotating, written
+    // when the primary was mempool and blockstream was the endpoint worth
+    // avoiding. The 2026-07-09 flip made blockstream the primary and turned
+    // that logic inside out: `sessionEsploraUrl === ESPLORA_URL` is true for a
+    // handle already pinned to blockstream, so the early return fired and the
+    // on-chain wallet could never rotate off a provider that was bot-blocking
+    // it. It retried the dead endpoint every tick forever.
+    //
+    // The visible damage was on the exit path: `onchain.sync()` kept throwing,
+    // `setLastOnchainBalanceSats` was never reached, the exit-fee wallet read 0
+    // sats, and Emergency Exit sat gated behind "Fund exit fees first" while the
+    // funds were on-chain the whole time. Observed on device 2026-08-16.
+    //
+    // The wallet-open loop in restore.ts already rotates this way and recovers
+    // from the same bot-block, so this brings the on-chain handle in line with it.
+    if (ESPLORA_URLS.length < 2) return;
+    const current = ESPLORA_URLS.indexOf(sessionEsploraUrl);
+    // Unknown current provider (-1) lands on index 0, i.e. the primary.
+    const next = ESPLORA_URLS[(current + 1) % ESPLORA_URLS.length];
+    if (next === sessionEsploraUrl) return;
     if (onchainHandle && typeof (onchainHandle as any).uniffiDestroy === 'function') {
         try {
             (onchainHandle as any).uniffiDestroy();
@@ -422,8 +435,8 @@ export function rotateArkOnchainEsplora(): void {
         }
     }
     onchainHandle = null;
-    sessionEsploraUrl = ESPLORA_URL;
-    if (__DEV__) console.log('[Ark] onchain esplora reset to primary ->', ESPLORA_URL);
+    sessionEsploraUrl = next;
+    if (__DEV__) console.log('[Ark] onchain esplora rotated ->', next);
 }
 
 /**

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -486,6 +486,18 @@ export async function ensureArkOnchainHandle(): Promise<OnchainWalletInterface> 
             const config = createArkConfig({ esploraAddress: esploraUrl });
             // bark 0.11.3 OnchainWallet.default_ signature adds a leading network arg.
             onchainHandle = await OnchainWallet.default_(ARK_NETWORK, mnemonic, config, datadir);
+            // Record the provider that ACTUALLY worked, not the one we asked
+            // for. This loop falls through to the alternate when the preferred
+            // endpoint cannot spawn, and without this `sessionEsploraUrl` keeps
+            // naming a provider we are not using. rotateArkOnchainEsplora then
+            // computes "next" from that stale value and can rotate straight
+            // onto the endpoint that just failed.
+            //
+            // Seen live 2026-08-18: a sync failed against mempool.space and the
+            // very next line read "rotated -> https://mempool.space/api",
+            // because the recorded session still said blockstream. The rotation
+            // was a no-op exactly when it was needed.
+            sessionEsploraUrl = esploraUrl;
             if (__DEV__) console.log('[Ark] Spawned onchain wallet via', esploraUrl);
             return onchainHandle;
         } catch (err) {

--- a/src/services/coinos/withdrawGuard.ts
+++ b/src/services/coinos/withdrawGuard.ts
@@ -1,0 +1,126 @@
+/**
+ * Duplicate protection for CoinOS on-chain withdrawals.
+ *
+ * THE HAZARD. `POST /bitcoin/send` crosses the network. If the connection dies
+ * after CoinOS accepted the request but before the reply arrives, the client
+ * cannot tell "never sent" from "sent, reply lost". The withdraw screen treated
+ * every failure as the former: it showed "Failed to Send to bitcoin. Please try
+ * again." and re-armed the swipe button. Following that instruction sends the
+ * money a second time, irreversibly.
+ *
+ * WHY NOT JUST AN IDEMPOTENCY KEY. A key only works if the server honours it,
+ * and we have not confirmed CoinOS does. We send one anyway (it costs nothing
+ * and helps if supported), but nothing here relies on it. The protection that
+ * actually works is client-side and has two halves:
+ *
+ *   1. Before sending, look for a withdrawal to the same address for the same
+ *      amount in the recent past. If one exists, this is almost certainly a
+ *      retry of a request that already went through.
+ *   2. When a send fails in a network-shaped way, do NOT report failure. The
+ *      outcome is unknown, and saying otherwise is what caused the double-send.
+ *
+ * Same reasoning as the indeterminate Lightning send in services/ark/send.ts:
+ * an unknown outcome must never be presented as a safe one.
+ */
+
+/** Shape we rely on from `GET /payments`. Deliberately loose. */
+export type CoinosPaymentLike = {
+    amount?: number | string | null;
+    created?: number | string | null;
+    type?: string | null;
+    hash?: string | null;
+    address?: string | null;
+    onchain?: { address?: string | null } | null;
+};
+
+/** How far back a matching withdrawal still counts as "probably this one". */
+export const WITHDRAW_DUPLICATE_WINDOW_MS = 10 * 60 * 1000;
+
+/** Error thrown when a withdrawal's outcome is UNKNOWN rather than failed. */
+export type CoinosWithdrawIndeterminateError = Error & {
+    coinosWithdrawIndeterminate: true;
+};
+
+/** True when the outcome is unknown and retrying risks paying twice. */
+export function isCoinosWithdrawIndeterminate(err: unknown): boolean {
+    return (
+        !!err &&
+        (err as { coinosWithdrawIndeterminate?: boolean }).coinosWithdrawIndeterminate === true
+    );
+}
+
+/**
+ * Network-shaped failures leave the request's fate unknown: it may well have
+ * reached CoinOS. Anything else (a validation rejection, say) is a real
+ * failure, because the server answered.
+ */
+export function isNetworkShapedFailure(err: unknown): boolean {
+    if (!err) return false;
+    const text = `${(err as Error)?.name ?? ''} ${(err as Error)?.message ?? ''}`;
+    return /network request failed|timeout|timed out|aborted|socket|econn|failed to fetch|network error/i.test(
+        text,
+    );
+}
+
+export function markWithdrawIndeterminate(message: string): CoinosWithdrawIndeterminateError {
+    const e = new Error(message) as CoinosWithdrawIndeterminateError;
+    e.coinosWithdrawIndeterminate = true;
+    return e;
+}
+
+function addressOf(p: CoinosPaymentLike): string | null {
+    const a = p?.onchain?.address ?? p?.address ?? null;
+    return typeof a === 'string' && a ? a.trim().toLowerCase() : null;
+}
+
+function createdMs(p: CoinosPaymentLike): number | null {
+    const c = p?.created;
+    if (typeof c === 'number' && Number.isFinite(c)) {
+        // CoinOS timestamps are ms; a seconds-shaped value would land in 1970.
+        return c < 1e12 ? c * 1000 : c;
+    }
+    if (typeof c === 'string') {
+        const t = Date.parse(c);
+        return Number.isNaN(t) ? null : t;
+    }
+    return null;
+}
+
+/**
+ * A recent withdrawal matching this destination and amount, or null.
+ *
+ * Amount is compared on magnitude: outgoing payments are negative in CoinOS's
+ * history, and the caller thinks in positive sats.
+ *
+ * Matching needs BOTH address and amount. Address alone would flag a legitimate
+ * second payment to the same destination, and amount alone would flag any
+ * same-sized payment to anyone.
+ */
+export function findRecentMatchingWithdrawal(
+    payments: readonly CoinosPaymentLike[] | null | undefined,
+    criteria: { address: string; amountSats: number; now: number; withinMs?: number },
+): CoinosPaymentLike | null {
+    const { address, amountSats, now } = criteria;
+    const withinMs = criteria.withinMs ?? WITHDRAW_DUPLICATE_WINDOW_MS;
+    if (!payments?.length || !address || !Number.isFinite(amountSats)) return null;
+
+    const wanted = address.trim().toLowerCase();
+    const wantedSats = Math.abs(Math.round(amountSats));
+
+    for (const p of payments) {
+        if (addressOf(p) !== wanted) continue;
+
+        const raw = typeof p?.amount === 'string' ? Number(p.amount) : p?.amount;
+        if (!Number.isFinite(raw as number)) continue;
+        if (Math.abs(Math.round(raw as number)) !== wantedSats) continue;
+
+        // No usable timestamp: treat as a match rather than risk a double-send.
+        // A false positive costs the user a confirmation tap; a false negative
+        // costs them the money.
+        const ts = createdMs(p);
+        if (ts == null) return p;
+
+        if (now - ts <= withinMs && now - ts >= -withinMs) return p;
+    }
+    return null;
+}

--- a/src/services/hotVaultKeychain.ts
+++ b/src/services/hotVaultKeychain.ts
@@ -72,15 +72,18 @@ export interface HotVaultMeta {
     version: 1;
     createdAt: number;
     label?: string | null;
-    /**
-     * True when the vault was created with a BIP39 passphrase. The keychain
-     * stores the WORDS ONLY (the passphrase is deliberately never persisted
-     * anywhere — it is the "something you know"); this flag tells the
-     * keychain-recovery flow to prompt for the passphrase after the
-     * biometric seed read. Reveals only that protection exists, never the
-     * protection itself. Absent on pre-feature backups (=> no prompt).
-     */
-    hasPassphrase?: boolean;
+    // DELIBERATELY NO `hasPassphrase`.
+    //
+    // It used to live here so keychain recovery could prompt for the passphrase
+    // after the biometric read, on the reasoning that it "reveals only that
+    // protection exists, never the protection itself". That reveal is the
+    // problem. A BIP39 passphrase is a deniability tool: its value is that
+    // nobody can tell the hidden wallet exists, so a flag saying one does
+    // defeats the feature for anyone holding the unlocked phone.
+    //
+    // Stale `hasPassphrase` values in sidecars written by older builds are
+    // ignored on read (see readHotVaultMeta) rather than migrated, since
+    // rewriting them would need the seed and a biometric prompt.
 }
 
 export type HotVaultKeychainSaveResult =
@@ -145,7 +148,7 @@ export async function backupHotVaultMeta(
             version: 1,
             createdAt: meta.createdAt,
             label: meta.label ?? null,
-            hasPassphrase: meta.hasPassphrase ?? false,
+            // No passphrase flag is written. See HotVaultMeta.
         };
         await Keychain.setGenericPassword(
             walletID,
@@ -184,7 +187,6 @@ export async function backupHotVaultSeedWithMeta(
     const metaResult = await backupHotVaultMeta(walletID, {
         createdAt: meta?.createdAt ?? Date.now(),
         label: meta?.label ?? null,
-        hasPassphrase: meta?.hasPassphrase ?? false,
     });
     // Deliberately don't bubble up meta failures — the seed is saved, and a
     // missing meta row just falls back to a walletID-only picker row. That's
@@ -270,12 +272,10 @@ export async function getHotVaultMeta(
             version: 1,
             createdAt: parsed.createdAt,
             label: typeof parsed.label === 'string' ? parsed.label : null,
-            // Preserve the passphrase flag across the read. Dropping it here
-            // (as an earlier version did) makes every recovered backup look
-            // passphrase-less, so the Recover flow skips the passphrase prompt
-            // and reconstructs the wrong wallet. Coerce to a strict boolean so
-            // legacy entries (field absent) read as false.
-            hasPassphrase: parsed.hasPassphrase === true,
+            // A legacy `parsed.hasPassphrase` is deliberately DROPPED rather
+            // than surfaced. Recovery is passphrase-agnostic now, so nothing
+            // may branch on it: acting on the flag is what told anyone holding
+            // the phone that a hidden wallet existed. See HotVaultMeta.
         };
     } catch (err) {
         console.warn('[HotVault] Meta read failed for', walletID, err);

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -242,6 +242,15 @@ export type AuthStateType = {
      */
     arkExitStartedAt: number | null;
     /**
+     * When the current exit first had ANY claimable capsule, epoch ms.
+     *
+     * Drives the claim batching window: each claim is its own on-chain
+     * transaction with its own fee, so sweeping five capsules one at a time
+     * costs five fees where one would do. Persisted rather than held in a ref
+     * because the exit outlives the process by a day or more.
+     */
+    arkExitClaimBatchSince: number | null;
+    /**
      * Spendable sats captured at the moment the exit was started. Display
      * fallback for the "X sats pending exit" panel: the SDK's live counters
      * read 0 mid-broadcast (see useArkSync exit block) and any live read
@@ -291,6 +300,7 @@ export type AuthStateType = {
     setArkExitInProgress: (state: boolean) => void;
     setArkExitDestinationAddress: (state: string | null) => void;
     setArkExitStartedAt: (state: number | null) => void;
+    setArkExitClaimBatchSince: (state: number | null) => void;
     setArkExitDrained: (state: boolean) => void;
     setArkExitStartedSats: (state: number | null) => void;
     setArkExitFeeReserveSats: (state: number) => void;
@@ -512,6 +522,7 @@ const createAuthStore = (
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
+    arkExitClaimBatchSince: null,
     arkExitDrained: false,
     arkExitStartedSats: null,
     arkExitFeeReserveSats: 0,
@@ -588,6 +599,7 @@ const createAuthStore = (
     setArkExitInProgress: (state: boolean) => set({ arkExitInProgress: state }),
     setArkExitDestinationAddress: (state: string | null) => set({ arkExitDestinationAddress: state }),
     setArkExitStartedAt: (state: number | null) => set({ arkExitStartedAt: state }),
+    setArkExitClaimBatchSince: (state: number | null) => set({ arkExitClaimBatchSince: state }),
     setArkExitDrained: (state: boolean) => set({ arkExitDrained: state }),
     setArkExitStartedSats: (state: number | null) => set({ arkExitStartedSats: state }),
     setArkExitFeeReserveSats: (state: number) => set({ arkExitFeeReserveSats: state }),
@@ -631,6 +643,7 @@ const createAuthStore = (
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,
+            arkExitClaimBatchSince: null,
             arkExitDrained: false,
             arkExitStartedSats: null,
             arkExitFeeReserveSats: 0,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -269,6 +269,13 @@ export type AuthStateType = {
      * the user opens the "Fund exit fees" flow; reset on wallet teardown.
      */
     arkExitFeeReserveSats: number;
+    /**
+     * Last computed exit-cost estimate (computeExitFeeReserveSats). Persisted
+     * ONLY so the sync loop's auto-board can see it: the estimate is computed
+     * on the exit settings screen, but auto-board runs headless and would
+     * otherwise hold just what the user armed and board the rest away.
+     */
+    arkExitRecommendedReserveSats: number | null;
     arkUseHotVaultSeed: boolean;
     withdrawArkThreshold: any | null;
     reserveArkAmount: number;
@@ -294,6 +301,7 @@ export type AuthStateType = {
     setArkExitDrained: (state: boolean) => void;
     setArkExitStartedSats: (state: number | null) => void;
     setArkExitFeeReserveSats: (state: number) => void;
+    setArkExitRecommendedReserveSats: (state: number | null) => void;
     setArkUseHotVaultSeed: (state: boolean) => void;
     setWithdrawArkThreshold: (state: any) => void;
     setReserveArkAmount: (state: number) => void;
@@ -515,6 +523,7 @@ const createAuthStore = (
     arkExitDrained: false,
     arkExitStartedSats: null,
     arkExitFeeReserveSats: 0,
+    arkExitRecommendedReserveSats: null,
     arkUseHotVaultSeed: false,
     withdrawArkThreshold: 500000,
     reserveArkAmount: 100000,
@@ -591,6 +600,8 @@ const createAuthStore = (
     setArkExitDrained: (state: boolean) => set({ arkExitDrained: state }),
     setArkExitStartedSats: (state: number | null) => set({ arkExitStartedSats: state }),
     setArkExitFeeReserveSats: (state: number) => set({ arkExitFeeReserveSats: state }),
+    setArkExitRecommendedReserveSats: (state: number | null) =>
+        set({ arkExitRecommendedReserveSats: state }),
     setArkUseHotVaultSeed: (state: boolean) => set({ arkUseHotVaultSeed: state }),
     setWithdrawArkThreshold: (state: any) => set({ withdrawArkThreshold: state }),
     setReserveArkAmount: (state: number) => set({ reserveArkAmount: state }),
@@ -634,6 +645,7 @@ const createAuthStore = (
             arkExitDrained: false,
             arkExitStartedSats: null,
             arkExitFeeReserveSats: 0,
+            arkExitRecommendedReserveSats: null,
             arkUseHotVaultSeed: false,
             allBTCWallets: get().allBTCWallets.filter(wallet => wallet !== 'ARK'),
             // Keep thresholds — don't reset on logout

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -220,6 +220,26 @@ export type AuthStateType = {
      */
     arkRoundIntervalSecs: number | null;
     /**
+     * CSV delay in blocks a unilateral exit output must sit out before it can
+     * be claimed (`ArkInfo.vtxoExitDelta`, observed 144 on mainnet). Cached
+     * from the same one-shot arkInfo fetch as `arkRoundIntervalSecs`.
+     *
+     * Cached rather than fetched on demand because the exit path must never
+     * call the ASP: the user pressed the trustless button precisely because the
+     * server may be gone. Exit triage needs this to work out whether a capsule
+     * has the runway to clear its timelock before it expires, and a null makes
+     * it assume the worst plausible delta rather than skip the check.
+     */
+    arkVtxoExitDeltaBlocks: number | null;
+    /**
+     * `ArkInfo.maxVtxoExitDepth` (observed 100). Past this the server refuses
+     * to cosign further out-of-round spends of a capsule, so exit or refresh
+     * are the only moves left with it. Surfaced as a disclosure during exit
+     * triage; it never excludes a capsule, since being un-spendable through the
+     * server is an argument FOR exiting it.
+     */
+    arkMaxVtxoExitDepth: number | null;
+    /**
      * Unilateral-exit state — set when user taps "Emergency Exit" in
      * Settings. While true, `useArkSync` switches modes: it stops issuing
      * normal sync/refresh calls (they'd race the exit machinery) and instead
@@ -288,6 +308,10 @@ export type AuthStateType = {
     setArkLastSyncedAt: (state: number | null) => void;
     setArkLastBackupAt: (state: number | null) => void;
     setArkRoundIntervalSecs: (state: number | null) => void;
+    setArkExitParams: (state: {
+        vtxoExitDeltaBlocks: number | null;
+        maxVtxoExitDepth: number | null;
+    }) => void;
     setArkExitInProgress: (state: boolean) => void;
     setArkExitDestinationAddress: (state: string | null) => void;
     setArkExitStartedAt: (state: number | null) => void;
@@ -509,6 +533,8 @@ const createAuthStore = (
     arkLastSyncedAt: null,
     arkLastBackupAt: null,
     arkRoundIntervalSecs: null,
+    arkVtxoExitDeltaBlocks: null,
+    arkMaxVtxoExitDepth: null,
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
@@ -585,6 +611,10 @@ const createAuthStore = (
     setArkLastSyncedAt: (state: number | null) => set({ arkLastSyncedAt: state }),
     setArkLastBackupAt: (state: number | null) => set({ arkLastBackupAt: state }),
     setArkRoundIntervalSecs: (state: number | null) => set({ arkRoundIntervalSecs: state }),
+    setArkExitParams: (state) => set({
+        arkVtxoExitDeltaBlocks: state.vtxoExitDeltaBlocks,
+        arkMaxVtxoExitDepth: state.maxVtxoExitDepth,
+    }),
     setArkExitInProgress: (state: boolean) => set({ arkExitInProgress: state }),
     setArkExitDestinationAddress: (state: string | null) => set({ arkExitDestinationAddress: state }),
     setArkExitStartedAt: (state: number | null) => set({ arkExitStartedAt: state }),
@@ -628,6 +658,13 @@ const createAuthStore = (
             arkLastSyncedAt: null,
             arkLastBackupAt: null,
             arkRoundIntervalSecs: null,
+            // arkVtxoExitDeltaBlocks / arkMaxVtxoExitDepth are deliberately NOT
+            // reset. They are the server's protocol constants, not wallet
+            // state, and exit triage falls back to a worst-case delta whenever
+            // they are null. Clearing them here would leave a freshly recovered
+            // wallet triaging against that worst case until the next arkInfo
+            // fetch lands, which excludes capsules that had the runway all
+            // along. Same reasoning as arkBgRefreshEnabled below.
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -629,12 +629,27 @@ const createAuthStore = (
             arkLastBackupAt: null,
             arkRoundIntervalSecs: null,
             arkExitInProgress: false,
-            arkExitDestinationAddress: null,
             arkExitStartedAt: null,
             arkExitDrained: false,
             arkExitStartedSats: null,
-            arkExitFeeReserveSats: 0,
             arkUseHotVaultSeed: false,
+            // arkExitDestinationAddress and arkExitFeeReserveSats are
+            // deliberately NOT reset here. Both are user-chosen exit-funding
+            // settings, and clearArkAuth is not only a logout: the boot path
+            // calls it on a `no-datadir` restore result
+            // (useArkRestoreOnBoot.ts:99), so a transient read on a device that
+            // does have a vault silently discarded both.
+            //
+            // Observed on device 2026-08-16. The reserve went to 0, which flips
+            // sync.ts out of the "hold funds on-chain" branch and into
+            // boardAll(), i.e. boarding away the very sats set aside to pay for
+            // a unilateral exit. And the nulled destination let
+            // useArkExitDestinationBackfill (which only fills when unset)
+            // substitute a fresh Hot Vault address, so a live exit was
+            // redirected away from the address the user had chosen.
+            //
+            // Same reasoning as the kept thresholds below and as
+            // arkArkoorPromptEnabled.
             allBTCWallets: get().allBTCWallets.filter(wallet => wallet !== 'ARK'),
             // Keep thresholds — don't reset on logout
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -240,6 +240,17 @@ export type AuthStateType = {
      */
     arkMaxVtxoExitDepth: number | null;
     /**
+     * Block height by which the tightest capsule in an in-flight exit must have
+     * cleared its timelock. Written when the exit starts.
+     *
+     * The exit drive prices its CPFP bids from how much runway is left, and the
+     * runway shrinks every block over an exit that runs for days. Persisting the
+     * DEADLINE rather than the urgency band lets the drive re-derive the band
+     * each tick against the current tip, with no extra wallet read and no stale
+     * band. Null means unknown, which the pricing treats as most urgent.
+     */
+    arkExitFeeDeadlineHeight: number | null;
+    /**
      * Unilateral-exit state — set when user taps "Emergency Exit" in
      * Settings. While true, `useArkSync` switches modes: it stops issuing
      * normal sync/refresh calls (they'd race the exit machinery) and instead
@@ -308,6 +319,7 @@ export type AuthStateType = {
     setArkLastSyncedAt: (state: number | null) => void;
     setArkLastBackupAt: (state: number | null) => void;
     setArkRoundIntervalSecs: (state: number | null) => void;
+    setArkExitFeeDeadlineHeight: (state: number | null) => void;
     setArkExitParams: (state: {
         vtxoExitDeltaBlocks: number | null;
         maxVtxoExitDepth: number | null;
@@ -535,6 +547,7 @@ const createAuthStore = (
     arkRoundIntervalSecs: null,
     arkVtxoExitDeltaBlocks: null,
     arkMaxVtxoExitDepth: null,
+    arkExitFeeDeadlineHeight: null,
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
@@ -611,6 +624,7 @@ const createAuthStore = (
     setArkLastSyncedAt: (state: number | null) => set({ arkLastSyncedAt: state }),
     setArkLastBackupAt: (state: number | null) => set({ arkLastBackupAt: state }),
     setArkRoundIntervalSecs: (state: number | null) => set({ arkRoundIntervalSecs: state }),
+    setArkExitFeeDeadlineHeight: (state: number | null) => set({ arkExitFeeDeadlineHeight: state }),
     setArkExitParams: (state) => set({
         arkVtxoExitDeltaBlocks: state.vtxoExitDeltaBlocks,
         arkMaxVtxoExitDepth: state.maxVtxoExitDepth,
@@ -665,6 +679,7 @@ const createAuthStore = (
             // wallet triaging against that worst case until the next arkInfo
             // fetch lands, which excludes capsules that had the runway all
             // along. Same reasoning as arkBgRefreshEnabled below.
+            arkExitFeeDeadlineHeight: null,
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,

--- a/tests/unit/arkAutoBackup.test.ts
+++ b/tests/unit/arkAutoBackup.test.ts
@@ -1,0 +1,231 @@
+/**
+ * writeArkAutoBackup must never destroy the last good backup on a tick that
+ * stored nothing.
+ *
+ * Every destination in this function is deliberately silent-fail, which is
+ * right for a background write that retries next tick. The hazard is that
+ * "this function resolved" was then treated as evidence that something was
+ * stored, by two callers that must not be wrong about it:
+ *
+ *   1. migrateLegacyBackupsForActiveWallet, which DELETES the previous
+ *      snapshot, and
+ *   2. arkLastBackupAt, which drives "Backed up" in the capsule UI.
+ *
+ * For a Bark vault the .cbark carries the pre-signed exit chain, so losing
+ * every copy also loses the ability to exit unilaterally. That is why this is
+ * a unit test and not device QA: you cannot make iCloud, Drive and SAF all
+ * fail from the UI, but a background tick on a device with no space and no
+ * network does it for free.
+ */
+
+const mockRNFS = {
+    DocumentDirectoryPath: '/docs',
+    writeFile: jest.fn(),
+    moveFile: jest.fn(),
+    unlink: jest.fn(),
+    exists: jest.fn(),
+    readFile: jest.fn(),
+    readDir: jest.fn(),
+    mkdir: jest.fn(),
+    stat: jest.fn(),
+};
+
+const mockPlatform = { OS: 'ios' as 'ios' | 'android' };
+const mockGetICloudDocumentsPath = jest.fn();
+
+jest.mock('react-native', () => ({
+    __esModule: true,
+    get Platform() {
+        return mockPlatform;
+    },
+    NativeModules: {
+        get CypherCloudStorage() {
+            return { getICloudDocumentsPath: mockGetICloudDocumentsPath };
+        },
+    },
+}));
+
+jest.mock('react-native-fs', () => ({ __esModule: true, default: mockRNFS }));
+
+jest.mock('react-native-aes-crypto', () => ({
+    __esModule: true,
+    default: {
+        pbkdf2: jest.fn().mockResolvedValue('00'.repeat(32)),
+        randomKey: jest.fn().mockResolvedValue('11'.repeat(16)),
+        encrypt: jest.fn().mockResolvedValue('CIPHERTEXT'),
+        decrypt: jest.fn().mockResolvedValue('{}'),
+    },
+}));
+
+jest.mock('../../src/services/ark/backupFingerprint', () => ({
+    __esModule: true,
+    deriveBackupFingerprint: jest.fn().mockResolvedValue('17424cf4'),
+    normalizeMnemonic: (m: string) => m.trim(),
+}));
+
+jest.mock('../../src/services/ark/datadir', () => ({
+    __esModule: true,
+    ARK_DATADIR: '/datadir',
+    ensureArkDatadir: jest.fn().mockResolvedValue('/datadir'),
+}));
+
+const mockIsGoogleDriveConnected = jest.fn();
+const mockUploadArkBackupToDrive = jest.fn();
+jest.mock('../../src/services/ark/googleDrive', () => ({
+    __esModule: true,
+    classifyDriveError: jest.fn(() => 'unknown'),
+    deleteDriveBackupByFingerprint: jest.fn(),
+    deleteLegacyDriveBackup: jest.fn(),
+    downloadArkBackupFromDrive: jest.fn().mockResolvedValue(null),
+    downloadDriveBackupByFingerprint: jest.fn().mockResolvedValue(null),
+    isGoogleDriveConnected: mockIsGoogleDriveConnected,
+    uploadArkBackupToDrive: mockUploadArkBackupToDrive,
+}));
+
+const mockGetSavedSafBackupFolder = jest.fn();
+const mockWriteArkBackupToSaf = jest.fn();
+jest.mock('../../src/services/ark/safFolderBackup', () => ({
+    __esModule: true,
+    deleteLegacySafBackup: jest.fn(),
+    deleteSafBackupByFingerprint: jest.fn(),
+    getSavedSafBackupFolder: mockGetSavedSafBackupFolder,
+    readArkBackupFromSaf: jest.fn().mockResolvedValue(null),
+    writeAndReadbackSafBackup: jest.fn(),
+    writeArkBackupToSaf: mockWriteArkBackupToSaf,
+}));
+
+jest.mock('../../src/services/ark/walletHandle', () => ({
+    __esModule: true,
+    clearArkWalletHandle: jest.fn(),
+}));
+
+jest.mock('../../src/services/ark/restore', () => ({
+    __esModule: true,
+    openArkWalletWithRotation: jest.fn(),
+}));
+
+import { writeArkAutoBackup } from '../../src/services/ark/backup';
+
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/**
+ * Deletions that would destroy a real backup.
+ *
+ * `atomicWriteFile` unlinks its own `.tmp` scratch file on the failure path,
+ * which is correct and unrelated. Only non-tmp unlinks represent the legacy
+ * cleanup that must not run on a tick that stored nothing.
+ */
+function legacyDeletions(): string[] {
+    return mockRNFS.unlink.mock.calls
+        .map((c) => String(c[0]))
+        .filter((p) => !p.endsWith('.tmp'));
+}
+
+/** Datadir with one file, so the packer always has something to encrypt. */
+function healthyDatadir() {
+    mockRNFS.readDir.mockResolvedValue([
+        { name: 'db.sqlite', path: '/datadir/db.sqlite', isFile: () => true, isDirectory: () => false, size: 10 },
+    ]);
+    mockRNFS.readFile.mockResolvedValue('ZGF0YQ==');
+}
+
+/** Both the atomic move and the direct write fail: no local copy is stored. */
+function localWriteFails() {
+    mockRNFS.writeFile.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    mockRNFS.moveFile.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+}
+
+function localWriteSucceeds() {
+    mockRNFS.writeFile.mockResolvedValue(undefined);
+    mockRNFS.moveFile.mockResolvedValue(undefined);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlatform.OS = 'ios';
+    healthyDatadir();
+    mockRNFS.exists.mockResolvedValue(false);
+    mockRNFS.mkdir.mockResolvedValue(undefined);
+    mockRNFS.unlink.mockResolvedValue(undefined);
+    // Default: every mirror unavailable.
+    mockGetICloudDocumentsPath.mockResolvedValue(null);
+    mockIsGoogleDriveConnected.mockResolvedValue(false);
+    mockGetSavedSafBackupFolder.mockResolvedValue(null);
+});
+
+describe('writeArkAutoBackup when every destination fails', () => {
+    it('rejects rather than resolving, so callers skip the "Backed up" stamp', async () => {
+        localWriteFails();
+        await expect(writeArkAutoBackup(MNEMONIC)).rejects.toThrow(/wrote nothing/i);
+    });
+
+    it('does NOT delete the legacy backup', async () => {
+        // The whole point. Pre-fix, the legacy cleanup ran unconditionally, so a
+        // tick that stored nothing still removed the previous good snapshot and
+        // could leave the wallet with no .cbark anywhere.
+        localWriteFails();
+        mockRNFS.exists.mockResolvedValue(true); // a legacy file IS present
+        await expect(writeArkAutoBackup(MNEMONIC)).rejects.toThrow();
+        expect(legacyDeletions()).toEqual([]);
+    });
+
+    it('still fails when iCloud is reachable but its write throws', async () => {
+        localWriteFails();
+        mockGetICloudDocumentsPath.mockResolvedValue('/icloud');
+        // iCloud goes through the same RNFS writer, already rejecting above.
+        await expect(writeArkAutoBackup(MNEMONIC)).rejects.toThrow(/wrote nothing/i);
+        expect(legacyDeletions()).toEqual([]);
+    });
+
+    it('still fails when Drive is connected but the upload throws', async () => {
+        localWriteFails();
+        mockPlatform.OS = 'android';
+        mockIsGoogleDriveConnected.mockResolvedValue(true);
+        mockUploadArkBackupToDrive.mockRejectedValue(new Error('403 quota'));
+        await expect(writeArkAutoBackup(MNEMONIC)).rejects.toThrow(/wrote nothing/i);
+        expect(legacyDeletions()).toEqual([]);
+    });
+
+    it('still fails when a SAF folder is chosen but the write throws', async () => {
+        localWriteFails();
+        mockPlatform.OS = 'android';
+        mockGetSavedSafBackupFolder.mockResolvedValue('content://tree/backups');
+        mockWriteArkBackupToSaf.mockRejectedValue(new Error('permission revoked'));
+        await expect(writeArkAutoBackup(MNEMONIC)).rejects.toThrow(/wrote nothing/i);
+        expect(legacyDeletions()).toEqual([]);
+    });
+});
+
+describe('writeArkAutoBackup when at least one destination succeeds', () => {
+    it('resolves when only the local write succeeds', async () => {
+        localWriteSucceeds();
+        await expect(writeArkAutoBackup(MNEMONIC)).resolves.toEqual(
+            expect.objectContaining({ path: expect.stringContaining('ark-backup-17424cf4.cbark') }),
+        );
+    });
+
+    it('resolves when the local write fails but Drive succeeds', async () => {
+        // A local-write failure must not veto a tick that DID reach a mirror,
+        // otherwise an out-of-space device stops backing up entirely.
+        localWriteFails();
+        mockPlatform.OS = 'android';
+        mockIsGoogleDriveConnected.mockResolvedValue(true);
+        mockUploadArkBackupToDrive.mockResolvedValue(undefined);
+        await expect(writeArkAutoBackup(MNEMONIC)).resolves.toBeDefined();
+    });
+
+    it('resolves when the local write fails but a SAF folder succeeds', async () => {
+        localWriteFails();
+        mockPlatform.OS = 'android';
+        mockGetSavedSafBackupFolder.mockResolvedValue('content://tree/backups');
+        mockWriteArkBackupToSaf.mockResolvedValue(undefined);
+        await expect(writeArkAutoBackup(MNEMONIC)).resolves.toBeDefined();
+    });
+
+    it('reports the size of what it actually wrote', async () => {
+        localWriteSucceeds();
+        const res = await writeArkAutoBackup(MNEMONIC);
+        expect(res.sizeBytes).toBeGreaterThan(0);
+        expect(typeof res.createdAt).toBe('number');
+    });
+});

--- a/tests/unit/arkExitGuard.test.ts
+++ b/tests/unit/arkExitGuard.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Exit guard: never run a cooperative round while a unilateral exit is live.
+ *
+ * bark does NOT defend against this. Confirmed with Second 2026-08-13: "we
+ * allow VTXOs to be marked for exit and for the user to still spend them."
+ * The lock/unlock API they suggest is not exposed in bark-react-native 0.16.1,
+ * so this client-side guard is the only thing standing between a delegated
+ * round and a coin that is already committed on-chain.
+ *
+ * These paths are deliberately NOT reachable from the UI, which is why they get
+ * a unit test rather than device QA. On device (2026-08-16) every refresh
+ * control is disabled once an exit is active, so the guard underneath can never
+ * be exercised by tapping. The background wake has no UI at all: it runs
+ * headless from a silent push, picks its own VTXOs inside bark, and executes
+ * before the store has hydrated.
+ */
+
+const mockGetExitVtxos = jest.fn();
+const mockStoreState = {
+    arkExitInProgress: false,
+    arkVtxos: [] as Array<{ id: string; exiting?: boolean }>,
+};
+
+jest.mock('@Cypher/stores/authStore', () => ({
+    __esModule: true,
+    default: { getState: () => mockStoreState },
+}));
+
+jest.mock('../../src/services/ark/walletHandle', () => ({
+    __esModule: true,
+    getArkWalletHandle: () => ({ getExitVtxos: mockGetExitVtxos }),
+    ensureArkOnchainHandle: jest.fn(),
+}));
+
+jest.mock('@secondts/bark-react-native', () => ({
+    __esModule: true,
+    extractTxFromPsbt: jest.fn(),
+}));
+
+import {
+    assertNoActiveArkExitAsync,
+    hasActiveArkExitRecords,
+} from '../../src/services/ark/exit';
+
+beforeEach(() => {
+    mockGetExitVtxos.mockReset();
+    mockStoreState.arkExitInProgress = false;
+    mockStoreState.arkVtxos = [];
+});
+
+describe('hasActiveArkExitRecords', () => {
+    it('is false when bark reports no exit records at all', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+
+    it('is true while an exit is Processing (broadcasting)', async () => {
+        // The live state observed on device: every capsule sat at Processing
+        // for the whole broadcast phase.
+        mockGetExitVtxos.mockResolvedValue([{ state: 'Processing', isClaimable: false }]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it.each([
+        'AwaitingConfirmation',
+        'AwaitingInputConfirmation',
+        'AwaitingCpfpBroadcast',
+        'AwaitingDelta',
+    ])('is true during the %s phase', async (state) => {
+        // Matching only Processing would report "no exit" for most of an exit's
+        // life: AwaitingDelta alone is the ~24h CSV wait.
+        mockGetExitVtxos.mockResolvedValue([{ state, isClaimable: false }]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is true when a vtxo is claimable but not yet claimed', async () => {
+        mockGetExitVtxos.mockResolvedValue([{ state: 'Done', isClaimable: true }]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is false once every record is terminal', async () => {
+        mockGetExitVtxos.mockResolvedValue([
+            { state: 'Done', isClaimable: false },
+            { state: 'Exited', isClaimable: false },
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+
+    it('is true when only ONE of several records is still active', async () => {
+        mockGetExitVtxos.mockResolvedValue([
+            { state: 'Done', isClaimable: false },
+            { state: 'Exited', isClaimable: false },
+            { state: 'Processing', isClaimable: false },
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is false when the read throws, because a failed read is not evidence of an exit', async () => {
+        // Callers use this to BLOCK an action. Returning true on a failed read
+        // would wedge refresh whenever bark's DB hiccuped.
+        mockGetExitVtxos.mockRejectedValue(new Error('db locked'));
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+
+    it('is false when getExitVtxos resolves null rather than an array', async () => {
+        mockGetExitVtxos.mockResolvedValue(null);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+});
+
+describe('assertNoActiveArkExitAsync', () => {
+    it('resolves when nothing indicates an exit', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        await expect(assertNoActiveArkExitAsync('Refreshing capsules')).resolves.toBeUndefined();
+    });
+
+    it('throws on the zustand flag alone', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        mockStoreState.arkExitInProgress = true;
+        await expect(assertNoActiveArkExitAsync('Refreshing capsules')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
+    });
+
+    it('throws on a vtxo flagged exiting even when the store flag is clear', async () => {
+        mockGetExitVtxos.mockResolvedValue([]);
+        mockStoreState.arkVtxos = [{ id: 'a' }, { id: 'b', exiting: true }];
+        await expect(assertNoActiveArkExitAsync('Refreshing capsules')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
+    });
+
+    it("throws on bark's DB even when the store looks clean", async () => {
+        // The whole reason this async variant exists. The background wake runs
+        // before the store hydrates, so `arkExitInProgress` reads its default
+        // false and the sync guard silently passes. bark is the authority.
+        mockStoreState.arkExitInProgress = false;
+        mockStoreState.arkVtxos = [];
+        mockGetExitVtxos.mockResolvedValue([{ state: 'Processing', isClaimable: false }]);
+        await expect(assertNoActiveArkExitAsync('Background refresh')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
+    });
+
+    it('names the action in the message so the UI can surface it verbatim', async () => {
+        mockStoreState.arkExitInProgress = true;
+        mockGetExitVtxos.mockResolvedValue([]);
+        await expect(assertNoActiveArkExitAsync('Background refresh')).rejects.toThrow(
+            /^Background refresh is unavailable/,
+        );
+    });
+});

--- a/tests/unit/arkExitGuard.test.ts
+++ b/tests/unit/arkExitGuard.test.ts
@@ -79,18 +79,33 @@ describe('hasActiveArkExitRecords', () => {
     });
 
     it('is false once every record is terminal', async () => {
+        // The terminal set is exactly Claimed / VtxoAlreadySpent / Canceled,
+        // per the SDK's generated ExitState_Tags. This case used to assert on
+        // 'Done' and 'Exited', which are not ExitState variants at all, so it
+        // proved nothing about real terminal detection.
         mockGetExitVtxos.mockResolvedValue([
-            { state: 'Done', isClaimable: false },
-            { state: 'Exited', isClaimable: false },
+            { state: 'Claimed', isClaimable: false },
+            { state: 'VtxoAlreadySpent', isClaimable: false },
+            { state: 'Canceled', isClaimable: false },
         ]);
         await expect(hasActiveArkExitRecords()).resolves.toBe(false);
     });
 
     it('is true when only ONE of several records is still active', async () => {
         mockGetExitVtxos.mockResolvedValue([
-            { state: 'Done', isClaimable: false },
-            { state: 'Exited', isClaimable: false },
+            { state: 'Claimed', isClaimable: false },
+            { state: 'VtxoAlreadySpent', isClaimable: false },
             { state: 'Processing', isClaimable: false },
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('treats an unrecognised state as ACTIVE, not complete', async () => {
+        // Deliberate asymmetry. Mis-reading an in-flight exit as finished is
+        // what retired an exit early and deleted a wallet mid-exit (2026-07-31);
+        // mis-reading a finished exit as live only delays a refresh.
+        mockGetExitVtxos.mockResolvedValue([
+            { state: 'SomeFutureSdkState', isClaimable: false },
         ]);
         await expect(hasActiveArkExitRecords()).resolves.toBe(true);
     });
@@ -105,6 +120,95 @@ describe('hasActiveArkExitRecords', () => {
     it('is false when getExitVtxos resolves null rather than an array', async () => {
         mockGetExitVtxos.mockResolvedValue(null);
         await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+    });
+});
+
+/**
+ * bark 0.6.1 turned `ExitVtxo.state` from a plain string into a UniFFI
+ * tagged-enum object. Every fixture above uses the OLD string shape, which is
+ * why this suite stayed green while the guard was broken in production: the
+ * implementation regexed `String(v.state)` for /^(Processing|Awaiting)/, and
+ * against a real object that is "[object Object]", which matches nothing. The
+ * check silently collapsed to `v.isClaimable`.
+ *
+ * Read off the device on 2026-08-18 during a live mainnet exit with 2794 sats
+ * in flight: three capsules AwaitingDelta, one ClaimInProgress, every one of
+ * them isClaimable=false. hasActiveArkExitRecords() returned false, so the
+ * cooperative-round guard was open for essentially the whole exit.
+ *
+ * These fixtures are those exact payloads. They fail against the regex.
+ */
+describe('hasActiveArkExitRecords with bark 0.6.1 tagged-enum states', () => {
+    const awaitingDelta = {
+        state: {
+            tag: 'AwaitingDelta',
+            inner: {
+                tipHeight: 962962,
+                confirmedBlock: { height: 962957, hash: '0000000000000000000217a2e759c9143db1946b6a49ddf6a07c2c59b7e9341c' },
+                claimableHeight: 963101,
+            },
+        },
+        isClaimable: false,
+    };
+    const claimInProgress = {
+        state: {
+            tag: 'ClaimInProgress',
+            inner: {
+                tipHeight: 963060,
+                claimableSince: { height: 963046, hash: '00000000000000000000e17fac82dcb0cb9c5d78a7dfc2328c3bb970fd2a2cbc' },
+                claimTxid: 'fcdfa310ecd61bdbea44d03d88412a7756ad65a8c0483c1f5ca6bd8d7d558482',
+            },
+        },
+        isClaimable: false,
+    };
+
+    it('is true during AwaitingDelta, the ~24h CSV wait', async () => {
+        mockGetExitVtxos.mockResolvedValue([awaitingDelta]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is true during ClaimInProgress, after the claim is broadcast', async () => {
+        mockGetExitVtxos.mockResolvedValue([claimInProgress]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it('is true for the exact 4-capsule set read off the device', async () => {
+        mockGetExitVtxos.mockResolvedValue([
+            claimInProgress,
+            awaitingDelta,
+            awaitingDelta,
+            awaitingDelta,
+        ]);
+        await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+    });
+
+    it.each(['Start', 'Processing', 'AwaitingDelta', 'Claimable', 'ClaimInProgress'])(
+        'is true for tagged-enum %s',
+        async (tag) => {
+            mockGetExitVtxos.mockResolvedValue([{ state: { tag }, isClaimable: false }]);
+            await expect(hasActiveArkExitRecords()).resolves.toBe(true);
+        },
+    );
+
+    it.each(['Claimed', 'VtxoAlreadySpent', 'Canceled'])(
+        'is false for terminal tagged-enum %s',
+        async (tag) => {
+            mockGetExitVtxos.mockResolvedValue([{ state: { tag }, isClaimable: false }]);
+            await expect(hasActiveArkExitRecords()).resolves.toBe(false);
+        },
+    );
+
+    it('blocks a background refresh mid-exit with a clean store', async () => {
+        // The end-to-end shape of the production bug: store flag lost (or not
+        // yet hydrated), bark holding a live AwaitingDelta exit. Before the
+        // fix this resolved, letting a cooperative round spend a coin already
+        // committed on-chain.
+        mockStoreState.arkExitInProgress = false;
+        mockStoreState.arkVtxos = [];
+        mockGetExitVtxos.mockResolvedValue([awaitingDelta]);
+        await expect(assertNoActiveArkExitAsync('Background refresh')).rejects.toThrow(
+            /Emergency Exit is in progress/,
+        );
     });
 });
 

--- a/tests/unit/arkExitSettingsSurvival.test.ts
+++ b/tests/unit/arkExitSettingsSurvival.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The two exit-funding settings must survive clearArkAuth().
+ *
+ * clearArkAuth is not only a logout. The boot path calls it whenever a restore
+ * comes back `no-datadir` (useArkRestoreOnBoot), so a transient read on a device
+ * that DOES have a vault used to discard both of these silently.
+ *
+ * Observed on device 2026-08-16, and both consequences are real money:
+ *
+ *   - arkExitFeeReserveSats going to 0 flips sync.ts out of its
+ *     "hold funds on-chain" branch and into boardAll(), i.e. boarding away the
+ *     exact sats the user set aside to pay for a unilateral exit.
+ *   - arkExitDestinationAddress going null lets useArkExitDestinationBackfill
+ *     (which only fills when unset) substitute a fresh Hot Vault address. A
+ *     live exit was seen being redirected away from the address the user chose.
+ *
+ * Same reasoning as arkArkoorPromptEnabled and the kept thresholds.
+ */
+
+jest.mock('../../src/stores/index', () => ({
+    __esModule: true,
+    zustandStorage: {
+        getItem: jest.fn().mockResolvedValue(null),
+        setItem: jest.fn().mockResolvedValue(undefined),
+        removeItem: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+import useAuthStore from '../../src/stores/authStore';
+
+const RESERVE = 14504;
+const DESTINATION = 'bc1qvr33z4mcexampledestinationchosenbytheuser';
+
+/** Put the store in the state of a user who has armed exit funding. */
+function armExitFunding() {
+    const s = useAuthStore.getState();
+    s.setArkExitFeeReserveSats(RESERVE);
+    s.setArkExitDestinationAddress(DESTINATION);
+    s.setArkAuth(true);
+}
+
+beforeEach(() => {
+    armExitFunding();
+});
+
+describe('clearArkAuth preserves exit-funding settings', () => {
+    it('keeps the armed exit fee reserve', () => {
+        expect(useAuthStore.getState().arkExitFeeReserveSats).toBe(RESERVE);
+        useAuthStore.getState().clearArkAuth();
+        expect(useAuthStore.getState().arkExitFeeReserveSats).toBe(RESERVE);
+    });
+
+    it('keeps the chosen exit destination address', () => {
+        expect(useAuthStore.getState().arkExitDestinationAddress).toBe(DESTINATION);
+        useAuthStore.getState().clearArkAuth();
+        expect(useAuthStore.getState().arkExitDestinationAddress).toBe(DESTINATION);
+    });
+
+    it('survives repeated clears, since the boot path can fire it every launch', () => {
+        for (let i = 0; i < 5; i++) useAuthStore.getState().clearArkAuth();
+        expect(useAuthStore.getState().arkExitFeeReserveSats).toBe(RESERVE);
+        expect(useAuthStore.getState().arkExitDestinationAddress).toBe(DESTINATION);
+    });
+
+    it('still clears the wallet-scoped state it is responsible for', () => {
+        // Guard against "fix" by deleting the reset entirely: clearArkAuth must
+        // keep doing its actual job.
+        const s = useAuthStore.getState();
+        s.setArkExitInProgress(true);
+        expect(useAuthStore.getState().isArkAuth).toBe(true); // precondition, not a trivial pass
+        useAuthStore.getState().clearArkAuth();
+        const after = useAuthStore.getState();
+        expect(after.isArkAuth).toBe(false);
+        expect(after.arkVtxos).toEqual([]);
+        expect(after.arkExitInProgress).toBe(false);
+        expect(after.allBTCWallets).not.toContain('ARK');
+    });
+});

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Telling the user which side of the network is unreachable.
+ *
+ * Chain-source failures and Ark-server failures look identical to a user and
+ * need opposite advice. Switching to mobile data genuinely fixed a chain-source
+ * outage on device; suggesting it while the ASP is down is noise at the exact
+ * moment someone thinks their money is stuck.
+ *
+ * Every error string below is one we actually captured on device.
+ */
+
+import {
+    arkErrorText,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+} from '../../src/services/ark/networkFault';
+
+const ENDPOINTS = {
+    chainUrls: ['https://blockstream.info/api', 'https://mempool.space/api'],
+    arkUrl: 'https://ark.second.tech',
+};
+
+const classify = (err: unknown) => classifyArkNetworkFault(err, ENDPOINTS);
+
+describe('chain-source failures', () => {
+    it('recognises the Blockstream bot-block page', () => {
+        // The literal error from the device, typo and all.
+        const err = {
+            tag: 'Inner',
+            message:
+                'Exception.Inner: Failed to create chain source: bad response from server (not a blockhash). Esplora client possibly misconfigured: failed to parse hex: invilad hex string length 338 (expected 64)',
+        };
+        expect(classify(err)).toBe('chain-source');
+    });
+
+    it('recognises the mempool.space TCP timeout by hostname', () => {
+        const err = {
+            tag: 'Inner',
+            message:
+                'Sync failed: Reqwest(reqwest::Error { kind: Request, url: "https://mempool.space/api/scripthash/abc/txs", source: Os { code: 60, kind: TimedOut } })',
+        };
+        expect(classify(err)).toBe('chain-source');
+    });
+
+    it('reads detail out of a BarkError inner payload', () => {
+        const err = { tag: 'ServerConnection', inner: { errorMessage: 'esplora request failed' } };
+        expect(classify(err)).toBe('chain-source');
+    });
+
+    it('suggests switching networks, which is the fix that worked', () => {
+        expect(arkNetworkFaultMessage('chain-source')).toMatch(/mobile data/i);
+    });
+});
+
+describe('ark-server failures', () => {
+    it('recognises the ASP by hostname', () => {
+        const err = { message: 'transport error connecting to https://ark.second.tech' };
+        expect(classify(err)).toBe('ark-server');
+    });
+
+    it('does NOT suggest switching networks', () => {
+        // The whole point of splitting the two. A network switch cannot fix a
+        // server that is down, and the advice wastes the user's time while
+        // their balance looks wrong.
+        const msg = arkNetworkFaultMessage('ark-server');
+        expect(msg).not.toMatch(/wi-?fi|mobile data|cellular/i);
+    });
+
+    it('says the exit does not depend on that server', () => {
+        expect(arkNetworkFaultMessage('ark-server')).toMatch(/exit/i);
+    });
+});
+
+describe('what it refuses to guess', () => {
+    it('does not treat ServerConnection alone as an Ark-server fault', () => {
+        // The tempting shortcut, and wrong: config.ts records that exact tag
+        // appearing for an esplora 429 during recovery. It identifies no side.
+        expect(classify({ tag: 'ServerConnection', message: 'BarkError.ServerConnection' })).toBe('unknown');
+    });
+
+    it('returns unknown for an unrelated failure', () => {
+        expect(classify(new Error('Insufficient balance'))).toBe('unknown');
+    });
+
+    it.each([null, undefined, '', {}])('returns unknown for %p', (v) => {
+        expect(classify(v)).toBe('unknown');
+    });
+
+    it('offers no message when it does not know', () => {
+        // Better silent than misleading: the caller still shows its own
+        // context, so the user is not left with nothing.
+        expect(arkNetworkFaultMessage('unknown')).toBeNull();
+    });
+
+    it('never throws on a malformed endpoint', () => {
+        expect(() =>
+            classifyArkNetworkFault({ message: 'boom' }, { chainUrls: ['not a url', ''], arkUrl: '::::' }),
+        ).not.toThrow();
+    });
+});
+
+describe('arkErrorText', () => {
+    it('flattens tag, message and inner detail together', () => {
+        const t = arkErrorText({ tag: 'Inner', message: 'outer', inner: { errorMessage: 'deep cause' } });
+        expect(t).toContain('outer');
+        expect(t).toContain('deep cause');
+    });
+
+    it('passes a plain string through', () => {
+        expect(arkErrorText('just text')).toBe('just text');
+    });
+
+    it('is empty for a value carrying no text', () => {
+        expect(arkErrorText({ code: 7 })).toBe('');
+    });
+});

--- a/tests/unit/arkSendIndeterminate.test.ts
+++ b/tests/unit/arkSendIndeterminate.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A Lightning send whose outcome is UNKNOWN must never be reported as failed.
+ *
+ * When the settlement wait times out with the HTLC still live, send.ts throws
+ * deliberately so the caller does not retry: the payment may yet settle. The
+ * review screen used to append "Your funds were not moved." to that error and
+ * clear isSending, which re-armed Send with the same destination and amount.
+ * Retrying an ln-address or ln-offer mints a FRESH invoice with a new payment
+ * hash, so the retry can settle alongside the original and pay the recipient
+ * twice, irreversibly, once per tap.
+ *
+ * This is the hardest path to reach on a device: it needs a real Lightning
+ * payment still unsettled after 75 seconds, which cannot be conjured on demand.
+ * Here the bark handle is faked to never report settlement and the clock is
+ * advanced past the deadline, so the branch runs deterministically.
+ *
+ * The contract under test is that the thrown error carries the indeterminate
+ * flag, and that its wording never claims the funds are safe. Callers branch on
+ * isArkSendIndeterminate() to decide whether to keep Send disabled.
+ */
+
+const LightningSendStatus_Tags = {
+    Unknown: 'Unknown',
+    InProgress: 'InProgress',
+    Paid: 'Paid',
+} as const;
+
+const mockHandle = {
+    estimateLightningSendFee: jest.fn(),
+    payLightningAddress: jest.fn(),
+    payLightningInvoice: jest.fn(),
+    payLightningOffer: jest.fn(),
+    checkLightningPayment: jest.fn(),
+    history: jest.fn(),
+};
+
+jest.mock('@secondts/bark-react-native', () => ({
+    __esModule: true,
+    LightningSendStatus_Tags,
+    validateArkAddress: jest.fn(() => false),
+}));
+
+jest.mock('../../src/services/ark/exit', () => ({
+    __esModule: true,
+    assertNoActiveArkExit: jest.fn(),
+}));
+
+jest.mock('../../src/services/ark/restore', () => ({
+    __esModule: true,
+    ensureArkWalletHandleReady: jest.fn(async () => mockHandle),
+}));
+
+jest.mock('../../src/services/ark/balance', () => ({
+    __esModule: true,
+    fetchArkBalance: jest.fn(async () => ({ spendableSats: 100_000 })),
+}));
+
+jest.mock('../../src/services/ark/vtxos', () => ({
+    __esModule: true,
+    fetchArkVtxos: jest.fn(async () => ({ spendable: [], all: [] })),
+}));
+
+jest.mock('@Cypher/stores/eventLogStore', () => ({
+    __esModule: true,
+    recordEvent: jest.fn(),
+}));
+
+import { executeArkSend, isArkSendIndeterminate } from '../../src/services/ark/send';
+
+const LN_ADDRESS_DEST = { kind: 'ln-address' as const, value: 'someone@example.com' };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandle.estimateLightningSendFee.mockResolvedValue({
+        feeSats: 2n,
+        grossAmountSats: 1002n,
+        netAmountSats: 1000n,
+        vtxosSpent: [],
+    });
+    // Dispatch returns without settling. `Unknown` carries no resolved bolt11,
+    // so the wait falls back to the raw destination, which is not a decodable
+    // invoice, so no payment hash is available to poll.
+    mockHandle.payLightningAddress.mockResolvedValue({ tag: LightningSendStatus_Tags.Unknown });
+    // No matching movement ever appears: the HTLC stays live.
+    mockHandle.history.mockResolvedValue([]);
+    mockHandle.checkLightningPayment.mockResolvedValue({ tag: LightningSendStatus_Tags.Unknown });
+});
+
+/**
+ * Run a send to completion with the 75s settlement wait collapsed.
+ *
+ * The wait sleeps on setTimeout between polls and compares Date.now() against a
+ * deadline. Under fake timers both are driven by the same clock, so flushing
+ * microtasks and then jumping past the deadline lets the loop exit on its next
+ * check without waiting in real time.
+ */
+async function runSendPastDeadline() {
+    jest.useFakeTimers();
+    try {
+        const pending = executeArkSend(LN_ADDRESS_DEST, 1000);
+        const caught = pending.catch((e) => e);
+        // Let dispatch + the first poll settle, then jump the clock repeatedly
+        // so every scheduled poll fires and the deadline check finally fails.
+        for (let i = 0; i < 20; i++) {
+            await Promise.resolve();
+            await Promise.resolve();
+            jest.advanceTimersByTime(10_000);
+        }
+        return await caught;
+    } finally {
+        jest.useRealTimers();
+    }
+}
+
+describe('an unsettled Lightning send is reported as indeterminate', () => {
+    it('throws rather than resolving, so no caller records a success', async () => {
+        const err = await runSendPastDeadline();
+        expect(err).toBeInstanceOf(Error);
+    });
+
+    it('flags the error so callers can branch without string matching', async () => {
+        const err = await runSendPastDeadline();
+        expect(isArkSendIndeterminate(err)).toBe(true);
+    });
+
+    it('never claims the funds are safe or unmoved', async () => {
+        // The exact false statement that used to be the last sentence the user
+        // read, while the payment was still in flight.
+        const err = await runSendPastDeadline();
+        expect(err.message).not.toMatch(/not moved/i);
+        expect(err.message).not.toMatch(/funds are safe/i);
+        expect(err.message).not.toMatch(/nothing was sent/i);
+    });
+
+    it('tells the user not to send again', async () => {
+        const err = await runSendPastDeadline();
+        expect(err.message).toMatch(/do not send it again/i);
+    });
+
+    it('did not retry the payment itself', async () => {
+        // A pending outcome must break the retry loop. Re-dispatching to an
+        // ln-address mints a new invoice and can pay twice.
+        await runSendPastDeadline();
+        expect(mockHandle.payLightningAddress).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('isArkSendIndeterminate', () => {
+    it('is true only for the flagged error', () => {
+        const flagged = Object.assign(new Error('may still be in flight'), {
+            arkSendIndeterminate: true,
+        });
+        expect(isArkSendIndeterminate(flagged)).toBe(true);
+    });
+
+    it('is false for an ordinary send failure, which MAY say funds are safe', () => {
+        // The refunded-after-retries error is a genuine failure. Treating it as
+        // indeterminate would disable Send forever after a recoverable error.
+        expect(isArkSendIndeterminate(new Error('failed after several attempts and was refunded'))).toBe(false);
+    });
+
+    it.each([null, undefined, 'a string', 0, {}, { arkSendIndeterminate: false }])(
+        'is false for %p',
+        (value) => {
+            expect(isArkSendIndeterminate(value)).toBe(false);
+        },
+    );
+
+    it('is false for a truthy-but-not-true flag, so only the real marker counts', () => {
+        expect(isArkSendIndeterminate({ arkSendIndeterminate: 'yes' })).toBe(false);
+        expect(isArkSendIndeterminate({ arkSendIndeterminate: 1 })).toBe(false);
+    });
+});

--- a/tests/unit/autoBoardDecision.test.ts
+++ b/tests/unit/autoBoardDecision.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Auto-board is the only thing that moves the on-chain balance without the user
+ * asking, and that balance is where unilateral-exit CPFP fees come from. Board
+ * the wrong amount and the exit is disarmed, silently.
+ */
+import { decideAutoBoard, AutoBoardInput } from '../../src/services/ark/autoBoardDecision';
+
+const MIN_BOARD = 50_000;
+const HEADROOM = 1_500;
+
+const base = (over: Partial<AutoBoardInput> = {}): AutoBoardInput => ({
+    confirmedSats: 0,
+    pendingBoardSats: 0,
+    exitInProgress: false,
+    armedReserveSats: 0,
+    recommendedReserveSats: null,
+    minBoardSats: MIN_BOARD,
+    boardFeeHeadroomSats: HEADROOM,
+    ...over,
+});
+
+describe('decideAutoBoard', () => {
+    it('boards nothing at all while an exit is in progress', () => {
+        const d = decideAutoBoard(base({ confirmedSats: 500_000, exitInProgress: true }));
+        expect(d).toEqual({ action: 'skip', reason: 'exit-in-progress' });
+    });
+
+    it('skips when a board is already in flight, which would otherwise double-board', () => {
+        const d = decideAutoBoard(base({ confirmedSats: 500_000, pendingBoardSats: 60_000 }));
+        expect(d).toEqual({ action: 'skip', reason: 'board-in-flight' });
+    });
+
+    it('skips when there is nothing on-chain', () => {
+        expect(decideAutoBoard(base({ confirmedSats: 0 }))).toEqual({
+            action: 'skip', reason: 'nothing-onchain',
+        });
+    });
+
+    describe('THE BUG: a funded reserve above the armed value', () => {
+        // Device figures, 2026-08-20: armed 3,654 while the estimate said
+        // 233,120. Funding to the recommendation by external deposit used to
+        // leave everything above 3,654 eligible for boarding.
+        const funded = base({
+            confirmedSats: 233_120,
+            armedReserveSats: 3_654,
+            recommendedReserveSats: 233_120,
+        });
+
+        it('holds the full recommendation, not the stale armed value', () => {
+            const d = decideAutoBoard(funded);
+            expect(d.action).toBe('hold');
+            expect((d as any).holdSats).toBe(233_120);
+        });
+
+        it('would have boarded 227,966 sats away under the old armed-only rule', () => {
+            // What the previous logic computed: confirmed - armed - headroom.
+            const oldExcess = 233_120 - 3_654 - HEADROOM;
+            expect(oldExcess).toBe(227_966);
+            expect(oldExcess).toBeGreaterThanOrEqual(MIN_BOARD); // so it WOULD have fired
+            const d = decideAutoBoard(funded);
+            expect(d.action).not.toBe('board-amount');
+        });
+    });
+
+    it('boards a genuine surplus above the hold target', () => {
+        const d = decideAutoBoard(base({
+            confirmedSats: 300_000,
+            armedReserveSats: 3_654,
+            recommendedReserveSats: 233_120,
+        }));
+        expect(d).toEqual({ action: 'board-amount', sats: 300_000 - 233_120 - HEADROOM, holdSats: 233_120 });
+    });
+
+    it('honours an armed reserve larger than the recommendation', () => {
+        const d = decideAutoBoard(base({
+            confirmedSats: 400_000,
+            armedReserveSats: 350_000,
+            recommendedReserveSats: 233_120,
+        }));
+        expect((d as any).holdSats).toBe(350_000);
+    });
+
+    describe('the unarmed path', () => {
+        it('boards everything when nothing needs holding', () => {
+            const d = decideAutoBoard(base({ confirmedSats: 60_000 }));
+            expect(d).toEqual({ action: 'board-all', holdSats: 0 });
+        });
+
+        it('THE SECOND BUG: holds instead of retrying a board that can never succeed', () => {
+            // 6,259 on-chain against a 50,000 minimum. The old code called
+            // boardAll here every sync tick, forever.
+            const d = decideAutoBoard(base({ confirmedSats: 6_259 }));
+            expect(d).toEqual({
+                action: 'hold', reason: 'below-board-minimum', surplusSats: 6_259, holdSats: 0,
+            });
+        });
+    });
+
+    it('never boards a surplus below the server minimum', () => {
+        const d = decideAutoBoard(base({
+            confirmedSats: 60_000,
+            armedReserveSats: 20_000,
+            recommendedReserveSats: null,
+        }));
+        // 60,000 - 20,000 - 1,500 = 38,500, under the 50,000 minimum.
+        expect(d).toEqual({
+            action: 'hold', reason: 'below-board-minimum', surplusSats: 38_500, holdSats: 20_000,
+        });
+    });
+
+    it('leaves the headroom so boardAmount fees cannot dip below the hold', () => {
+        const d = decideAutoBoard(base({ confirmedSats: 151_500, armedReserveSats: 100_000 }));
+        expect(d).toEqual({ action: 'board-amount', sats: 50_000, holdSats: 100_000 });
+    });
+});

--- a/tests/unit/capsuleSelection.test.ts
+++ b/tests/unit/capsuleSelection.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Vault sends must spend the capsules the user ticked.
+ *
+ * Before the fix, ColdStorage filtered the selection into `fUtxo` but only used
+ * it for the displayed balance: both the fee pre-calc and createTransaction
+ * received the UNFILTERED set. coinselect sorts descending and takes the
+ * largest, so every vault send ignored the selection and broke open whatever
+ * coin it liked, while the confirm screen showed change derived from the
+ * selection. Those two can differ by orders of magnitude, and the change is
+ * routed to a Strike or CoinOS deposit address.
+ *
+ * The second describe block is the part that actually demonstrates the money
+ * behaviour: it runs the real wallet and shows the same targets producing a
+ * DIFFERENT spent coin depending on whether the selection was applied.
+ */
+
+import { outpointKey, selectCapsules, selectedTotalSats } from '../../src/helpers/capsuleSelection';
+
+const SMALL = { txid: 'aa'.repeat(32), vout: 0, value: 20_000 };
+const LARGE = { txid: 'bb'.repeat(32), vout: 1, value: 500_000 };
+const MID = { txid: 'cc'.repeat(32), vout: 0, value: 80_000 };
+const ALL = [SMALL, LARGE, MID];
+
+describe('selectCapsules', () => {
+    it('returns exactly the ticked capsule, not the largest', () => {
+        const picked = selectCapsules(ALL, [outpointKey(SMALL)]);
+        expect(picked).toEqual([SMALL]);
+    });
+
+    it('keys on txid AND vout, so sibling outputs of one tx are distinguishable', () => {
+        // A single funding tx paying the vault twice is ordinary. Keying on
+        // txid alone would silently pull in the sibling output.
+        const v0 = { txid: 'dd'.repeat(32), vout: 0, value: 10_000 };
+        const v1 = { txid: 'dd'.repeat(32), vout: 1, value: 999_000 };
+        const picked = selectCapsules([v0, v1], [outpointKey(v0)]);
+        expect(picked).toEqual([v0]);
+    });
+
+    it('preserves the caller ordering of utxo, not the order ids were given in', () => {
+        const picked = selectCapsules(ALL, [outpointKey(MID), outpointKey(SMALL)]);
+        expect(picked).toEqual([SMALL, MID]);
+    });
+
+    it('returns empty for an empty selection, with no whole-wallet fallback', () => {
+        // The dangerous case. Falling back to the full set here is what made
+        // every send spend the wrong coin.
+        expect(selectCapsules(ALL, [])).toEqual([]);
+        expect(selectCapsules(ALL, null)).toEqual([]);
+        expect(selectCapsules(ALL, undefined)).toEqual([]);
+    });
+
+    it('returns empty when there are no utxos at all', () => {
+        expect(selectCapsules([], [outpointKey(SMALL)])).toEqual([]);
+        expect(selectCapsules(null, [outpointKey(SMALL)])).toEqual([]);
+    });
+
+    it('ignores ids with no matching utxo instead of fabricating inputs', () => {
+        // Stale selection: the coin was spent elsewhere since the picker
+        // rendered. Narrowing the spend is safe; inventing an input is not.
+        const picked = selectCapsules(ALL, [outpointKey(SMALL), 'ff'.repeat(32) + ':7']);
+        expect(picked).toEqual([SMALL]);
+    });
+
+    it('never returns a coin the user did not tick', () => {
+        const picked = selectCapsules(ALL, [outpointKey(SMALL), outpointKey(MID)]);
+        expect(picked).not.toContainEqual(LARGE);
+        expect(selectedTotalSats(picked)).toBe(100_000);
+    });
+
+    it('tolerates duplicate ids without duplicating the input', () => {
+        // A double-tap in the picker must not double-spend the same outpoint
+        // into the transaction.
+        const picked = selectCapsules(ALL, [outpointKey(SMALL), outpointKey(SMALL)]);
+        expect(picked).toEqual([SMALL]);
+    });
+});
+
+describe('the spend actually follows the selection', () => {
+    // Uses the real wallet so this asserts money behaviour, not just filtering.
+    const { HDSegwitBech32Wallet } = require('../../class');
+
+    function fundedWallet() {
+        const w = new HDSegwitBech32Wallet();
+        w.setSecret(
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        );
+        return w;
+    }
+
+    function utxosFor(w: any) {
+        const addr = w._getExternalAddressByIndex(0);
+        return [
+            { ...SMALL, address: addr, wif: w._getWifForAddress(addr), confirmations: 6, height: 1 },
+            { ...LARGE, address: addr, wif: w._getWifForAddress(addr), confirmations: 6, height: 1 },
+        ];
+    }
+
+    it('spends the LARGE coin when the selection is ignored, and the SMALL one when it is honoured', () => {
+        const w = fundedWallet();
+        const utxos = utxosFor(w);
+        const target = [{ address: 'bc1qtmcfj7lvgjp866w8lytdpap82u7eege58jy52hp4ctk0hsncegyqel8prp', value: 10_000 }];
+        const change = w._getInternalAddressByIndex(0);
+
+        // Unfiltered: this is the pre-fix behaviour. coinselect sorts
+        // descending and reaches for the biggest coin.
+        const unfiltered = w.createTransaction(utxos, target, 1, change);
+        const unfilteredInputs = unfiltered.psbt.txInputs.map((i: any) =>
+            Buffer.from(i.hash).reverse().toString('hex'),
+        );
+        expect(unfilteredInputs).toContain(LARGE.txid);
+
+        // Filtered to the user's pick: only the small coin can be spent.
+        const picked = selectCapsules(utxos, [outpointKey(SMALL)]);
+        const filtered = w.createTransaction(picked, target, 1, change);
+        const filteredInputs = filtered.psbt.txInputs.map((i: any) =>
+            Buffer.from(i.hash).reverse().toString('hex'),
+        );
+        expect(filteredInputs).toEqual([SMALL.txid]);
+        expect(filteredInputs).not.toContain(LARGE.txid);
+    });
+});

--- a/tests/unit/coinosWithdrawGuard.test.ts
+++ b/tests/unit/coinosWithdrawGuard.test.ts
@@ -1,0 +1,154 @@
+/**
+ * CoinOS on-chain withdrawals must not be sendable twice.
+ *
+ * `POST /bitcoin/send` crosses the network, so a dropped connection leaves the
+ * outcome unknown: the request may have reached CoinOS. The withdraw screen
+ * treated every failure as "never sent", told the user "Please try again", and
+ * re-armed the button. Following that instruction sends the money again.
+ */
+
+import {
+    WITHDRAW_DUPLICATE_WINDOW_MS,
+    findRecentMatchingWithdrawal,
+    isCoinosWithdrawIndeterminate,
+    isNetworkShapedFailure,
+    markWithdrawIndeterminate,
+} from '../../src/services/coinos/withdrawGuard';
+
+const ADDR = 'bc1qdph4zqqkvf72nd6uz87q2c5hw9tzapfnkmq93c';
+const OTHER = 'bc1qtmcfj7lvgjp866w8lytdpap82u7eege58jy52hp4ctk0hsncegyqel8prp';
+const NOW = 1_700_000_000_000;
+
+const payment = (over: Record<string, unknown> = {}) => ({
+    amount: -10_000,
+    created: NOW - 60_000,
+    type: 'bitcoin',
+    onchain: { address: ADDR },
+    ...over,
+});
+
+const find = (payments: any[], over: Record<string, unknown> = {}) =>
+    findRecentMatchingWithdrawal(payments, {
+        address: ADDR,
+        amountSats: 10_000,
+        now: NOW,
+        ...over,
+    });
+
+describe('spotting a withdrawal that already went out', () => {
+    it('matches the same address and amount within the window', () => {
+        expect(find([payment()])).not.toBeNull();
+    });
+
+    it('compares amount by magnitude, since outgoing payments are negative', () => {
+        expect(find([payment({ amount: -10_000 })])).not.toBeNull();
+        expect(find([payment({ amount: 10_000 })])).not.toBeNull();
+    });
+
+    it('accepts a string amount', () => {
+        expect(find([payment({ amount: '-10000' })])).not.toBeNull();
+    });
+
+    it('reads the address from the flat field as well as the onchain object', () => {
+        expect(find([{ amount: -10_000, created: NOW - 1000, address: ADDR }])).not.toBeNull();
+    });
+
+    it('is case and whitespace insensitive on the address', () => {
+        expect(find([payment({ onchain: { address: `  ${ADDR.toUpperCase()} ` } })])).not.toBeNull();
+    });
+
+    it('handles a seconds-based timestamp', () => {
+        expect(find([payment({ created: Math.floor((NOW - 60_000) / 1000) })])).not.toBeNull();
+    });
+
+    it('handles an ISO timestamp', () => {
+        expect(find([payment({ created: new Date(NOW - 60_000).toISOString() })])).not.toBeNull();
+    });
+
+    it('matches when the timestamp is unusable, erring toward blocking', () => {
+        // A false positive costs a confirmation tap. A false negative costs the
+        // user the money.
+        expect(find([payment({ created: 'not a date' })])).not.toBeNull();
+        expect(find([payment({ created: null })])).not.toBeNull();
+    });
+});
+
+describe('what must NOT be treated as a duplicate', () => {
+    it('a payment to a different address', () => {
+        expect(find([payment({ onchain: { address: OTHER } })])).toBeNull();
+    });
+
+    it('a different amount to the same address', () => {
+        // Address alone would flag a legitimate second payment to the same
+        // destination.
+        expect(find([payment({ amount: -9_999 })])).toBeNull();
+    });
+
+    it('the same payment from outside the window', () => {
+        expect(find([payment({ created: NOW - WITHDRAW_DUPLICATE_WINDOW_MS - 1 })])).toBeNull();
+    });
+
+    it('an empty or missing history', () => {
+        expect(find([])).toBeNull();
+        expect(findRecentMatchingWithdrawal(null, { address: ADDR, amountSats: 1, now: NOW })).toBeNull();
+        expect(findRecentMatchingWithdrawal(undefined, { address: ADDR, amountSats: 1, now: NOW })).toBeNull();
+    });
+
+    it('records with no amount at all', () => {
+        expect(find([{ onchain: { address: ADDR }, created: NOW }])).toBeNull();
+    });
+
+    it('does not crash on malformed records', () => {
+        expect(() => find([null as any, {} as any, { onchain: null } as any, payment()])).not.toThrow();
+        expect(find([null as any, {} as any, payment()])).not.toBeNull();
+    });
+});
+
+describe('unknown outcomes are not failures', () => {
+    it.each([
+        'Network request failed',
+        'The request timed out',
+        'Aborted',
+        'socket hang up',
+        'ECONNRESET',
+        'Failed to fetch',
+    ])('treats %p as network-shaped, so the outcome is unknown', (msg) => {
+        expect(isNetworkShapedFailure(new Error(msg))).toBe(true);
+    });
+
+    it('does not treat a server rejection as unknown', () => {
+        // CoinOS answered, so nothing was sent. Retrying is safe here.
+        expect(isNetworkShapedFailure(new Error('Insufficient funds'))).toBe(false);
+        expect(isNetworkShapedFailure(new Error('invalid address'))).toBe(false);
+    });
+
+    it('flags an indeterminate error so callers can branch on a marker', () => {
+        const e = markWithdrawIndeterminate('may have been sent');
+        expect(isCoinosWithdrawIndeterminate(e)).toBe(true);
+    });
+
+    it.each([null, undefined, 'string', {}, new Error('ordinary')])(
+        'is not indeterminate for %p',
+        (v) => {
+            expect(isCoinosWithdrawIndeterminate(v)).toBe(false);
+        },
+    );
+
+    it('is not satisfied by a truthy-but-not-true marker', () => {
+        expect(isCoinosWithdrawIndeterminate({ coinosWithdrawIndeterminate: 'yes' })).toBe(false);
+    });
+});
+
+describe('the double-send scenario, end to end', () => {
+    it('the retry after a lost reply is caught by the history check', () => {
+        // First attempt: reply lost, so the app cannot know it succeeded.
+        const err = markWithdrawIndeterminate('unknown');
+        expect(isCoinosWithdrawIndeterminate(err)).toBe(true);
+
+        // CoinOS did send it, so it is in the history.
+        const history = [payment({ created: NOW - 5_000 })];
+
+        // The retry is blocked before any second request is made.
+        expect(find(history)).not.toBeNull();
+    });
+});

--- a/tests/unit/esploraProviders.test.ts
+++ b/tests/unit/esploraProviders.test.ts
@@ -1,0 +1,54 @@
+import {
+  ESPLORA_FALLBACK_URLS,
+  ESPLORA_OPEN_ATTEMPTS,
+  esploraOperator,
+} from '../../src/services/ark/esploraProviders';
+
+describe('esplora fallback list', () => {
+  it('has more than one real alternative', () => {
+    // The list held two entries on 2026-08-21. One was down all session and the
+    // other rate-limited the device, so there was nowhere to rotate to and the
+    // wallet could not open for hours. Two is not redundancy.
+    expect(ESPLORA_FALLBACK_URLS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('is fully reachable within the attempt budget', () => {
+    // The trap this module exists to make visible: a provider added past the
+    // attempt count is never tried, and nothing anywhere would have said so.
+    expect(ESPLORA_OPEN_ATTEMPTS).toBeGreaterThanOrEqual(ESPLORA_FALLBACK_URLS.length);
+  });
+
+  it('never places two providers from one operator back to back', () => {
+    // A single operator's outage must not be able to burn consecutive
+    // attempts. mempool.space's apex was down while its regional node was up,
+    // so the two must not sit next to each other.
+    const ops = ESPLORA_FALLBACK_URLS.map(esploraOperator);
+    for (let i = 1; i < ops.length; i++) {
+      expect(ops[i]).not.toBe(ops[i - 1]);
+    }
+  });
+
+  it('has no duplicates', () => {
+    expect(new Set(ESPLORA_FALLBACK_URLS).size).toBe(ESPLORA_FALLBACK_URLS.length);
+  });
+
+  it('is https only, with no trailing slash', () => {
+    for (const u of ESPLORA_FALLBACK_URLS) {
+      expect(u.startsWith('https://')).toBe(true);
+      expect(u.endsWith('/')).toBe(false);
+    }
+  });
+
+  it('keeps the previously configured primary first', () => {
+    // Changing the primary changes who sees every healthy wallet's addresses.
+    // That is a deliberate decision, not something to drift into by reordering.
+    expect(ESPLORA_FALLBACK_URLS[0]).toBe('https://blockstream.info/api');
+  });
+
+  it('reads the operator from the registrable domain', () => {
+    expect(esploraOperator('https://mempool.va1.mempool.space/api')).toBe('mempool.space');
+    expect(esploraOperator('https://mempool.space/api')).toBe('mempool.space');
+    expect(esploraOperator('https://blockstream.info/api')).toBe('blockstream.info');
+    expect(esploraOperator('https://mempool.emzy.de/api')).toBe('emzy.de');
+  });
+});

--- a/tests/unit/exitClaimBatch.test.ts
+++ b/tests/unit/exitClaimBatch.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The exit claim sweep must batch, and must not wait forever.
+ *
+ * drainExits([]) already sweeps every claimable capsule into one transaction,
+ * so the cost is per-claim, not per-capsule. Firing on the first ripe capsule
+ * pays a separate fee for each one. Observed on a live five-capsule exit: 225
+ * sats to move 877, four more queued behind it, on a fee wallet that had
+ * already fallen from 3654 to 699 sats.
+ *
+ * The opposing risk is a wedged capsule holding healthy ones hostage forever,
+ * which is why the wait is bounded.
+ */
+
+import { decideExitClaimBatch } from '../../src/services/ark/exitClaimBatch';
+
+const HOUR = 60 * 60 * 1000;
+const MAX_WAIT = 6 * HOUR;
+const T0 = 1_700_000_000_000;
+
+const decide = (over: Partial<Parameters<typeof decideExitClaimBatch>[0]> = {}) =>
+    decideExitClaimBatch({
+        claimableCount: 1,
+        stillProgressingCount: 0,
+        batchSince: null,
+        now: T0,
+        maxWaitMs: MAX_WAIT,
+        ...over,
+    });
+
+describe('nothing to claim', () => {
+    it('does not claim and clears the window', () => {
+        const d = decide({ claimableCount: 0, batchSince: T0 - HOUR });
+        expect(d.claim).toBe(false);
+        expect(d.batchSince).toBeNull();
+        expect(d.reason).toBe('nothing-claimable');
+    });
+
+    it('clears a stale window so the next batch starts fresh', () => {
+        // Otherwise a capsule ripening tomorrow would inherit today's elapsed
+        // time and skip batching entirely.
+        expect(decide({ claimableCount: 0, batchSince: T0 - 5 * HOUR }).batchSince).toBeNull();
+    });
+});
+
+describe('everything is ready', () => {
+    it('claims immediately when no capsule is still progressing', () => {
+        const d = decide({ claimableCount: 3, stillProgressingCount: 0 });
+        expect(d.claim).toBe(true);
+        expect(d.reason).toBe('all-ready');
+    });
+
+    it('claims a lone capsule when it is the whole exit', () => {
+        // A one-capsule exit must not sit through the window for company that
+        // is never coming.
+        const d = decide({ claimableCount: 1, stillProgressingCount: 0 });
+        expect(d.claim).toBe(true);
+    });
+});
+
+describe('stragglers still progressing', () => {
+    it('holds the claim and opens the window on first sight', () => {
+        const d = decide({ claimableCount: 1, stillProgressingCount: 4, batchSince: null });
+        expect(d.claim).toBe(false);
+        expect(d.reason).toBe('waiting');
+        expect(d.batchSince).toBe(T0);
+    });
+
+    it('keeps waiting inside the window', () => {
+        const d = decide({
+            claimableCount: 2,
+            stillProgressingCount: 1,
+            batchSince: T0 - 3 * HOUR,
+            now: T0,
+        });
+        expect(d.claim).toBe(false);
+        expect(d.batchSince).toBe(T0 - 3 * HOUR);
+    });
+
+    it('preserves the original window start rather than restarting the clock', () => {
+        // Restarting on each tick would make the bound unreachable and the
+        // straggler could stall the batch indefinitely.
+        const since = T0 - 5 * HOUR;
+        expect(decide({ stillProgressingCount: 2, batchSince: since }).batchSince).toBe(since);
+    });
+
+    it('gives up and claims once the window expires', () => {
+        const d = decide({
+            claimableCount: 1,
+            stillProgressingCount: 3,
+            batchSince: T0 - MAX_WAIT,
+            now: T0,
+        });
+        expect(d.claim).toBe(true);
+        expect(d.reason).toBe('window-expired');
+    });
+
+    it('claims at exactly the boundary, not a tick later', () => {
+        expect(decide({ stillProgressingCount: 1, batchSince: T0 - MAX_WAIT }).claim).toBe(true);
+        expect(decide({ stillProgressingCount: 1, batchSince: T0 - MAX_WAIT + 1 }).claim).toBe(false);
+    });
+
+    it('a wedged capsule cannot hold the others past the bound', () => {
+        // The whole point of the ceiling: one leaf stuck forever must not mean
+        // funds never sweep.
+        const d = decide({
+            claimableCount: 4,
+            stillProgressingCount: 1,
+            batchSince: T0 - 30 * HOUR,
+            now: T0,
+        });
+        expect(d.claim).toBe(true);
+    });
+});
+
+describe('the batch we actually lived through', () => {
+    it('would have held the first capsule instead of paying five fees', () => {
+        // Five-capsule exit, one ripe, four still working: the old code claimed
+        // straight away.
+        const d = decide({ claimableCount: 1, stillProgressingCount: 4, batchSince: null });
+        expect(d.claim).toBe(false);
+    });
+
+    it('sweeps all five together once the last one ripens', () => {
+        const d = decide({
+            claimableCount: 5,
+            stillProgressingCount: 0,
+            batchSince: T0 - 2 * HOUR,
+            now: T0,
+        });
+        expect(d.claim).toBe(true);
+        expect(d.reason).toBe('all-ready');
+    });
+});

--- a/tests/unit/exitClaimBatch.test.ts
+++ b/tests/unit/exitClaimBatch.test.ts
@@ -131,3 +131,161 @@ describe('the batch we actually lived through', () => {
         expect(d.reason).toBe('all-ready');
     });
 });
+
+// --- Height-aware batching -------------------------------------------------
+//
+// The three capsules still in flight on the 2026-08-17/20 mainnet exit reported
+// these ripening heights. The spread is what makes a wall-clock ceiling wrong.
+const H = [963101, 963142, 963145];
+
+describe('one exit, one UTXO: waiting on the schedule rather than a clock', () => {
+  it('holds past the wall-clock ceiling while the tip has not reached the last height', () => {
+    // 6h after the first capsule ripened the tip is ~36 blocks on, still 8
+    // short of 963145. The old rule fired here and split the exit in two.
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [963142, 963145],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(false);
+    expect(d.reason).toBe('waiting-for-schedule');
+    expect(d.blocksUntilAllReady).toBe(8);
+  });
+
+  it('sweeps once the tip reaches the last scheduled height', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 3,
+      stillProgressingCount: 0,
+      batchSince: T0,
+      now: T0 + 8 * 60 * 60 * 1000,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963145,
+      pendingClaimableHeights: [],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('all-ready');
+  });
+
+  it('reports blocks remaining so the wait can be shown honestly', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + 60_000,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: H[0],
+      pendingClaimableHeights: [H[1], H[2]],
+      unknownScheduleCount: 0,
+    });
+    expect(d.blocksUntilAllReady).toBe(44);
+  });
+
+  it('still bounds the wait when a straggler has no known ripening height', () => {
+    // Still Processing, so no leaf has confirmed and there is no schedule to
+    // wait on. This is the case the wall-clock ceiling is actually for.
+    const held = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + MAX_WAIT - 1,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [],
+      unknownScheduleCount: 1,
+    });
+    expect(held.claim).toBe(false);
+    expect(held.reason).toBe('waiting');
+
+    const expired = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [],
+      unknownScheduleCount: 1,
+    });
+    expect(expired.claim).toBe(true);
+    expect(expired.reason).toBe('window-expired');
+  });
+
+  it('does not wait on a schedule when one straggler of several is unscheduled', () => {
+    // A known height for two of three proves nothing about the third.
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 3,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [963142, 963145],
+      unknownScheduleCount: 1,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('window-expired');
+  });
+
+  it('falls back to the clock when the chain tip is unreadable', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: null,
+      pendingClaimableHeights: [963142, 963145],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('window-expired');
+  });
+
+  it('stops waiting on a schedule the tip has already passed', () => {
+    // Heights reached but bark still does not call them claimable: they need
+    // confirmations, or they are wedged. Bound it rather than hold forever.
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + MAX_WAIT,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963200,
+      pendingClaimableHeights: [963145],
+      unknownScheduleCount: 0,
+    });
+    expect(d.claim).toBe(true);
+    expect(d.reason).toBe('window-expired');
+  });
+
+  it('infers the unscheduled count when the caller does not pass one', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 2,
+      batchSince: T0,
+      now: T0 + 60_000,
+      maxWaitMs: MAX_WAIT,
+      tipHeight: 963137,
+      pendingClaimableHeights: [963142, 963145],
+    });
+    expect(d.reason).toBe('waiting-for-schedule');
+  });
+
+  it('keeps the old behaviour when no schedule is supplied at all', () => {
+    const d = decideExitClaimBatch({
+      claimableCount: 1,
+      stillProgressingCount: 1,
+      batchSince: T0,
+      now: T0 + 60_000,
+      maxWaitMs: MAX_WAIT,
+    });
+    expect(d.claim).toBe(false);
+    expect(d.reason).toBe('waiting');
+  });
+});

--- a/tests/unit/exitFundingCoinos.test.ts
+++ b/tests/unit/exitFundingCoinos.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Funding the exit-fee reserve from CoinOS.
+ *
+ * The two orderings under test are the ones that silently undo the whole point
+ * if they are wrong: the reserve must be armed BEFORE the send, or auto-board
+ * sweeps the sats back into Ark when they confirm, and the duplicate check must
+ * happen BEFORE the send, or a retry after a lost reply pays twice.
+ */
+
+import { fundExitFeesFromCoinos } from '../../src/services/ark/exitFundingCoinos';
+import { markWithdrawIndeterminate } from '../../src/services/coinos/withdrawGuard';
+
+const ADDR = 'bc1qdph4zqqkvf72nd6uz87q2c5hw9tzapfnkmq93c';
+const NOW = 1_700_000_000_000;
+
+function deps(over: Partial<Parameters<typeof fundExitFeesFromCoinos>[1]> = {}) {
+    const calls: string[] = [];
+    const base = {
+        calls,
+        getOnchainAddress: jest.fn(async () => {
+            calls.push('address');
+            return ADDR;
+        }),
+        getRecentPayments: jest.fn(async () => {
+            calls.push('history');
+            return { payments: [] };
+        }),
+        estimateFeeSats: jest.fn(async () => {
+            calls.push('fee');
+            return 300;
+        }),
+        send: jest.fn(async () => {
+            calls.push('send');
+            return JSON.stringify({ txid: 'abc123' });
+        }),
+        armReserve: jest.fn(() => {
+            calls.push('arm');
+        }),
+        now: () => NOW,
+    };
+    return { ...base, ...over } as any;
+}
+
+const req = (over: Record<string, unknown> = {}) => ({
+    shortfallSats: 14_504,
+    availableSats: 50_000,
+    idempotencyKey: 'cbx-test-key',
+    ...over,
+});
+
+describe('the happy path', () => {
+    it('sends the shortfall and reports the txid', async () => {
+        const d = deps();
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res).toMatchObject({ ok: true, txid: 'abc123', sentSats: 14_504, partial: false });
+    });
+
+    it('sends to Bark own on-chain address with the idempotency key', async () => {
+        const d = deps();
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.send).toHaveBeenCalledWith(ADDR, 14_504, 'cbx-test-key');
+    });
+});
+
+describe('ordering that must not change', () => {
+    it('arms the reserve BEFORE sending', async () => {
+        // Otherwise sync.ts boards the sats into Ark the moment they confirm,
+        // undoing the top-up the user just paid for.
+        const d = deps();
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.calls.indexOf('arm')).toBeLessThan(d.calls.indexOf('send'));
+    });
+
+    it('checks history BEFORE sending', async () => {
+        const d = deps();
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.calls.indexOf('history')).toBeLessThan(d.calls.indexOf('send'));
+    });
+
+    it('never lowers a reserve the user already set higher', async () => {
+        const d = deps();
+        await fundExitFeesFromCoinos(req({ currentReserveSats: 100_000 }), d);
+        const armed = d.armReserve.mock.calls[0][0];
+        expect(armed).toBeGreaterThanOrEqual(100_000);
+    });
+});
+
+describe('duplicate protection', () => {
+    it('refuses when a matching top-up already went out', async () => {
+        const d = deps({
+            getRecentPayments: async () => ({
+                payments: [{ amount: -14_504, created: NOW - 5_000, onchain: { address: ADDR } }],
+            }),
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res).toMatchObject({ ok: false, duplicate: true });
+        expect(d.send).not.toHaveBeenCalled();
+    });
+
+    it('still sends when history cannot be read', async () => {
+        // Not being able to read history is not evidence of a duplicate, and
+        // refusing there would strand a user mid-exit.
+        const d = deps({
+            getRecentPayments: async () => {
+                throw new Error('Network request failed');
+            },
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(true);
+        expect(d.send).toHaveBeenCalled();
+    });
+});
+
+describe('failures', () => {
+    it('surfaces an unknown outcome without claiming failure', async () => {
+        const d = deps({
+            send: async () => {
+                throw markWithdrawIndeterminate('may already have been sent');
+            },
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res).toMatchObject({ ok: false, indeterminate: true });
+    });
+
+    it('leaves the reserve armed after an unknown outcome', async () => {
+        // If the send DID go through, the sats must not be boarded away when
+        // they land. Disarming here would be the worst possible response.
+        const d = deps({
+            send: async () => {
+                throw markWithdrawIndeterminate('unknown');
+            },
+        });
+        await fundExitFeesFromCoinos(req(), d);
+        expect(d.armReserve).toHaveBeenCalled();
+    });
+
+    it('reports a plain server refusal as itself', async () => {
+        const d = deps({ send: async () => 'insufficient funds' });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(false);
+        // Must NOT be flagged indeterminate: the server answered, so nothing
+        // was sent and retrying is safe.
+        expect(res.ok === false && res.indeterminate).toBeFalsy();
+        expect(res.ok === false && res.reason).toMatch(/insufficient funds/i);
+    });
+
+    it('refuses when the balance cannot cover the fee', async () => {
+        const d = deps({ estimateFeeSats: async () => 900 });
+        const res = await fundExitFeesFromCoinos(req({ availableSats: 1_100 }), d);
+        expect(res.ok).toBe(false);
+        expect(d.send).not.toHaveBeenCalled();
+    });
+
+    it('does not send when there is no address', async () => {
+        const d = deps({ getOnchainAddress: async () => '' });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(false);
+        expect(d.send).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with fee 0 when the estimate fails', async () => {
+        // A missing estimate must not block funding; CoinOS charges what it
+        // charges either way.
+        const d = deps({
+            estimateFeeSats: async () => {
+                throw new Error('estimate unavailable');
+            },
+        });
+        const res = await fundExitFeesFromCoinos(req(), d);
+        expect(res.ok).toBe(true);
+    });
+});
+
+describe('partial funding', () => {
+    it('sends what fits and flags it as partial', async () => {
+        const d = deps();
+        const res = await fundExitFeesFromCoinos(req({ availableSats: 5_000 }), d);
+        expect(res).toMatchObject({ ok: true, partial: true, sentSats: 4_700 });
+    });
+});

--- a/tests/unit/exitFundingPlan.test.ts
+++ b/tests/unit/exitFundingPlan.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Sizing a top-up of the exit-fee reserve.
+ *
+ * Wrong in either direction is expensive: too little leaves the exit stalled
+ * after the user believes they fixed it, too much strips a wallet they still
+ * need. The subtlety is that the miner fee comes off the top, so a wallet
+ * holding exactly the shortfall cannot deliver the shortfall.
+ */
+
+import { planExitFunding } from '../../src/services/ark/exitFundingPlan';
+import { MIN_USEFUL_FUNDING_SATS } from '../../src/services/ark/exitFundingSources';
+
+const plan = (over: Partial<Parameters<typeof planExitFunding>[0]> = {}) =>
+    planExitFunding({ shortfallSats: 14_504, availableSats: 50_000, feeSats: 300, ...over });
+
+describe('the ordinary case', () => {
+    it('sends exactly the shortfall when the source can cover it', () => {
+        const p = plan();
+        expect(p).toMatchObject({ ok: true, sendSats: 14_504, partial: false });
+    });
+
+    it('reports the total leaving the wallet, fee included', () => {
+        // What lands and what leaves are different numbers, and the confirm
+        // screen has to show both or the user is surprised by the difference.
+        const p = plan();
+        expect(p.ok && p.totalCostSats).toBe(14_804);
+    });
+});
+
+describe('the fee comes off the top', () => {
+    it('cannot deliver the shortfall from a wallet holding exactly it', () => {
+        // The trap. 14,504 available against a 14,504 shortfall lands only
+        // 14,204 once the fee is paid.
+        const p = plan({ availableSats: 14_504, feeSats: 300 });
+        expect(p).toMatchObject({ ok: true, partial: true });
+        expect(p.ok && p.sendSats).toBe(14_204);
+    });
+
+    it('spends the whole balance on a partial top-up', () => {
+        const p = plan({ availableSats: 5_000, feeSats: 300 });
+        expect(p.ok && p.sendSats).toBe(4_700);
+        expect(p.ok && p.totalCostSats).toBe(5_000);
+    });
+
+    it('covers the shortfall exactly when the balance leaves room for the fee', () => {
+        const p = plan({ availableSats: 14_804, feeSats: 300 });
+        expect(p).toMatchObject({ ok: true, sendSats: 14_504, partial: false });
+    });
+});
+
+describe('refusing to send', () => {
+    it('will not send when the fee eats almost everything', () => {
+        const p = plan({ availableSats: 1_200, feeSats: 300 });
+        expect(p.ok).toBe(false);
+    });
+
+    it('names the fee rather than claiming an insufficient balance', () => {
+        // "Insufficient balance" reads as a lie to someone looking at a balance
+        // bigger than the amount they typed.
+        const p = plan({ availableSats: 1_100, feeSats: 900 });
+        expect(p.ok === false && p.reason).toMatch(/900/);
+        expect(p.ok === false && p.reason).toMatch(/network fee/i);
+    });
+
+    it('refuses when the reserve is already funded', () => {
+        const p = plan({ shortfallSats: 0 });
+        expect(p.ok).toBe(false);
+        expect(p.ok === false && p.reason).toMatch(/already funded/i);
+    });
+
+    it('refuses at one sat under the useful floor', () => {
+        const p = plan({ availableSats: MIN_USEFUL_FUNDING_SATS - 1, feeSats: 0 });
+        expect(p.ok).toBe(false);
+    });
+
+    it('accepts exactly at the floor', () => {
+        const p = plan({ availableSats: MIN_USEFUL_FUNDING_SATS, feeSats: 0, shortfallSats: 99_999 });
+        expect(p.ok).toBe(true);
+    });
+});
+
+describe('an unreadable balance', () => {
+    it('plans the full shortfall rather than refusing', () => {
+        // A balance that failed to load is not a balance of zero. Refusing here
+        // would strand a user whose network hiccuped on the balance call; the
+        // provider will reject the send if the funds really are not there.
+        const p = plan({ availableSats: null });
+        expect(p).toMatchObject({ ok: true, sendSats: 14_504, partial: false });
+    });
+});
+
+describe('junk input', () => {
+    it('does not produce a negative or fractional send', () => {
+        const p = plan({ availableSats: 20_000.7, feeSats: 12.9, shortfallSats: 10_000.4 });
+        expect(p.ok && Number.isInteger(p.sendSats)).toBe(true);
+        expect(p.ok && p.sendSats).toBeGreaterThan(0);
+    });
+
+    it('treats a negative balance as empty', () => {
+        expect(plan({ availableSats: -500 }).ok).toBe(false);
+    });
+
+    it('tolerates a NaN fee', () => {
+        const p = plan({ feeSats: Number.NaN });
+        expect(p.ok).toBe(true);
+    });
+});

--- a/tests/unit/exitFundingSources.test.ts
+++ b/tests/unit/exitFundingSources.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The "fund exit fees from another wallet" source list.
+ *
+ * Two rules carry most of the value here and neither is obvious from the UI:
+ * unavailable sources are still listed with a reason rather than hidden, and
+ * Cold Vault is always last because it needs a hardware signing round-trip.
+ */
+
+import {
+    MIN_USEFUL_FUNDING_SATS,
+    buildExitFundingSources,
+    hasUsableExitFundingSource,
+} from '../../src/services/ark/exitFundingSources';
+
+const connected = (balanceSats: number) => ({ connected: true, balanceSats });
+const vaultWith = (balanceSats: number) => ({ walletID: 'w'.repeat(64), balanceSats });
+
+const ALL_READY = {
+    coinos: connected(50_000),
+    strike: connected(50_000),
+    hotVault: vaultWith(50_000),
+    coldVault: vaultWith(50_000),
+};
+
+describe('ordering', () => {
+    it('puts custodial wallets first and Cold Vault last', () => {
+        // Cold Vault needs a PSBT round-trip through an airgapped signer, so it
+        // must never sit next to Hot Vault as an equal-looking choice.
+        expect(buildExitFundingSources(ALL_READY).map((s) => s.id)).toEqual([
+            'coinos',
+            'strike',
+            'hot-vault',
+            'cold-vault',
+        ]);
+    });
+
+    it('keeps Cold Vault last even when it is the only funded source', () => {
+        const ids = buildExitFundingSources({ coldVault: vaultWith(50_000) }).map((s) => s.id);
+        expect(ids[ids.length - 1]).toBe('cold-vault');
+    });
+
+    it('flags Cold Vault as slow and nothing else', () => {
+        const sources = buildExitFundingSources(ALL_READY);
+        expect(sources.find((s) => s.id === 'cold-vault')?.slow).toBe(true);
+        expect(sources.filter((s) => s.slow).map((s) => s.id)).toEqual(['cold-vault']);
+    });
+});
+
+describe('every source is listed, even when unusable', () => {
+    it('returns all four with an empty state', () => {
+        // Hiding them makes the feature look broken. Showing them with a reason
+        // teaches the user what to fix.
+        const sources = buildExitFundingSources();
+        expect(sources).toHaveLength(4);
+        expect(sources.every((s) => !s.available)).toBe(true);
+    });
+
+    it('says why a custodial wallet cannot be used', () => {
+        const s = buildExitFundingSources({ coinos: { connected: false } });
+        expect(s.find((x) => x.id === 'coinos')?.unavailableReason).toMatch(/not connected/i);
+    });
+
+    it('says why a vault cannot be used', () => {
+        const s = buildExitFundingSources({ hotVault: { walletID: null } });
+        expect(s.find((x) => x.id === 'hot-vault')?.unavailableReason).toMatch(/no vault/i);
+    });
+
+    it('names the floor rather than saying "insufficient"', () => {
+        // "Insufficient balance" leaves the user guessing how much is enough.
+        const s = buildExitFundingSources({ coinos: connected(MIN_USEFUL_FUNDING_SATS - 1) });
+        expect(s.find((x) => x.id === 'coinos')?.unavailableReason).toContain(
+            MIN_USEFUL_FUNDING_SATS.toLocaleString(),
+        );
+    });
+
+    it('marks a drained vault as having no spendable capsules', () => {
+        const s = buildExitFundingSources({ hotVault: vaultWith(0) });
+        const hot = s.find((x) => x.id === 'hot-vault');
+        expect(hot?.available).toBe(false);
+        expect(hot?.unavailableReason).toMatch(/no spendable capsules/i);
+    });
+});
+
+describe('availability', () => {
+    it('accepts a connected wallet at exactly the floor', () => {
+        const s = buildExitFundingSources({ coinos: connected(MIN_USEFUL_FUNDING_SATS) });
+        expect(s.find((x) => x.id === 'coinos')?.available).toBe(true);
+    });
+
+    it('offers a source that cannot cover the whole shortfall', () => {
+        // Partial funding is still progress: it may be the difference between a
+        // stalled exit and a finished one.
+        const s = buildExitFundingSources({
+            coinos: connected(5_000),
+            shortfallSats: 14_504,
+        });
+        expect(s.find((x) => x.id === 'coinos')?.available).toBe(true);
+    });
+
+    it('treats an unknown balance as usable rather than blocking', () => {
+        // A balance we could not read is not the same as a balance of zero, and
+        // refusing on a failed read would strand the user.
+        const s = buildExitFundingSources({ strike: { connected: true, balanceSats: null } });
+        expect(s.find((x) => x.id === 'strike')?.available).toBe(true);
+    });
+
+    it('ignores a nonsense balance instead of crashing', () => {
+        const s = buildExitFundingSources({
+            coinos: { connected: true, balanceSats: Number.NaN },
+            hotVault: { walletID: 'x'.repeat(64), balanceSats: -5 },
+        });
+        expect(s.find((x) => x.id === 'coinos')?.available).toBe(true);
+        expect(s.find((x) => x.id === 'hot-vault')?.available).toBe(true);
+    });
+
+    it('reports balances for the ones it could read', () => {
+        const s = buildExitFundingSources({ coinos: connected(42_000) });
+        expect(s.find((x) => x.id === 'coinos')?.balanceSats).toBe(42_000);
+    });
+});
+
+describe('hasUsableExitFundingSource', () => {
+    it('is false when nothing is connected, so the caller can fall back', () => {
+        // The caller shows the receive-an-address path instead, which is the
+        // one that always works.
+        expect(hasUsableExitFundingSource(buildExitFundingSources())).toBe(false);
+    });
+
+    it('is true when any single source works', () => {
+        expect(
+            hasUsableExitFundingSource(buildExitFundingSources({ strike: connected(20_000) })),
+        ).toBe(true);
+    });
+});

--- a/tests/unit/exitReserveTarget.test.ts
+++ b/tests/unit/exitReserveTarget.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Which reserve figure the exit-fee gate measures against.
+ *
+ * The bug this pins was found on device, not in review: an armed reserve of
+ * 3,654 sats against a live recommendation of 233,120 made the gate report the
+ * reserve fully funded and the shortfall 0, on the same screen that displayed
+ * the 233,120. The user was 227k short of the app's own estimate and was told
+ * they were ready to exit.
+ */
+import { resolveExitReserveTarget } from '../../src/services/ark/exitReserveTarget';
+
+describe('resolveExitReserveTarget', () => {
+    it('is 0 when neither figure is known, so callers do not gate yet', () => {
+        expect(resolveExitReserveTarget({ armedSats: null, recommendedSats: null })).toBe(0);
+        expect(resolveExitReserveTarget({ armedSats: undefined, recommendedSats: undefined })).toBe(0);
+    });
+
+    it('uses the recommendation when nothing is armed', () => {
+        expect(resolveExitReserveTarget({ armedSats: 0, recommendedSats: 233_120 })).toBe(233_120);
+    });
+
+    it('uses the armed value while the recommendation is still computing', () => {
+        expect(resolveExitReserveTarget({ armedSats: 3_654, recommendedSats: null })).toBe(3_654);
+    });
+
+    it('THE BUG: a stale armed value can no longer claim the exit is funded', () => {
+        // Exact figures read off the device on 2026-08-20.
+        const target = resolveExitReserveTarget({ armedSats: 3_654, recommendedSats: 233_120 });
+        expect(target).toBe(233_120);
+        const onchain = 6_259;
+        expect(Math.max(0, target - onchain)).toBe(226_861);
+        // The old rule was `armed > 0 ? armed : recommended`, which gave 3_654
+        // and therefore a shortfall of 0 against the same 6,259 on-chain.
+        expect(target).not.toBe(3_654);
+    });
+
+    it('honours an armed value ABOVE the recommendation, since that is a deliberate buffer', () => {
+        expect(resolveExitReserveTarget({ armedSats: 300_000, recommendedSats: 233_120 })).toBe(300_000);
+    });
+
+    it('never returns a negative or fractional target', () => {
+        expect(resolveExitReserveTarget({ armedSats: -50, recommendedSats: -10 })).toBe(0);
+        expect(resolveExitReserveTarget({ armedSats: 10.9, recommendedSats: 0 })).toBe(10);
+    });
+
+    it('is stable as the recommendation grows, which is how the wallet actually moves', () => {
+        // Depth drives the reserve and rises as capsules are spent through
+        // arkoor hops, so the recommendation climbs over a wallet's life.
+        const armed = 3_654;
+        const climbing = [3_654, 12_000, 60_000, 233_120];
+        const targets = climbing.map((r) => resolveExitReserveTarget({ armedSats: armed, recommendedSats: r }));
+        expect(targets).toEqual([3_654, 12_000, 60_000, 233_120]);
+    });
+});

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,6 +1,7 @@
 import {
   ASSUMED_EXIT_DELTA_BLOCKS,
   EXIT_FEE_FALLBACK_RATES,
+  MIN_FRESHNESS_BLOCKS,
   claimRateFromExitRate,
   exitFeeUrgency,
   normaliseExitFeeRates,
@@ -286,6 +287,9 @@ describe('temporal axis', () => {
   it('scales the confirmation budget with tree depth', () => {
     // Same expiry, same value; only the depth differs.
     const runway = TIP + 160;
+    // recover-everything to get past the 4-day freshness floor: what is under
+    // test here is the runway, and a capsule this close to expiry only reaches
+    // the exit set when the user has explicitly forced it.
     const r = triageArkExit({
       vtxos: [
         v({ id: 'shallow', sats: 20_000, exitDepth: 2, expiryHeight: runway }),
@@ -294,6 +298,7 @@ describe('temporal axis', () => {
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
     });
     expect(requiredRunwayBlocks(2, EXIT_DELTA)).toBe(156);
     expect(requiredRunwayBlocks(3, EXIT_DELTA)).toBe(162);
@@ -308,12 +313,14 @@ describe('temporal axis', () => {
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+     economicPolicy: 'recover-everything',
     });
     const uncached = triageArkExit({
       vtxos: [near],
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: null,
+     economicPolicy: 'recover-everything',
     });
     expect(cached.selectedIds).toEqual(['near']);
     expect(cached.usedAssumedExitDelta).toBe(false);
@@ -646,6 +653,7 @@ describe('exit-tree pricing: how much of a hurry the tree is actually in', () =>
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
     });
     expect(r.selectedIds).toEqual(['x']);
     expect(exitFeeUrgency(r.selected).urgency).toBe(band);
@@ -676,6 +684,7 @@ describe('exit-tree pricing: how much of a hurry the tree is actually in', () =>
       feeRateSatPerVb: 1,
       chainTipHeight: TIP,
       vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
     });
     expect(r.selectedIds).toHaveLength(2);
     expect(exitFeeUrgency(r.selected).urgency).toBe('soon');
@@ -790,5 +799,163 @@ describe('fee sources: what happens when the market cannot be read', () => {
       vtxoExitDeltaBlocks: EXIT_DELTA,
     });
     expect(exitFeeUrgency(urgentSet.selected).urgency).toBe('urgent');
+  });
+});
+
+describe('freshness floor: refresh a stale capsule, do not exit it', () => {
+  const fresh = (id: string, daysLeft: number, over: Partial<ExitTriageVtxo> = {}) =>
+    v({ id, sats: 20_000, expiryHeight: TIP + Math.round(daysLeft * 144), ...over });
+
+  it('excludes a capsule with under 4 days left even though it is safe to exit', () => {
+    // 3 days clears the runway easily (156 blocks for depth 2), so the temporal
+    // axis is happy. This is an economic call, not a safety one.
+    const r = triageArkExit({
+      vtxos: [fresh('stale', 3)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('refresh-before-exiting');
+    expect(r.excluded[0].blocksUntilExpiry).toBeGreaterThan(r.excluded[0].requiredRunwayBlocks);
+  });
+
+  it.each([
+    [0.5, false],
+    [3, false],
+    [3.9, false],
+    [4, true],
+    [10, true],
+    [27, true],
+  ])('%s days left -> exited=%s', (days, kept) => {
+    const r = triageArkExit({
+      vtxos: [fresh('c', days as number)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds.length === 1).toBe(kept);
+  });
+
+  it('applies to every capsule kind, not just arkoor', () => {
+    // Freshness decides, not provenance. A stale round output is just as deep
+    // and just as expensive as a stale arkoor one.
+    const r = triageArkExit({
+      vtxos: [
+        fresh('stale-registered', 2, { registered: true }),
+        fresh('stale-unregistered', 2, { registered: false }),
+        fresh('healthy', 20),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['healthy']);
+    expect(r.excluded.map((e) => e.reason)).toEqual([
+      'refresh-before-exiting',
+      'refresh-before-exiting',
+    ]);
+  });
+
+  it('still hard-excludes a capsule inside its runway, which is a different fault', () => {
+    // Under 4 days AND inside the runway. The safety exclusion has to win, or
+    // the override would let a user take a capsule the server can sweep
+    // out from under the exit.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'doomed', sats: 20_000, expiryHeight: TIP + 40 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('too-close-to-expiry');
+  });
+
+  it('lets a user with no server left take them anyway', () => {
+    // Refreshing needs the ASP. A user reaching for a unilateral exit may have
+    // no ASP to reach, so this default must not become a law.
+    const r = triageArkExit({
+      vtxos: [fresh('stale', 3)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual(['stale']);
+  });
+
+  it('offers the override when freshness is the only thing holding a capsule back', () => {
+    const r = triageArkExit({
+      vtxos: [fresh('stale', 3), fresh('healthy', 20)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['healthy']);
+    expect(r.overridableCount).toBe(1);
+    expect(r.overridableSats).toBe(20_000);
+  });
+
+  it('does not fire when the chain tip is unreadable', () => {
+    // No tip means no idea how fresh anything is. Guessing "stale" would
+    // abandon a healthy wallet on a failed network read.
+    const r = triageArkExit({
+      vtxos: [fresh('c', 3)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: null,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['c']);
+    expect(r.selected[0].notes).toContain('expiry-unknown');
+  });
+
+  it('leaves tonight\'s live wallet untouched', () => {
+    // All seven sit ~27 days out, so the floor is inert here. Recorded so a
+    // future change to the threshold shows up against real capsules.
+    const r = triage();
+    expect(r.selectedIds).toHaveLength(6);
+    // The two 400s ARE under 4 days, but they are reported as uneconomic,
+    // which is the reason a user can act on: below the per-input round
+    // minimum, they cannot be refreshed alone anyway.
+    expect(r.excluded.map((e) => e.reason)).toEqual([
+      'reserve-dwarfs-value',
+      'reserve-dwarfs-value',
+    ]);
+  });
+});
+
+describe('how the freshness floor and the fee bands interact', () => {
+  it('makes the urgent bands unreachable by default, which is coherent', () => {
+    // Not a coincidence worth leaving undocumented. The floor keeps anything
+    // under 576 blocks out of the exit set, and the runway is ~156, so a
+    // selected capsule always has 420+ blocks of slack and can never read
+    // 'soon' or 'urgent'. Exit only fresh capsules, and fresh capsules are
+    // never in a hurry, so the exit never bids for speed.
+    const justFresh = v({ id: 'edge', sats: 200_000, expiryHeight: TIP + MIN_FRESHNESS_BLOCKS });
+    const r = triageArkExit({
+      vtxos: [justFresh],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['edge']);
+    const u = exitFeeUrgency(r.selected);
+    expect(u.tightestSlackBlocks).toBe(MIN_FRESHNESS_BLOCKS - 156);
+    expect(['relaxed', 'moderate']).toContain(u.urgency);
+  });
+
+  it('still bids urgently when the user forces a stale capsule in', () => {
+    // Which is exactly when bidding high is right: the capsule the user
+    // overrode the floor for is the one actually racing its expiry.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'forced', sats: 200_000, expiryHeight: TIP + 200 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual(['forced']);
+    expect(exitFeeUrgency(r.selected).urgency).toBe('urgent');
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,12 +1,15 @@
 import {
   ASSUMED_EXIT_DELTA_BLOCKS,
   claimRateFromExitRate,
+  exitFeeUrgency,
+  URGENCY_SOON_BLOCKS,
   ExitTriageVtxo,
   RESERVE_FLOOR_SATS,
   perVtxoExitVb,
   requiredRunwayBlocks,
   reserveSatsForExitVb,
   triageArkExit,
+  urgencyFromSlackBlocks,
 } from '../../src/services/ark/exitTriage';
 
 // Every capsule below is a real one, read off the QA wallet on 2026-08-20.
@@ -594,5 +597,103 @@ describe('economic policy: how far past the economics the user may go', () => {
     // 84,504 sats of reserve to recover 2,330. The user has to see that.
     expect(forced.netRecoverableSats).toBe(2330);
     expect(forced.netLossSats).toBe(82174);
+  });
+});
+
+describe('exit-tree pricing: how much of a hurry the tree is actually in', () => {
+  it('reads the live wallet as relaxed, not urgent', () => {
+    // The mistake this replaces: the app priced these at a fastestFee of 7 when
+    // the exit set sat ~3,800 blocks clear of the runway it needed, about 26
+    // days. That is a 3.5x over-demand for urgency that did not exist.
+    const u = exitFeeUrgency(triage().selected);
+    expect(u.urgency).toBe('relaxed');
+    // Tightest of the six selected is a depth-3 at 967241: 4007 - 162 = 3845.
+    expect(u.tightestSlackBlocks).toBe(3845);
+    expect(u.deadlineHeight).toBe(967241 - 162);
+    expect(u.consideredCount).toBe(6);
+  });
+
+  it('does not let capsules the exit is abandoning decide what it pays', () => {
+    // This is why urgency reads the SELECTED set and not the candidates. The
+    // two 400s are 22 and 34 blocks off their runway, so pricing the candidate
+    // list called the whole exit urgent on behalf of two capsules that were
+    // never going to be exited.
+    const plan = triage();
+    const dust = plan.excluded.map((e) => e.blocksUntilExpiry! - e.requiredRunwayBlocks);
+    expect(Math.min(...dust)).toBeLessThan(URGENCY_SOON_BLOCKS);
+    expect(exitFeeUrgency([...plan.selected, ...plan.excluded]).urgency).toBe('urgent');
+    expect(exitFeeUrgency(plan.selected).urgency).toBe('relaxed');
+  });
+
+  it.each([
+    [5000, 'relaxed'],
+    [1008, 'relaxed'],
+    [1007, 'moderate'],
+    [288, 'moderate'],
+    [287, 'soon'],
+    [144, 'soon'],
+    [143, 'urgent'],
+    [1, 'urgent'],
+  ])('%s blocks of slack is %s', (slack, band) => {
+    expect(urgencyFromSlackBlocks(slack as number)).toBe(band);
+    // And end to end, through a real triage at a rate that keeps it selected.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'x', sats: 200_000, expiryHeight: TIP + 156 + (slack as number) })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['x']);
+    expect(exitFeeUrgency(r.selected).urgency).toBe(band);
+  });
+
+  it('bids as if urgent when the chain tip is unreadable', () => {
+    // Over-reserving parks sats the user still owns. Under-reserving stalls the
+    // exit and can cost the capsule. Unknown resolves toward paying more.
+    const u = exitFeeUrgency(triage({ chainTipHeight: null }).selected);
+    expect(u.urgency).toBe('urgent');
+    expect(u.tightestSlackBlocks).toBeNull();
+    expect(u.deadlineHeight).toBeNull();
+    expect(urgencyFromSlackBlocks(null)).toBe('urgent');
+  });
+
+  it('bids as if urgent when nothing was selected', () => {
+    expect(exitFeeUrgency([]).urgency).toBe('urgent');
+    expect(exitFeeUrgency(triage({ economicPolicy: 'profitable-only' }).selected).urgency)
+      .toBe('urgent');
+  });
+
+  it('prices off the tightest member, not the average', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'roomy', sats: 200_000, expiryHeight: TIP + 9000 }),
+        v({ id: 'tight', sats: 200_000, expiryHeight: TIP + 156 + 200 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toHaveLength(2);
+    expect(exitFeeUrgency(r.selected).urgency).toBe('soon');
+  });
+
+  it('climbs the bands on its own as an exit runs and the runway shrinks', () => {
+    // The drive re-derives from the persisted deadline against the live tip, so
+    // a capsule drifting toward expiry starts bidding harder with nobody
+    // recomputing a plan.
+    const deadline = TIP + 1200;
+    expect(urgencyFromSlackBlocks(deadline - TIP)).toBe('relaxed');
+    expect(urgencyFromSlackBlocks(deadline - (TIP + 300))).toBe('moderate');
+    expect(urgencyFromSlackBlocks(deadline - (TIP + 1000))).toBe('soon');
+    expect(urgencyFromSlackBlocks(deadline - (TIP + 1100))).toBe('urgent');
+  });
+
+  it('gives the drive a deadline that stays fixed as the chain advances', () => {
+    const u = exitFeeUrgency(triage().selected);
+    // Persisting the deadline rather than the band is what keeps it honest over
+    // a multi-day exit: slack recomputed against a later tip is smaller.
+    expect(u.deadlineHeight! - TIP).toBe(u.tightestSlackBlocks);
+    expect(u.deadlineHeight! - (TIP + 3000)).toBe(845);
+    expect(urgencyFromSlackBlocks(u.deadlineHeight! - (TIP + 3000))).toBe('moderate');
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,7 +1,11 @@
 import {
   ASSUMED_EXIT_DELTA_BLOCKS,
+  EXIT_FEE_FALLBACK_RATES,
   claimRateFromExitRate,
   exitFeeUrgency,
+  normaliseExitFeeRates,
+  ratesFromEsploraEstimates,
+  ratesFromMempoolRecommended,
   URGENCY_SOON_BLOCKS,
   ExitTriageVtxo,
   RESERVE_FLOOR_SATS,
@@ -695,5 +699,96 @@ describe('exit-tree pricing: how much of a hurry the tree is actually in', () =>
     expect(u.deadlineHeight! - TIP).toBe(u.tightestSlackBlocks);
     expect(u.deadlineHeight! - (TIP + 3000)).toBe(845);
     expect(urgencyFromSlackBlocks(u.deadlineHeight! - (TIP + 3000))).toBe('moderate');
+  });
+});
+
+describe('fee sources: what happens when the market cannot be read', () => {
+  it('maps mempool.space named tiers onto the bands', () => {
+    const r = ratesFromMempoolRecommended({
+      fastestFee: 7, halfHourFee: 6, hourFee: 5, economyFee: 2, minimumFee: 1,
+    })!;
+    expect(r).toEqual({ relaxed: 2, moderate: 5, soon: 6, urgent: 7 });
+  });
+
+  it('maps an esplora fee-estimates map onto the bands', () => {
+    // Real shape, read off blockstream 2026-08-20.
+    const r = ratesFromEsploraEstimates({
+      '1': 5.2, '2': 4.586, '3': 4.3, '4': 4.178, '6': 3.9, '8': 3.285,
+      '10': 1.069, '15': 1.003, '144': 1.001, '504': 1.0,
+    })!;
+    // relaxed asks for target 144, urgent for target 1.
+    expect(r.relaxed).toBe(2);
+    expect(r.urgent).toBe(6);
+    expect(r.relaxed).toBeLessThanOrEqual(r.urgent);
+  });
+
+  it('rounds a missing esplora target DOWN, which rounds the fee up', () => {
+    // Longer targets are cheaper, so falling back to a shorter one is the safe
+    // direction when the exact target is absent.
+    const r = ratesFromEsploraEstimates({ '1': 20, '6': 9, '25': 3 })!;
+    // relaxed wants 144, the longest available is 25.
+    expect(r.relaxed).toBe(3);
+    expect(r.moderate).toBe(9);
+    expect(r.urgent).toBe(20);
+  });
+
+  it('never lets a cheaper band cost more than a dearer one', () => {
+    // An inverted table would have a RELAXED exit outbidding an urgent one,
+    // which is the exact failure this path exists to prevent.
+    const r = normaliseExitFeeRates({ relaxed: 50, moderate: 4, soon: 3, urgent: 2 })!;
+    expect(r).toEqual({ relaxed: 2, moderate: 2, soon: 2, urgent: 2 });
+    expect(r.relaxed).toBeLessThanOrEqual(r.moderate);
+    expect(r.moderate).toBeLessThanOrEqual(r.soon);
+    expect(r.soon).toBeLessThanOrEqual(r.urgent);
+  });
+
+  it('fills a missing band from the dearer neighbour, not the cheaper one', () => {
+    const r = normaliseExitFeeRates({ relaxed: 2, urgent: 9 })!;
+    expect(r).toEqual({ relaxed: 2, moderate: 9, soon: 9, urgent: 9 });
+  });
+
+  it('rejects unusable shapes rather than inventing a table', () => {
+    expect(ratesFromMempoolRecommended(null)).toBeNull();
+    expect(ratesFromMempoolRecommended({})).toBeNull();
+    expect(ratesFromEsploraEstimates(null)).toBeNull();
+    expect(ratesFromEsploraEstimates({})).toBeNull();
+    expect(ratesFromEsploraEstimates({ '1': 0, '6': -3 })).toBeNull();
+    expect(normaliseExitFeeRates({})).toBeNull();
+  });
+
+  it('keeps urgency meaningful when every fee source is unreachable', () => {
+    // The defect this replaces: a single flat congestion hedge for every band,
+    // which quietly undid the runway pricing at exactly the moment it could not
+    // be checked. Observed live with mempool.space down, a wallet with 26 days
+    // of runway was priced at 10 sat/vB.
+    const f = EXIT_FEE_FALLBACK_RATES;
+    expect(f.relaxed).toBeLessThan(f.urgent);
+    expect(f.relaxed).toBeLessThanOrEqual(f.moderate);
+    expect(f.moderate).toBeLessThanOrEqual(f.soon);
+    expect(f.soon).toBeLessThanOrEqual(f.urgent);
+
+    // 6,036 vB of exit set, the live wallet forced through.
+    const flat = reserveSatsForExitVb(6036, f.urgent);
+    const banded = reserveSatsForExitVb(6036, f.relaxed);
+    expect(flat).toBe(120_720);
+    expect(banded).toBe(24_144);
+  });
+
+  it('prices a relaxed wallet cheaply even blind, and an urgent one dearly', () => {
+    const relaxedSet = triageArkExit({
+      vtxos: [v({ id: 'roomy', sats: 200_000, expiryHeight: TIP + 9000 })],
+      feeRateSatPerVb: EXIT_FEE_FALLBACK_RATES.relaxed,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(exitFeeUrgency(relaxedSet.selected).urgency).toBe('relaxed');
+
+    const urgentSet = triageArkExit({
+      vtxos: [v({ id: 'tight', sats: 200_000, expiryHeight: TIP + 156 + 10 })],
+      feeRateSatPerVb: EXIT_FEE_FALLBACK_RATES.urgent,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(exitFeeUrgency(urgentSet.selected).urgency).toBe('urgent');
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -472,12 +472,127 @@ describe('reserve sizing', () => {
   });
 });
 
-describe('marginal opt-out', () => {
-  it('can be told to exit only capsules that pay for themselves', () => {
-    const r = triage({ includeMarginal: false });
-    // At 1 sat/vB nothing in this wallet clears its own reserve cost, which is
-    // the finding, not a bug. Default-on is what keeps the exit useful.
+describe('economic policy: how far past the economics the user may go', () => {
+  it('profitable-only exits nothing in this wallet, which is the finding, not a bug', () => {
+    const r = triage({ economicPolicy: 'profitable-only' });
+    // At 1 sat/vB nothing here clears its own reserve cost. Defaulting to
+    // 'default' rather than this is what keeps the exit useful at all.
     expect(r.selectedIds).toEqual([]);
     expect(r.excluded).toHaveLength(8);
+  });
+
+  it('recover-everything brings back the capsules excluded on the ratio', () => {
+    // Spec principle 4: the user may knowingly spend more than the funds are
+    // worth, for instance to deny a hostile server a hostage.
+    const forced = triage({ economicPolicy: 'recover-everything' });
+    expect(forced.selectedIds).toHaveLength(8);
+    expect(forced.excluded).toHaveLength(0);
+    expect(forced.totalExitVb).toBe(16060);
+    expect(forced.reserveSats).toBe(32120);
+  });
+
+  it('offers the override only when it would change something', () => {
+    const d = triage();
+    expect(d.overridableCount).toBe(2);
+    expect(d.overridableSats).toBe(800);
+    // Nothing left to force once it has been applied.
+    expect(triage({ economicPolicy: 'recover-everything' }).overridableCount).toBe(0);
+  });
+
+  it('states the loss the override accepts', () => {
+    const forced = triage({ economicPolicy: 'recover-everything' });
+    // 32,120 of reserve to recover 4,382 net. That gap is the choice.
+    expect(forced.netRecoverableSats).toBe(4990 - 8 * 76);
+    expect(forced.netLossSats).toBe(32120 - (4990 - 8 * 76));
+    expect(forced.underWaterCount).toBe(8);
+  });
+
+  it('reports no loss when the selected set actually pays for itself', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'big', sats: 500_000 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selected[0].economic).toBe('profitable');
+    expect(r.netLossSats).toBe(0);
+    expect(r.underWaterCount).toBe(0);
+  });
+
+  it('NEVER forces in a capsule that cannot return anything at any price', () => {
+    // bark refuses to build a claim whose fee exceeds its output and the drive
+    // rebuilds that same doomed claim forever, so this is not a trade the user
+    // could want: it wedges the batch and rescues nothing.
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'hopeless', sats: 200 }),
+        v({ id: 'forceable', sats: 400, exitDepth: 17, exitTxWeightWu: 12377 }),
+      ],
+      feeRateSatPerVb: 5,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual(['forceable']);
+    expect(r.excluded.map((e) => e.reason)).toEqual(['returns-nothing']);
+  });
+
+  it('NEVER forces past the expiry runway, whatever the policy', () => {
+    // Overriding this does not cost the user money to rescue funds, it loses
+    // the capsule AND the reserve when the server sweeps it mid-exit.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'fuse', sats: 20_000, expiryHeight: TIP + 40 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('too-close-to-expiry');
+  });
+
+  it('NEVER forces in a structurally unexitable capsule', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'chainless', sats: 20_000, exitDepth: 0, exitTxWeightWu: 0 }),
+        v({ id: 'gone', sats: 9000, stateTag: 'Exited' }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      economicPolicy: 'recover-everything',
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded.map((e) => e.reason)).toEqual(['no-exit-chain']);
+    expect(r.skippedTerminalCount).toBe(1);
+  });
+
+  it('reproduces the live 7 sat/vB wall and the way through it', () => {
+    // Measured on device 2026-08-20: mempool fastestFee 7, all seven capsules
+    // excluded, so Emergency Exit refuses. The override is what lets a user
+    // proceed anyway, with the cost stated.
+    const live = [
+      v({ id: 'aa2c257e', sats: 800, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967351 }),
+      v({ id: 'd4ec1101', sats: 700, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967253 }),
+      v({ id: '1f6627c2', sats: 698, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967241 }),
+      v({ id: '9211887d', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+      v({ id: 'a6e24d2f', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+      v({ id: 'bc672cb8', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+      v({ id: 'ec46d966', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+    ];
+    const at7 = { vtxos: live, feeRateSatPerVb: 7, chainTipHeight: 963334, vtxoExitDeltaBlocks: 144 };
+
+    const blocked = triageArkExit(at7);
+    expect(blocked.selectedIds).toEqual([]);
+    expect(blocked.excludedSats).toBe(4990);
+    expect(blocked.overridableCount).toBe(7);
+
+    const forced = triageArkExit({ ...at7, economicPolicy: 'recover-everything' });
+    expect(forced.selectedIds).toHaveLength(7);
+    expect(forced.totalExitVb).toBe(6036);
+    expect(forced.reserveSats).toBe(84504);
+    // 84,504 sats of reserve to recover 2,330. The user has to see that.
+    expect(forced.netRecoverableSats).toBe(2330);
+    expect(forced.netLossSats).toBe(82174);
   });
 });

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -1,0 +1,483 @@
+import {
+  ASSUMED_EXIT_DELTA_BLOCKS,
+  claimRateFromExitRate,
+  ExitTriageVtxo,
+  RESERVE_FLOOR_SATS,
+  perVtxoExitVb,
+  requiredRunwayBlocks,
+  reserveSatsForExitVb,
+  triageArkExit,
+} from '../../src/services/ark/exitTriage';
+
+// Every capsule below is a real one, read off the QA wallet on 2026-08-20.
+// Chain tip at the time of the snapshot was 963234 and the server reported
+// vtxoExitDelta 144 / maxVtxoExitDepth 100.
+//
+// The whole point of the module is that a capsule's fate is decided by
+// exitDepth and exitTxWeightWu, not by its sat value, so the fixtures keep the
+// measured weights rather than rounding them.
+const TIP = 963234;
+const EXIT_DELTA = 144;
+
+function v(p: Partial<ExitTriageVtxo> & { id: string; sats: number }): ExitTriageVtxo {
+  return {
+    exitDepth: 2,
+    exitTxWeightWu: 1325,
+    expiryHeight: 967241,
+    stateTag: 'Spendable',
+    registered: true,
+    ...p,
+  };
+}
+
+/** The eight live capsules, 4,990 sats total. */
+const LIVE: ExitTriageVtxo[] = [
+  v({ id: 'd4ec1101', sats: 700, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967253 }),
+  v({ id: '1f6627c2', sats: 698, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: 967241 }),
+  v({ id: '9211887d', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  v({ id: 'a6e24d2f', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  v({ id: 'bc672cb8', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  v({ id: 'ec46d966', sats: 698, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: 967241 }),
+  // The two that must be discarded: unrefreshable dust on a 1.8-day fuse.
+  v({ id: '095df741', sats: 400, exitDepth: 17, exitTxWeightWu: 12377, expiryHeight: 963502 }),
+  v({ id: '54b52b50', sats: 400, exitDepth: 15, exitTxWeightWu: 11041, expiryHeight: 963502 }),
+];
+
+function triage(over: Partial<Parameters<typeof triageArkExit>[0]> = {}) {
+  return triageArkExit({
+    vtxos: LIVE,
+    feeRateSatPerVb: 1,
+    chainTipHeight: TIP,
+    vtxoExitDeltaBlocks: EXIT_DELTA,
+    maxVtxoExitDepth: 100,
+    ...over,
+  });
+}
+
+describe('perVtxoExitVb: measured cost model', () => {
+  // If this drifts, every threshold in the module moves with it.
+  it.each([
+    ['700 @ depth 2', 2, 1325, 632],
+    ['698 @ depth 3', 3, 2337, 1035],
+    ['400 @ depth 15', 15, 11041, 5011],
+    ['400 @ depth 17', 17, 12377, 5645],
+  ])('%s costs %s vB', (_label, exitDepth, exitTxWeightWu, expected) => {
+    expect(perVtxoExitVb({ exitDepth: exitDepth as number, exitTxWeightWu: exitTxWeightWu as number }))
+      .toBe(expected);
+  });
+
+  it('falls back to a floor vsize when the SDK reports no exit weight', () => {
+    expect(perVtxoExitVb({ exitDepth: 0, exitTxWeightWu: 0 })).toBe(200);
+  });
+});
+
+describe('the exit set on the live wallet', () => {
+  it('discards the two 400s and keeps the six healthy capsules', () => {
+    const r = triage();
+    expect(r.selectedIds).toHaveLength(6);
+    expect(r.excluded.map((e) => e.id).sort()).toEqual(['095df741', '54b52b50']);
+    expect(r.excludedSats).toBe(800);
+    expect(r.selectedSats).toBe(4190);
+  });
+
+  it('sizes the reserve to the selected set, not the whole wallet', () => {
+    const r = triage();
+    // 632 + 632 + 1035*4 = 5,404 vB over the six, against 16,060 over all eight.
+    expect(r.totalExitVb).toBe(5404);
+    expect(r.reserveSats).toBe(10808);
+  });
+
+  it('costs the discarded dust at two thirds of the untriaged exit', () => {
+    // The number that justifies the whole module: 10,656 of 16,060 vB, 66%,
+    // for 800 of 4,990 sats, 16%.
+    const r = triage();
+    const dust = r.excluded.reduce((a, e) => a + e.perVtxoVb, 0);
+    expect(dust).toBe(10656);
+    expect(dust + r.totalExitVb).toBe(16060);
+  });
+
+  it('names every exclusion with an amount and a reason', () => {
+    const r = triage();
+    for (const e of r.excluded) {
+      expect(e.sats).toBeGreaterThan(0);
+      expect(e.reason).toBeTruthy();
+    }
+    expect(r.excluded.map((e) => e.reason)).toEqual([
+      'reserve-dwarfs-value',
+      'reserve-dwarfs-value',
+    ]);
+  });
+
+  it('reports what actually lands, net of each capsule claim fee', () => {
+    const r = triage();
+    // Six capsules, 76 vB each at 1 sat/vB.
+    expect(r.netRecoverableSats).toBe(4190 - 6 * 76);
+  });
+});
+
+describe('the threshold is not a sat amount', () => {
+  // This is the test that fails if anyone reintroduces a fixed dust floor.
+  it('keeps a 400-sat capsule at depth 2 and drops a 400-sat capsule at depth 17', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'shallow-400', sats: 400, exitDepth: 2, exitTxWeightWu: 1325 }),
+        v({ id: 'deep-400', sats: 400, exitDepth: 17, exitTxWeightWu: 12377 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['shallow-400']);
+    expect(r.excluded.map((e) => e.id)).toEqual(['deep-400']);
+    // Same value, same refresh verdict (both below ARK_REFRESH_MIN_SATS),
+    // opposite exit verdict, decided entirely by depth.
+    expect(r.selected[0].perVtxoVb).toBe(632);
+    expect(r.excluded[0].perVtxoVb).toBe(5645);
+  });
+
+  it('drops a large capsule whose tree is deep enough to outweigh it', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'deep-big', sats: 3000, exitDepth: 49, exitTxWeightWu: 24000 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // 6000 vB chain + 7350 CPFP = 13,350 vB to return 2,924 sats.
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+  });
+});
+
+describe('economic axis across the fee-rate matrix', () => {
+  const capsule = (sats: number, exitDepth: number, exitTxWeightWu: number) =>
+    v({ id: `c-${sats}-${exitDepth}`, sats, exitDepth, exitTxWeightWu });
+
+  it('never calls a 698 at 1 sat/vB profitable', () => {
+    const r = triageArkExit({
+      vtxos: [capsule(698, 2, 1325)],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // 632 sats of reserve to return 622. The cheapest fee market in years and
+    // the best capsule in the wallet is still a fraction under water.
+    expect(r.selected[0].economic).toBe('marginal');
+    expect(r.selected[0].notes).toContain('under-water');
+  });
+
+  it.each([
+    [1, 'marginal', true],
+    [5, 'uneconomic', false],
+    [20, 'uneconomic', false],
+    [50, 'uneconomic', false],
+  ])('at %s sat/vB a 698 @ depth 2 is %s', (rate, verdict, kept) => {
+    const r = triageArkExit({
+      vtxos: [capsule(698, 2, 1325)],
+      feeRateSatPerVb: rate as number,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    const entry = [...r.selected, ...r.excluded][0];
+    expect(entry.economic).toBe(verdict);
+    expect(entry.included).toBe(kept);
+  });
+
+  // Positive control. Without this the suite would pass just as happily if the
+  // module excluded everything at every rate.
+  it.each([1, 5, 20, 50])(
+    'at %s sat/vB a 50,000-sat capsule @ depth 2 exits and pays for itself',
+    (rate) => {
+      const r = triageArkExit({
+        vtxos: [capsule(50_000, 2, 1325)],
+        feeRateSatPerVb: rate as number,
+        chainTipHeight: TIP,
+        vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(r.selectedIds).toEqual(['c-50000-2']);
+      expect(r.selected[0].economic).toBe('profitable');
+      expect(r.selected[0].notes).not.toContain('under-water');
+    },
+  );
+
+  it('drops the same 50,000-sat capsule once its tree is deep enough', () => {
+    // Value alone never decides it. At 20 sat/vB a depth-49 tree costs 267,000
+    // sats of reserve to return 48,480.
+    const r = triageArkExit({
+      vtxos: [capsule(50_000, 49, 24000)],
+      feeRateSatPerVb: 20,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+  });
+
+  it('excludes a capsule its own claim fee would swallow, and says so', () => {
+    const r = triageArkExit({
+      vtxos: [capsule(400, 2, 1325)],
+      feeRateSatPerVb: 20,
+      claimFeeRateSatPerVb: 20,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // 76 vB of claim at 20 sat/vB is 1,520 against a 400-sat capsule.
+    expect(r.excluded[0].reason).toBe('returns-nothing');
+    expect(r.excluded[0].netRecoveredSats).toBeLessThan(0);
+  });
+
+  it('prices the claim at the clamped rate the claim path actually pays', () => {
+    // Pricing claims at the fastest rate would condemn capsules the claim path
+    // recovers fine. The clamp is the same one that stopped bark rebuilding a
+    // 779-sat claim against a 698-sat output forever.
+    expect(claimRateFromExitRate(1)).toBe(1);
+    expect(claimRateFromExitRate(3)).toBe(3);
+    expect(claimRateFromExitRate(50)).toBe(5);
+
+    const r = triageArkExit({
+      vtxos: [capsule(400, 2, 1325)],
+      feeRateSatPerVb: 20,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    // Same capsule, same fee spike, but the claim costs 380 rather than 1,520,
+    // so it is dropped for consuming reserve, not for returning nothing.
+    expect(r.excluded[0].marginalClaimSats).toBe(380);
+    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+  });
+
+  it('keeps the two costs in separate pots', () => {
+    const r = triageArkExit({
+      vtxos: [capsule(698, 2, 1325)],
+      feeRateSatPerVb: 1,
+      claimFeeRateSatPerVb: 3,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    const e = r.selected[0];
+    // Exit tree priced at the CPFP rate, claim priced at the claim rate.
+    expect(e.exitTreeCostSats).toBe(632);
+    expect(e.marginalClaimSats).toBe(228);
+    expect(e.netRecoveredSats).toBe(470);
+    // The reserve covers the exit tree only. The claim is never added to it.
+    expect(r.reserveSats).toBe(RESERVE_FLOOR_SATS);
+  });
+});
+
+describe('temporal axis', () => {
+  it('excludes a capsule that cannot clear its CSV before expiry', () => {
+    const r = triageArkExit({
+      // Healthy value, shallow tree, but 40 blocks of runway against 144 of CSV.
+      vtxos: [v({ id: 'fuse', sats: 20_000, expiryHeight: TIP + 40 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded[0].reason).toBe('too-close-to-expiry');
+  });
+
+  it('scales the confirmation budget with tree depth', () => {
+    // Same expiry, same value; only the depth differs.
+    const runway = TIP + 160;
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'shallow', sats: 20_000, exitDepth: 2, expiryHeight: runway }),
+        v({ id: 'deep', sats: 20_000, exitDepth: 3, exitTxWeightWu: 2337, expiryHeight: runway }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(requiredRunwayBlocks(2, EXIT_DELTA)).toBe(156);
+    expect(requiredRunwayBlocks(3, EXIT_DELTA)).toBe(162);
+    expect(r.selectedIds).toEqual(['shallow']);
+    expect(r.excluded[0].id).toBe('deep');
+  });
+
+  it('assumes the worst delta when ArkInfo was never cached, rather than skipping the check', () => {
+    const near = v({ id: 'near', sats: 20_000, exitDepth: 2, expiryHeight: TIP + 200 });
+    const cached = triageArkExit({
+      vtxos: [near],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    const uncached = triageArkExit({
+      vtxos: [near],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: null,
+    });
+    expect(cached.selectedIds).toEqual(['near']);
+    expect(cached.usedAssumedExitDelta).toBe(false);
+    // 200 blocks of runway clears 144 + 12 but not 288 + 12.
+    expect(uncached.selectedIds).toEqual([]);
+    expect(uncached.excluded[0].reason).toBe('too-close-to-expiry');
+    expect(uncached.usedAssumedExitDelta).toBe(true);
+    expect(ASSUMED_EXIT_DELTA_BLOCKS).toBeGreaterThan(EXIT_DELTA);
+  });
+
+  it('excludes the live 400s on runway alone once the delta is unknown', () => {
+    const r = triage({ vtxoExitDeltaBlocks: null });
+    const deep = r.excluded.find((e) => e.id === '095df741');
+    expect(deep?.reason).toBe('too-close-to-expiry');
+    expect(deep?.blocksUntilExpiry).toBe(268);
+    expect(deep?.requiredRunwayBlocks).toBe(390);
+  });
+
+  it('still exits, with a disclosure, when the chain tip is unreadable', () => {
+    // A failed tip read is a network fault, not evidence of a problem. Refusing
+    // to exit on it would disarm the emergency button exactly when the network
+    // is already misbehaving.
+    const r = triage({ chainTipHeight: null });
+    expect(r.selectedIds).toHaveLength(6);
+    expect(r.selected[0].notes).toContain('expiry-unknown');
+    expect(r.selected[0].blocksUntilExpiry).toBeNull();
+  });
+});
+
+describe('structural axis', () => {
+  it('exits unregistered capsules: registered is a mailbox flag, not exitability', () => {
+    // Measured 2026-08-19: all 117 unregistered capsules carried a full exit
+    // chain. Excluding them here would abandon arkoor change on every wallet.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'unreg', sats: 20_000, registered: false })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['unreg']);
+  });
+
+  it('exits a capsule past the server exit-depth cap, and flags it', () => {
+    // Past maxVtxoExitDepth the server refuses to cosign further arkoor spends,
+    // so exit and refresh are the only moves left. That is a reason to exit it,
+    // not a reason to abandon it.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'capped', sats: 500_000, exitDepth: 101, exitTxWeightWu: 24000 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+      maxVtxoExitDepth: 100,
+    });
+    expect(r.selectedIds).toEqual(['capped']);
+    expect(r.selected[0].notes).toContain('beyond-server-depth-cap');
+  });
+
+  it('drops terminal capsules so finished exits stop inflating the reserve', () => {
+    // bark keeps returning a completed exit as state Exited from allVtxos()
+    // forever. The old reserve calc filtered only `spent`, so ten of these on
+    // the measured wallet added 7,252 vB of demanded reserve for value that was
+    // already on-chain.
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'live', sats: 20_000 }),
+        v({ id: 'gone', sats: 22_001, exitDepth: 4, exitTxWeightWu: 2657, stateTag: 'Exited' }),
+        v({ id: 'used', sats: 5000, stateTag: 'Spent' }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['live']);
+    expect(r.totalExitVb).toBe(632);
+    expect(r.skippedTerminalCount).toBe(2);
+  });
+
+  it('never lists terminal capsules as exclusions the user has to read', () => {
+    // The measured wallet holds 178 Spent and 10 Exited against 8 live ones.
+    // Putting those in the disclosure list would bury the two that matter.
+    const history = Array.from({ length: 100 }, (_, i) =>
+      v({ id: `old-${i}`, sats: 1000, stateTag: 'Spent' }),
+    );
+    const r = triageArkExit({
+      vtxos: [...history, ...LIVE],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.skippedTerminalCount).toBe(100);
+    expect(r.excluded).toHaveLength(2);
+    expect(r.excludedSats).toBe(800);
+  });
+
+  it('drops a capsule the SDK reports no exit chain for', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'chainless', sats: 20_000, exitDepth: 0, exitTxWeightWu: 0 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.excluded[0].reason).toBe('no-exit-chain');
+  });
+});
+
+describe('ordering under a constrained reserve', () => {
+  it('orders the exit set by what each capsule actually returns, highest first', () => {
+    // Deliberately fed smallest-first, so the assertion fails if the sort is
+    // removed rather than passing on the input order by luck.
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'tiny', sats: 600 }),
+        v({ id: 'mid', sats: 4_000 }),
+        v({ id: 'huge', sats: 90_000 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['huge', 'mid', 'tiny']);
+    const net = r.selected.map((e) => e.netRecoveredSats);
+    expect(net).toEqual([...net].sort((a, b) => b - a));
+  });
+
+  it('puts the largest live capsule first on the real wallet', () => {
+    expect(triage().selectedIds[0]).toBe('d4ec1101');
+  });
+
+  it('orders exclusions largest first so disclosure leads with the biggest loss', () => {
+    const r = triageArkExit({
+      vtxos: [
+        v({ id: 'small', sats: 300, exitDepth: 17, exitTxWeightWu: 12377 }),
+        v({ id: 'large', sats: 900, exitDepth: 17, exitTxWeightWu: 12377 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.excluded.map((e) => e.id)).toEqual(['large', 'small']);
+  });
+});
+
+describe('reserve sizing', () => {
+  it('reserves nothing when nothing is selected, rather than the floor', () => {
+    const r = triageArkExit({
+      vtxos: [v({ id: 'dust', sats: 400, exitDepth: 17, exitTxWeightWu: 12377 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual([]);
+    expect(r.reserveSats).toBe(0);
+  });
+
+  it('applies the floor once there is something to exit', () => {
+    expect(reserveSatsForExitVb(0, 1)).toBe(0);
+    expect(reserveSatsForExitVb(100, 1)).toBe(RESERVE_FLOOR_SATS);
+    expect(reserveSatsForExitVb(5404, 1)).toBe(10808);
+  });
+
+  it('scales the reserve with the fee rate', () => {
+    expect(reserveSatsForExitVb(5404, 5)).toBe(54040);
+  });
+});
+
+describe('marginal opt-out', () => {
+  it('can be told to exit only capsules that pay for themselves', () => {
+    const r = triage({ includeMarginal: false });
+    // At 1 sat/vB nothing in this wallet clears its own reserve cost, which is
+    // the finding, not a bug. Default-on is what keeps the exit useful.
+    expect(r.selectedIds).toEqual([]);
+    expect(r.excluded).toHaveLength(8);
+  });
+});

--- a/tests/unit/hotVaultPassphraseDeniability.test.ts
+++ b/tests/unit/hotVaultPassphraseDeniability.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The keychain sidecar must never record, or report, whether a vault has a
+ * BIP39 passphrase.
+ *
+ * A passphrase is a deniability tool. Its whole value is that nobody can tell
+ * the hidden wallet exists: under duress you hand over twelve words and the
+ * wallet they open is the only wallet anyone can see.
+ *
+ * The sidecar used to carry `hasPassphrase`, on the reasoning that it "reveals
+ * only that protection exists, never the protection itself". That reveal is the
+ * leak. Recovery read the flag and announced "This vault is passphrase-
+ * protected" before prompting, so anyone holding the unlocked phone (which,
+ * under duress, is the premise) learned a second wallet existed.
+ *
+ * These tests pin both halves: nothing writes the flag, and a legacy flag
+ * written by an older build is dropped on read rather than surfaced, so no
+ * future caller can branch on it.
+ */
+
+const mockSetGenericPassword = jest.fn();
+const mockGetGenericPassword = jest.fn();
+
+jest.mock('react-native-keychain', () => ({
+    __esModule: true,
+    setGenericPassword: mockSetGenericPassword,
+    getGenericPassword: mockGetGenericPassword,
+    resetGenericPassword: jest.fn(),
+    getAllGenericPasswordServices: jest.fn(async () => []),
+    ACCESS_CONTROL: { BIOMETRY_ANY_OR_DEVICE_PASSCODE: 'bio' },
+    ACCESSIBLE: { WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: 'whenPasscodeSet' },
+}));
+
+import {
+    backupHotVaultMeta,
+    backupHotVaultSeedWithMeta,
+    getHotVaultMeta,
+} from '../../src/services/hotVaultKeychain';
+
+const WALLET_ID = 'a'.repeat(64);
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/** The JSON actually handed to the keychain for the meta sidecar. */
+function writtenMetaPayloads(): string[] {
+    return mockSetGenericPassword.mock.calls
+        .filter((c) => String(c[2]?.service ?? '').startsWith('hot-vault-meta'))
+        .map((c) => String(c[1]));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetGenericPassword.mockResolvedValue(true);
+});
+
+describe('the sidecar never records a passphrase flag', () => {
+    it('omits it when writing meta directly', async () => {
+        await backupHotVaultMeta(WALLET_ID, { createdAt: 1_700_000_000_000, label: null });
+        const payloads = writtenMetaPayloads();
+        expect(payloads).toHaveLength(1);
+        expect(payloads[0]).not.toMatch(/passphrase/i);
+        expect(JSON.parse(payloads[0])).not.toHaveProperty('hasPassphrase');
+    });
+
+    it('omits it on the seed+meta convenience path used at vault creation', async () => {
+        await backupHotVaultSeedWithMeta(WALLET_ID, MNEMONIC, { createdAt: 1_700_000_000_000 });
+        for (const payload of writtenMetaPayloads()) {
+            expect(payload).not.toMatch(/passphrase/i);
+            expect(JSON.parse(payload)).not.toHaveProperty('hasPassphrase');
+        }
+    });
+
+    it('cannot be coaxed into writing it by a caller that still passes one', async () => {
+        // Defence against a future caller reintroducing the field. The type no
+        // longer permits it, so this casts past the compiler the way a stale
+        // call site would.
+        await backupHotVaultMeta(WALLET_ID, {
+            createdAt: 1_700_000_000_000,
+            label: null,
+            hasPassphrase: true,
+        } as any);
+        expect(writtenMetaPayloads()[0]).not.toMatch(/passphrase/i);
+    });
+
+    it('still writes the fields the picker legitimately needs', async () => {
+        await backupHotVaultMeta(WALLET_ID, { createdAt: 1_700_000_000_000, label: 'vault' });
+        const parsed = JSON.parse(writtenMetaPayloads()[0]);
+        expect(parsed).toMatchObject({ version: 1, createdAt: 1_700_000_000_000, label: 'vault' });
+    });
+});
+
+describe('a legacy passphrase flag is dropped on read', () => {
+    it('does not surface hasPassphrase from an older sidecar', async () => {
+        // Written by a build that still recorded the flag. Reading it back must
+        // not hand any caller something to branch on.
+        mockGetGenericPassword.mockResolvedValue({
+            username: WALLET_ID,
+            password: JSON.stringify({
+                version: 1,
+                createdAt: 1_700_000_000_000,
+                label: null,
+                hasPassphrase: true,
+            }),
+        });
+        const meta = await getHotVaultMeta(WALLET_ID);
+        expect(meta).not.toBeNull();
+        expect(meta).not.toHaveProperty('hasPassphrase');
+        expect((meta as any)?.hasPassphrase).toBeUndefined();
+    });
+
+    it('still returns the harmless fields from a legacy sidecar', async () => {
+        mockGetGenericPassword.mockResolvedValue({
+            username: WALLET_ID,
+            password: JSON.stringify({
+                version: 1,
+                createdAt: 42,
+                label: 'old vault',
+                hasPassphrase: true,
+            }),
+        });
+        const meta = await getHotVaultMeta(WALLET_ID);
+        expect(meta).toMatchObject({ version: 1, createdAt: 42, label: 'old vault' });
+    });
+});


### PR DESCRIPTION
Lands 23 already-reviewed PRs as the configuration they were actually tested in.

Merging them individually would create 23 intermediate states on `main` that nobody has ever run. This branch is the only arrangement that has been exercised end to end, so it ships as one unit. GitHub should auto-close the listed PRs once their commits are reachable from `main`.

## Unilateral exit

The bulk of this work, and the part with the most on-device evidence behind it.

| | |
|---|---|
| #175 | never run a cooperative round while a unilateral exit is live |
| #179 | keep the unilateral exit reachable when esplora fails |
| #181 | batch the exit claim instead of paying a fee per capsule |
| #183 | let users see and fund the exit-fee reserve during an exit |
| #186 | stop the exit-destination backfill logging duplicate ticks |
| #187 | price the exit claim explicitly instead of letting bark bid for speed |
| #188 | stop a stale armed reserve claiming the exit is funded |
| #189 | stop auto-board boarding away the exit-fee reserve |
| #191 | exit triage: discard capsules an exit cannot economically recover |
| #192 | wait on the ripening schedule, not a clock, so an exit lands as one UTXO |
| #193 | stop the exit-funding confirm screen hiding the amount and the fee |

## Refresh and capsule state

| | |
|---|---|
| #172 | stop telling users a possibly-sent payment was not sent |
| #176 | treat delegated refreshes as mid-round everywhere |
| #190 | surface dust capsules on the home screen at the right threshold |
| #195 | stop the expiry-reminder switch claiming protection it does not have |

## Vault and recovery

| | |
|---|---|
| #171 | spend the capsules the user selected |
| #173 | never delete the last backup on a tick that wrote nothing |
| #178 | make keychain recovery passphrase-agnostic |
| #180 | stop the address list crashing the app when the wallet is unavailable |

## Chain source, network and payments

| | |
|---|---|
| #182 | stop a coinos double-send on withdraw timeout, and fund exit fees from another wallet |
| #184 | say which side of the network is down instead of pasting the SDK error |
| #198 | give the chain-source fallback somewhere to fall back to |

## Docs

| | |
|---|---|
| #185 | roadmap a user-supplied chain source, and stop hedging on the exit |

## Verification

**Device-tested as a bundle**, not as individual PRs. This branch ran on an iPhone through a complete 44-hour mainnet unilateral exit against a deliberately dead ASP endpoint, from `startExitForVtxos` through eleven exit-tree transactions and their CPFP children to a single batched claim.

That run produced measurements rather than a smoke test:

- the exit landed as **one UTXO**, 7 inputs to 1 output, 573 vB, 574 sats at exactly 1.00 sat/vB, confirmed at height 963660
- the batch held **15 hours 36 minutes** past the point the previous clock-based logic would have swept, which is #192 doing the thing it was written for. The old behaviour would have produced 3 UTXOs
- exit-tree cost came to 3,585 sats, verified on chain as eleven CPFP children summing exactly to the reserve delta

Automated checks on the merged branch:

- `npx jest -b -i tests/unit`: **52 suites, 546 passed, 1 skipped**
- `tsc --noEmit`: **400 errors, against 405 on `main`**, so this reduces the baseline by 5 and adds none

Merges to `main` with no conflicts.

## Two things to know before merging

**The merge commits on this branch are unsigned.** If the ruleset requires signed commits on `main`, they will need re-signing.

**Do not push to this branch before approving it.** `require_last_push_approval` will deadlock if the approver is also the last pusher.

## Not included

#202, #203 and #205 are branched off `main` and target it directly. They should be rebased onto the new `main` and device-tested after this lands, since the phone was tied up with the exit run until now.
