### PR TITLE
fix(ark): name a chain-source 429 instead of reporting it as corruption

### DIFF
--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -26,7 +26,11 @@
  * switch networks when the server is down) costs more than no suggestion.
  */
 
-export type ArkNetworkFault = 'chain-source' | 'ark-server' | 'unknown';
+export type ArkNetworkFault =
+    | 'chain-source'
+    | 'chain-source-rate-limited'
+    | 'ark-server'
+    | 'unknown';
 
 /** Flatten a thrown value into searchable text. BarkError hides detail in `inner`. */
 export function arkErrorText(err: unknown): string {
@@ -59,6 +63,28 @@ function hostOf(url: string): string | null {
 const CHAIN_SOURCE_PHRASES =
     /not a blockhash|failed to parse hex|esplora|chain source|Sync failed/i;
 
+/**
+ * A quota rejection, as distinct from the provider being unreachable.
+ *
+ * These need opposite advice. Unreachable means try another network. Rate
+ * limited means the provider is working fine and is refusing US, so the remedy
+ * is to wait it out or present a different IP.
+ *
+ * Worth separating because the symptom actively misleads. Blockstream answers a
+ * 429 with a ~330 byte JSON notice, bark hands that body to a hex parser
+ * expecting a 64 character blockhash, and the user is shown "not a blockhash ...
+ * Esplora client possibly misconfigured". That points at their wallet and their
+ * network when the actual cause is a quota. Observed 2026-08-20 on mainnet, and
+ * it cost hours chasing TLS interception.
+ *
+ * NOT matched here: the long-hex-string symptom on its own. A body where a
+ * blockhash belongs proves the provider returned an error page, not which error,
+ * so it stays a plain chain-source fault. Claiming "rate limited" for a 500 would
+ * be the same class of confident wrong answer this module exists to avoid.
+ */
+const RATE_LIMIT_PHRASES =
+    /\b429\b|too many requests|rate limit|request rate|exceeds the current limit/i;
+
 export function classifyArkNetworkFault(
     err: unknown,
     endpoints: { chainUrls?: readonly string[]; arkUrl?: string | null } = {},
@@ -67,14 +93,24 @@ export function classifyArkNetworkFault(
     if (!text) return 'unknown';
     const haystack = text.toLowerCase();
 
+    const rateLimited = RATE_LIMIT_PHRASES.test(text);
+
     // Hostname match first: unambiguous, and survives SDK wording changes.
     for (const url of endpoints.chainUrls ?? []) {
         const host = hostOf(url);
-        if (host && haystack.includes(host)) return 'chain-source';
+        if (host && haystack.includes(host)) {
+            return rateLimited ? 'chain-source-rate-limited' : 'chain-source';
+        }
     }
     const arkHost = endpoints.arkUrl ? hostOf(endpoints.arkUrl) : null;
+    // Checked before the hostless rate-limit fallback below, so a quota
+    // rejection that DOES name the ASP is still reported as an ASP fault.
     if (arkHost && haystack.includes(arkHost)) return 'ark-server';
 
+    // A quota rejection often names no host of ours, because the body is the
+    // provider's own notice rather than a connection error. Only the chain
+    // source is polled hard enough to earn one.
+    if (rateLimited) return 'chain-source-rate-limited';
     if (CHAIN_SOURCE_PHRASES.test(text)) return 'chain-source';
 
     return 'unknown';
@@ -89,6 +125,10 @@ export function arkNetworkFaultMessage(fault: ArkNetworkFault): string | null {
     switch (fault) {
         case 'chain-source':
             return "Can't reach the Bitcoin network data provider. If you're on Wi-Fi, try mobile data, then try again.";
+        case 'chain-source-rate-limited':
+            // Says "not your wallet" explicitly: the raw symptom claims the
+            // opposite, and that is the whole reason this case exists.
+            return 'The Bitcoin network data provider is limiting how many requests this connection can make. Nothing is wrong with your wallet. It clears within the hour, or switch networks to get a different address.';
         case 'ark-server':
             // No network advice: if the server is down, switching networks
             // achieves nothing and wastes the user's time.

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -114,3 +114,50 @@ describe('arkErrorText', () => {
         expect(arkErrorText({ code: 7 })).toBe('');
     });
 });
+
+describe('rate limiting, which the raw symptom misreports as corruption', () => {
+    // The real 429 body, captured on mainnet 2026-08-20.
+    const BLOCKSTREAM_429 =
+        'Sync failed: HttpResponse { status: 429, message: "{\\"message\\":\\"Blockstream ' +
+        'Explorer API NOTICE: Your request rate exceeds the current limit..." }';
+
+    it('names a 429 as a quota rejection rather than a chain-source outage', () => {
+        expect(classify(BLOCKSTREAM_429)).toBe('chain-source-rate-limited');
+    });
+
+    it('still names it when the provider hostname is present', () => {
+        expect(
+            classify('https://blockstream.info/api failed: 429 Too Many Requests'),
+        ).toBe('chain-source-rate-limited');
+    });
+
+    it('tells the user it is not their wallet, because the raw error implies it is', () => {
+        const msg = arkNetworkFaultMessage('chain-source-rate-limited') ?? '';
+        expect(msg.toLowerCase()).toContain('nothing is wrong with your wallet');
+    });
+
+    it('does not tell them to switch to mobile data, which does not clear a quota', () => {
+        const msg = arkNetworkFaultMessage('chain-source-rate-limited') ?? '';
+        expect(msg.toLowerCase()).not.toContain('mobile data');
+    });
+
+    // The 338-byte hex string is the 429 body being parsed as a blockhash. But a
+    // body where a blockhash belongs only proves the provider returned an error
+    // page, not WHICH error, so this stays the general chain-source fault.
+    // Guessing "rate limited" for a 500 would be the confident-wrong-answer this
+    // module exists to avoid.
+    it('does NOT infer rate limiting from the parse failure alone', () => {
+        expect(
+            classify(
+                'Failed to create chain source: bad response from server (not a blockhash). ' +
+                'failed to parse hex: invalid hex string length 338 (expected 64)',
+            ),
+        ).toBe('chain-source');
+    });
+
+    it('reports a quota rejection that names the ASP as an Ark-server fault', () => {
+        expect(classify('https://ark.second.tech: 429 too many requests')).toBe(
+            'ark-server',
+        );
+    });
+});


### PR DESCRIPTION
Closes fix 1 of #194.

## The problem

Blockstream answers a rate-limited request with a ~330 byte JSON notice. bark hands that body to a hex parser expecting a 64 character blockhash, so what the user sees is:

```
Failed to create chain source: bad response from server (not a blockhash).
Esplora client possibly misconfigured: failed to parse hex:
invalid hex string length 338 (expected 64)
```

Every part of that points the user at their own wallet or their own network. The actual cause is a quota. Observed on mainnet 2026-08-20, and it cost hours chasing TLS interception before anyone noticed 338 bytes was the size of a JSON error body.

## What this does

Adds a `chain-source-rate-limited` fault, so the two cases can be told apart. They need opposite advice:

| fault | remedy |
|---|---|
| chain source unreachable | try another network |
| chain source rate limited | the provider is working and refusing us, so wait it out or present a different address |

The new message says "nothing is wrong with your wallet" explicitly, because the raw symptom asserts the opposite and that is the entire reason this case exists.

## What it deliberately does not do

**It does not infer rate limiting from the parse failure alone.** A body where a blockhash belongs proves the provider returned an error page, not *which* error. A 500 or a Cloudflare page produces the same symptom. Guessing "rate limited" there would be exactly the confident-wrong-answer this module was written to avoid, and its header already says so: it returns `unknown` rather than guessing, because a wrong suggestion costs more than no suggestion.

So the 338-byte case stays a general chain-source fault. A test pins that.

**A quota rejection that names the ASP is still reported as an ASP fault.** The hostname check runs before the hostless rate-limit fallback. Also pinned by a test.

## Tests

Six added, using the real 429 body captured on device:

- names a 429 as a quota rejection rather than an outage
- still names it when the provider hostname is present
- tells the user it is not their wallet
- does not suggest mobile data, which does not clear a quota
- does NOT infer rate limiting from the parse failure alone
- an ASP-named 429 stays an ASP fault

## Verification

- `npx jest -i tests/unit`: **52 suites, 552 passed, 1 skipped** (up from 546, the six new ones)
- `tsc --noEmit`: **400**, matching the post-#208 baseline

Copy is a draft to be rewritten. Not device-verified.

## Still open in #194

Fixes 2, 3 and 4 are separate work and none are addressed here: budgeting requests to rotate before the cap, cutting exit-drive consumption, and an API key or our own chain source. This is the cheapest one and it is purely client side.
