### PR TITLE
feat(ark): fold deepened arkoor change back into a round after a send

### DIFF
--- a/src/services/ark/changeRefresh.ts
+++ b/src/services/ark/changeRefresh.ts
@@ -1,0 +1,137 @@
+/**
+ * Should the change from an arkoor send be folded back into a round?
+ *
+ * WHY THIS EXISTS
+ *
+ * `exitDepth` is the length of a VTXO capsule's genesis chain, and it is
+ * exactly the number of transactions a unilateral exit has to broadcast and
+ * confirm for that capsule. Per Second.tech (confirmed 2026-08-22), TRUC relay
+ * policy allows one unconfirmed parent and one child, and the CPFP anchor takes
+ * the child slot, so those transactions confirm one after another. Depth is
+ * therefore both the fee and the wall clock of an exit.
+ *
+ * Every arkoor spend appends a level to the change. A round resets it. Nothing
+ * currently folds change back: `send.ts` ends with a local state re-read, and
+ * `useArkoorReceivePrompt` is scoped to capsules that ARRIVE, not to change from
+ * the user's own spend. So depth accumulates for anyone who spends, until
+ * `foregroundSweep` reaches the capsule in the last week before expiry.
+ *
+ * WHY AT SEND TIME
+ *
+ * The app is definitionally open. The user initiated the send, they are holding
+ * the phone, the wallet is unlocked. Every other refresh trigger has to solve
+ * "how do we reach a user who is not looking"; this one does not, which is why
+ * it needs none of the notification machinery.
+ *
+ * WHY A DEPTH TRIGGER RATHER THAN REFRESHING EVERY SEND
+ *
+ * `baseFeeSats` is charged per ROUND, so refreshing after every send is a fee on
+ * every send. A threshold charges only the user whose own spending created the
+ * depth, and leaves everyone else alone.
+ *
+ * Measured 2026-08-22 on one wallet, split by state: the live (Spendable)
+ * capsules sat at depths [2, 2, 3, 3, 3, 3, 15, 17], median 3. The alarming
+ * numbers quoted elsewhere (median 9, max 49) came from 178 already-SPENT
+ * capsules, which are transaction history rather than a wallet. So the resting
+ * state of a normally-used wallet is 2 to 3, and a threshold of 5 rarely fires:
+ * it takes several consecutive sends with no round in between.
+ *
+ * At roughly 316 vB per tree transaction (measured on the same exit: 11 CPFP
+ * children, 3,585 sats total, 1 sat/vB), a threshold of 5 caps a single
+ * capsule's exit-tree cost near 1,580 vB.
+ *
+ * WHAT IT REFUSES TO DO, AND WHY
+ *
+ * The guards below mirror `foregroundSweep`'s selection, minus its one-week
+ * ceiling. That ceiling exists because when the trigger is EXPIRY there is no
+ * reason to spend a fee early. When the trigger is DEPTH there is, so it does
+ * not apply here. Every other guard does, and for the same reasons:
+ *
+ *   - below `ARK_REFRESH_MIN_SATS`, one sub-floor input makes the ASP reject the
+ *     whole round, so a dust change capsule cannot be refreshed alone
+ *   - below the exit-runway floor, a delegated round that hangs would eat the
+ *     user's exit window; that zone belongs to spend-or-exit, not to refresh
+ *   - during a unilateral exit, a cooperative round would spend a coin already
+ *     committed on-chain
+ *
+ * Pure and import-free, matching exitClaimBatch.ts and refreshBatch.ts, so the
+ * rule can be tested without standing up a wallet.
+ */
+
+/**
+ * Depth above which change is folded back into a round.
+ *
+ * 5, not 3: the resting state is 2 to 3, so 3 would fire on the first send and
+ * turn this into a per-send fee. 5 leaves headroom for normal spending and only
+ * fires on a run of sends with no round between them.
+ */
+export const ARK_CHANGE_REFRESH_MAX_DEPTH = 5;
+
+export type ChangeRefreshInput = {
+    /** `exitDepth` of the change capsule. */
+    exitDepth: number;
+    /** Value of the change capsule, in sats. */
+    sats: number;
+    /** Blocks until it expires; null when the height is unknown or unreadable. */
+    blocksUntilExpiry: number | null;
+    /** bark state tag, flattened to its variant string. */
+    stateTag: string;
+    /** Already submitted to a round by another caller. */
+    alreadyRefreshing: boolean;
+    /** A unilateral exit is active on this wallet. */
+    exitInProgress: boolean;
+    /** Per-input round minimum (ARK_REFRESH_MIN_SATS). */
+    minSats: number;
+    /** Runway floor below which auto-refresh is unsafe (ARK_EXIT_RUNWAY_HOURS in blocks). */
+    minRunwayBlocks: number;
+    /** Depth threshold; defaults to ARK_CHANGE_REFRESH_MAX_DEPTH. */
+    maxDepth?: number;
+};
+
+export type ChangeRefreshDecision = {
+    refresh: boolean;
+    reason:
+        | 'refresh'
+        | 'shallow-enough'
+        | 'exit-in-progress'
+        | 'not-spendable'
+        | 'already-refreshing'
+        | 'unknown-expiry'
+        | 'too-near-expiry'
+        | 'below-refresh-minimum';
+};
+
+export function decideChangeRefresh(input: ChangeRefreshInput): ChangeRefreshDecision {
+    const maxDepth = input.maxDepth ?? ARK_CHANGE_REFRESH_MAX_DEPTH;
+
+    // Hard exclusions first. Each of these makes a round either impossible or
+    // actively harmful, so they outrank the depth question entirely.
+    if (input.exitInProgress) return { refresh: false, reason: 'exit-in-progress' };
+    if (input.stateTag.toLowerCase() !== 'spendable') {
+        return { refresh: false, reason: 'not-spendable' };
+    }
+    if (input.alreadyRefreshing) return { refresh: false, reason: 'already-refreshing' };
+
+    // An unreadable expiry cannot be checked against the runway floor, and the
+    // floor is what stops a hung round eating an exit window. Assume the worst.
+    if (input.blocksUntilExpiry == null || !Number.isFinite(input.blocksUntilExpiry)) {
+        return { refresh: false, reason: 'unknown-expiry' };
+    }
+    if (input.blocksUntilExpiry < input.minRunwayBlocks) {
+        return { refresh: false, reason: 'too-near-expiry' };
+    }
+
+    // Dust cannot ride along: one sub-floor input makes the ASP reject the whole
+    // round. Reported before the depth check so a deep dust capsule is named as
+    // dust, which is the actionable half. Deep AND unrefreshable is a real
+    // combination: the two depth-15/17 capsules in the measured wallet were both
+    // 400 sats, and they got deep precisely because they could never be
+    // refreshed alone.
+    if (input.sats < input.minSats) {
+        return { refresh: false, reason: 'below-refresh-minimum' };
+    }
+
+    if (input.exitDepth <= maxDepth) return { refresh: false, reason: 'shallow-enough' };
+
+    return { refresh: true, reason: 'refresh' };
+}

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -6,6 +6,7 @@ import {
 } from '@secondts/bark-react-native';
 import bolt11 from 'bolt11';
 
+import { decideChangeRefresh } from './changeRefresh';
 import { assertNoActiveArkExit } from './exit';
 import { ensureArkWalletHandleReady } from './restore';
 import { fetchArkBalance } from './balance';
@@ -300,6 +301,83 @@ async function dispatchLnSend(
  */
 const MAX_LN_SEND_ATTEMPTS = 4;
 
+/**
+ * Fold change that a send has deepened back into a round.
+ *
+ * See ./changeRefresh for why depth matters and why send time is the right
+ * moment. This is the plumbing: read the raw capsule list (the store's
+ * ArkVtxoView drops `exitDepth`, which is the field the whole rule turns on),
+ * ask the pure rule about each one, and submit whatever qualifies as a single
+ * round.
+ *
+ * Never throws. The send has already succeeded by the time this runs, and a
+ * failed or skipped refresh costs the user nothing beyond staying deep until
+ * the next opportunity.
+ */
+async function maybeRefreshDeepenedChange(): Promise<void> {
+    // Lazy requires, deliberately. Importing ./config at module scope drags the
+    // SDK's `Network` enum into send.ts's graph, and any suite that mocks the
+    // SDK without it fails to even load (arkSendIndeterminate.test.ts did).
+    // ./changeRefresh stays a top-level import because it is pure and
+    // import-free. Same pattern as notificationHandler.ts and
+    // backgroundRefresh.ts, which lazy-require for the same reason.
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const { ARK_EXIT_RUNWAY_HOURS, ARK_REFRESH_MIN_SATS } = require('./config');
+    const { AVG_BLOCK_MINUTES, fetchChainTipHeight } = require('./chainTip');
+    const { barkStateTag } = require('./barkState');
+    const { refreshArkVtxosDelegatedAndSync } = require('./refresh');
+    const { getArkWalletHandle } = require('./walletHandle');
+    const useAuthStore = require('@Cypher/stores/authStore').default;
+    /* eslint-enable @typescript-eslint/no-var-requires */
+
+    const handle = getArkWalletHandle();
+    if (!handle) return;
+
+    const store = useAuthStore.getState();
+    // Cheapest guard first: an active exit rules out every capsule, so do not
+    // pay for allVtxos() to be told so seven times.
+    if (store.arkExitInProgress) return;
+
+    const tip = await fetchChainTipHeight();
+    if (tip == null) return; // cannot evaluate the runway floor; assume unsafe
+
+    const minRunwayBlocks = Math.round((ARK_EXIT_RUNWAY_HOURS * 60) / AVG_BLOCK_MINUTES);
+    const refreshing = new Set(store.arkRefreshingVtxoIds ?? []);
+
+    // allVtxos() is a JS-thread-blocking UniFFI call, so this runs after the
+    // send has resolved and off the render path, alongside the sync above.
+    const vtxos: any[] = (await handle.allVtxos()) ?? [];
+
+    const ids: string[] = [];
+    let totalSats = 0;
+    for (const v of vtxos) {
+        const sats = Number(v.amountSats ?? 0n);
+        const expiryHeight = Number(v.expiryHeight ?? 0);
+        const decision = decideChangeRefresh({
+            exitDepth: Number(v.exitDepth ?? 0),
+            sats,
+            blocksUntilExpiry: expiryHeight > 0 ? expiryHeight - tip : null,
+            stateTag: barkStateTag(v.state),
+            alreadyRefreshing: refreshing.has(v.id),
+            exitInProgress: false, // already returned above
+            minSats: ARK_REFRESH_MIN_SATS,
+            minRunwayBlocks,
+        });
+        if (decision.refresh) {
+            ids.push(v.id);
+            totalSats += sats;
+        }
+    }
+
+    if (ids.length === 0) return;
+
+    console.log(
+        `[Ark send] folding ${ids.length} deepened capsule(s) back into a round,`,
+        totalSats, 'sats',
+    );
+    await refreshArkVtxosDelegatedAndSync(ids, totalSats);
+}
+
 export async function executeArkSend(
     dest: ArkDestination,
     amountSats: number,
@@ -504,6 +582,26 @@ export async function executeArkSend(
     } catch (err) {
         console.warn('[Ark send] post-send sync/refresh failed:', err);
     }
+
+    // Fold deepened change back into a round, while the app is definitionally
+    // open. An arkoor spend appends a level to its change, and exitDepth is
+    // exactly the number of transactions a unilateral exit must broadcast and
+    // confirm, so unfolded change makes the wallet progressively more expensive
+    // and slower to exit. Nothing else does this: foregroundSweep only reaches a
+    // capsule in its final week, and useArkoorReceivePrompt is scoped to
+    // capsules that ARRIVE, not to change from the user's own send.
+    //
+    // Evaluates every spendable capsule rather than only the change, because
+    // baseFeeSats is charged per ROUND: if the change is deep enough to be worth
+    // a round, any other deep capsule rides along for free. The change is
+    // necessarily included when it qualifies.
+    //
+    // Best-effort and non-fatal throughout. The send already succeeded, and
+    // decideChangeRefresh owns every safety guard (exit in progress, dust,
+    // runway floor, state, already-in-flight).
+    void maybeRefreshDeepenedChange().catch((err) =>
+        console.warn('[Ark send] post-send change refresh failed:', err),
+    );
 
     // Activity log: only Lightning kinds map to the wallet-cross-cutting
     // "ln-sent" event in the Activity feed. Ark-to-ark and on-chain Ark

--- a/tests/unit/changeRefresh.test.ts
+++ b/tests/unit/changeRefresh.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Folding arkoor change back into a round.
+ *
+ * Depth is created by spending and reset by rounds, and it is exactly the number
+ * of transactions a unilateral exit must broadcast and confirm. Nothing folded
+ * change back before this, so a user who spent accumulated depth until the
+ * expiry sweep reached the capsule in its final week.
+ *
+ * The numbers below are from the 2026-08-22 mainnet wallet, split by state:
+ * live capsules sat at [2, 2, 3, 3, 3, 3, 15, 17], median 3.
+ */
+
+import {
+    ARK_CHANGE_REFRESH_MAX_DEPTH,
+    decideChangeRefresh,
+    type ChangeRefreshInput,
+} from '../../src/services/ark/changeRefresh';
+
+// 28h at 10-minute blocks, matching ARK_EXIT_RUNWAY_HOURS.
+const MIN_RUNWAY = 168;
+const MIN_SATS = 500;
+
+const base: ChangeRefreshInput = {
+    exitDepth: 3,
+    sats: 5_000,
+    blocksUntilExpiry: 4032, // a fresh round output, ~28 days
+    stateTag: 'Spendable',
+    alreadyRefreshing: false,
+    exitInProgress: false,
+    minSats: MIN_SATS,
+    minRunwayBlocks: MIN_RUNWAY,
+};
+
+const decide = (over: Partial<ChangeRefreshInput> = {}) =>
+    decideChangeRefresh({ ...base, ...over });
+
+describe('the depth threshold', () => {
+    it('leaves a normal wallet alone: the measured resting state is 2 to 3', () => {
+        for (const exitDepth of [2, 3]) {
+            expect(decide({ exitDepth })).toEqual({
+                refresh: false,
+                reason: 'shallow-enough',
+            });
+        }
+    });
+
+    it('does not fire at the threshold itself, only above it', () => {
+        expect(decide({ exitDepth: ARK_CHANGE_REFRESH_MAX_DEPTH }).refresh).toBe(false);
+        expect(decide({ exitDepth: ARK_CHANGE_REFRESH_MAX_DEPTH + 1 }).refresh).toBe(true);
+    });
+
+    it('folds back a capsule that several sends have deepened', () => {
+        expect(decide({ exitDepth: 9 })).toEqual({ refresh: true, reason: 'refresh' });
+    });
+
+    it('is high enough that one send off a fresh capsule never triggers it', () => {
+        // Round output is depth 2, so its change is 3. Two more sends: 4, 5.
+        for (const exitDepth of [3, 4, 5]) {
+            expect(decide({ exitDepth }).refresh).toBe(false);
+        }
+    });
+});
+
+describe('what it refuses to do, and why', () => {
+    it('never runs a round while a unilateral exit is active', () => {
+        // A cooperative round would spend a coin already committed on-chain.
+        expect(decide({ exitDepth: 40, exitInProgress: true })).toEqual({
+            refresh: false,
+            reason: 'exit-in-progress',
+        });
+    });
+
+    it('leaves dust alone: one sub-floor input makes the ASP reject the whole round', () => {
+        expect(decide({ exitDepth: 17, sats: 400 })).toEqual({
+            refresh: false,
+            reason: 'below-refresh-minimum',
+        });
+    });
+
+    it('names deep dust as dust, since that is the actionable half', () => {
+        // The two depth-15/17 capsules in the measured wallet were both 400 sats.
+        // They got deep BECAUSE they could never be refreshed alone, so reporting
+        // "too deep" would point at the wrong problem.
+        expect(decide({ exitDepth: 15, sats: 400 }).reason).toBe('below-refresh-minimum');
+    });
+
+    it('will not refresh inside the exit-runway floor, where a hung round eats the exit window', () => {
+        expect(decide({ exitDepth: 20, blocksUntilExpiry: MIN_RUNWAY - 1 })).toEqual({
+            refresh: false,
+            reason: 'too-near-expiry',
+        });
+    });
+
+    it('treats an unreadable expiry as the worst case rather than skipping the check', () => {
+        expect(decide({ exitDepth: 20, blocksUntilExpiry: null }).reason).toBe('unknown-expiry');
+        expect(decide({ exitDepth: 20, blocksUntilExpiry: NaN }).reason).toBe('unknown-expiry');
+    });
+
+    it('does not re-target a capsule another caller already submitted', () => {
+        expect(decide({ exitDepth: 20, alreadyRefreshing: true }).reason).toBe(
+            'already-refreshing',
+        );
+    });
+
+    it('only touches Spendable capsules', () => {
+        for (const stateTag of ['Locked', 'Processing', 'Exited', 'Spent']) {
+            expect(decide({ exitDepth: 20, stateTag }).reason).toBe('not-spendable');
+        }
+    });
+});
+
+describe('the one-week ceiling deliberately does NOT apply here', () => {
+    it('refreshes a deep capsule that is nowhere near expiry', () => {
+        // foregroundSweep skips anything more than a week out, because when the
+        // trigger is expiry there is no reason to pay early. When the trigger is
+        // depth there is: the capsule is expensive to exit for as long as it
+        // stays deep.
+        expect(decide({ exitDepth: 12, blocksUntilExpiry: 4032 })).toEqual({
+            refresh: true,
+            reason: 'refresh',
+        });
+    });
+});


### PR DESCRIPTION
Implements the primary fix from #206.

## The gap

An arkoor spend produces change at `parent depth + 1`, and `exitDepth` is exactly the number of transactions a unilateral exit must broadcast and confirm. Per Second.tech, TRUC relay policy allows one unconfirmed parent plus one child and the CPFP anchor takes the child slot, so those confirm sequentially. Depth is both the fee and the wall clock of an exit.

Nothing folded change back:

- `send.ts` ended with `handle.sync()` and a balance/vtxo refetch. Local state only, no round.
- `useArkoorReceivePrompt` is scoped in its own header to a "**received** Bark capsule (Lightning receive / arkoor)", driven by `movementWatcher`. Money arriving, not change from the user's own spend.

So depth accumulated until `foregroundSweep` reached the VTXO capsule in its final week before expiry.

## Why at send time

The app is **definitionally open**. The user initiated the send, they are holding the phone, the wallet is unlocked. Every other refresh trigger has to answer "how do we reach a user who is not looking", and this one does not. It needs no notification, no background wake, no silent push.

## Why a depth threshold rather than every send

`baseFeeSats` is charged per ROUND, so refreshing after every send is a fee on every send. A threshold charges only the user whose own spending created the depth.

Threshold is **5**. Measured on one wallet, split by state:

| state | n | median depth |
|---|---|---|
| Spent (history) | 178 | 10 |
| **Spendable (live)** | **8** | **3** |

Live VTXO capsules sat at `[2, 2, 3, 3, 3, 3, 15, 17]`. The resting state is 2 to 3, so 5 leaves normal use alone and only fires on a run of sends with no round in between. At roughly 316 vB per tree transaction, 5 caps a single capsule's exit-tree cost near 1,580 vB.

The two depth-15/17 capsules were both 400 sats. They got deep precisely because they were below the 500 sat per-input minimum and could never be refreshed alone, which is why the rule reports those as dust rather than as too-deep: dust is the actionable half.

## Guards

Mirrors `foregroundSweep`'s selection, minus its one-week ceiling. That ceiling exists because when the trigger is **expiry** there is no reason to pay early. When the trigger is **depth** there is: the capsule stays expensive to exit for as long as it stays deep. A test pins that difference.

Everything else is kept: exit in progress, non-Spendable state, already mid-refresh, unreadable expiry, inside the exit-runway floor, and below the refresh minimum.

## Scope note

Evaluates every spendable capsule, not only the change. `baseFeeSats` is per round, so if the change is deep enough to be worth a round then any other deep capsule rides along for free. The change is necessarily included when it qualifies.

## Implementation

`changeRefresh.ts` is pure and import-free, matching `exitClaimBatch.ts` and `refreshBatch.ts`, with **12 unit tests**.

`send.ts` uses lazy `require` for the wiring. Importing `./config` at module scope drags the SDK's `Network` enum into `send.ts`'s graph, which broke `arkSendIndeterminate.test.ts` at load time. Same pattern already used by `notificationHandler.ts` and `backgroundRefresh.ts`.

The call is fire-and-forget and non-fatal: the send has already succeeded by then.

## Verification

- `npx jest -i tests/unit --rootDir .`: **53 suites, 558 passed, 1 skipped**
- `tsc --noEmit`: **400**, matching the post-#208 baseline

## NEEDS DEVICE TESTING BEFORE MERGE

This touches the send path, which is the hottest path in the app, and no automated test exercises the wiring end to end. It needs a real arkoor send on device to confirm:

1. a normal send with shallow change does **not** trigger a round
2. a send that pushes change past depth 5 does trigger exactly one round
3. the fire-and-forget call never blocks or breaks the send UI when the ASP is unreachable
