### PR TITLE
fix(ark): stop telling users an exit finishes while the app is closed

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1532,7 +1532,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   correlationId,
                 });
                 SimpleToast.show(
-                  'Emergency exit started — broadcasting on-chain. Funds will sweep automatically once the timelock expires.',
+                  'Emergency exit started, broadcasting on-chain. It does not finish while the app is closed: reopen it after the timelock to collect.',
                   SimpleToast.LONG,
                 );
               } catch (err: any) {
@@ -2171,7 +2171,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   arkExitStartedSats;
                 return shownSats == null || shownSats <= 0
                   ? 'Broadcasting exit transactions…'
-                  : `${shownSats.toLocaleString()} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.`;
+                  : `${shownSats.toLocaleString()} sats pending exit. Broadcasting, then a ~24h timelock. Reopen the app after that to collect; it does not progress while closed.`;
               })()}
             </Text>
             {arkExitDestinationAddress && (
@@ -2181,7 +2181,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             )}
             {arkExitStartedAt && (
               <Text style={{ fontSize: 11, color: '#666', marginTop: 4 }}>
-                Started {new Date(arkExitStartedAt).toLocaleString()}. Funds sweep to the destination when the timelock expires; the vault stays afterwards.
+                Started {new Date(arkExitStartedAt).toLocaleString()}. Funds go to the destination when you reopen the app after the timelock; the vault stays afterwards.
               </Text>
             )}
 


### PR DESCRIPTION
Closes the copy half of #196.

## What was wrong

Three user-facing strings promised the exit completes on its own:

```
Settings.tsx:1535  'Emergency exit started ... Funds will sweep automatically once the timelock expires.'
Settings.tsx:2174  '{sats} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.'
Settings.tsx:2184  'Started {date}. Funds sweep to the destination when the timelock expires ...'
```

None of that is true. `progressArkExits`, `syncArkExits` and `claimArkExitsToAddress` are reached only from `useArkSync`, a foreground React hook, and the one background entry point bails deliberately while an exit is active.

## Measured, not argued

From the 44-hour mainnet exit against a deliberately dead ASP:

- every stretch the app spent closed produced **zero** progress on capsules still broadcasting, while capsules already in `AwaitingDelta` advanced normally, because the chain does that part
- the final claim fired only because the app happened to be open at block 963652

A user who read the old copy and closed the app got a stalled exit and no signal that anything was wrong.

## What it says now

The actual contract: it is publishing now, it does not progress while closed, reopen after the timelock to collect.

It deliberately **does not promise a notification**. Nothing schedules one yet, that is #199, and promising it here would replace one false claim with another.

Also removes an em dash that was sitting in shipped UI copy.

## Wording

Draft, expected to be rewritten. The intent is the constraint, not the words.

## Verification

- `tsc --noEmit`: **400**, matching the post-#208 baseline on `main`
- `npx jest -i tests/unit --rootDir .`: **52 suites, 546 passed, 1 skipped**

One earlier run in bail mode reported a single failure, but bail truncated the output before naming the test and it did not reproduce across two subsequent full runs. Recording it rather than hiding it.

Copy-only, no logic touched. Not device-verified yet.

## Not closed by this

#196 also asks for a notification (tracked as #199) and for opportunistic background execution, which that issue itself says must never be relied on. This PR addresses the part that was actively misleading users.
