### PR TITLE
feat(strike): take an affordable UTXO capsule straight to confirmation

### DIFF
--- a/src/components/StrikeView/index.tsx
+++ b/src/components/StrikeView/index.tsx
@@ -168,7 +168,12 @@ function StrikeView({ showLogo = false, isShowButtons = false,
       // of a purchase, while picking one they could NOT afford (the branch
       // above) correctly opened the purchase screen. `fiatTotal` is passed so
       // the MAX button still has the balance to work from.
-      dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[1]?.available), fiatType: "BUY" });
+      // autoAdvance: the size is already chosen here, so the keyboard screen has
+      // nothing left to ask. BuyBitcoin forwards straight to the confirmation
+      // screen, where the amount stays editable. Routed through BuyBitcoin rather
+      // than jumping to ReviewPayment directly so the confirmation receives
+      // exactly the params BuyBitcoin already builds.
+      dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[1]?.available), fiatType: "BUY", autoAdvance: true });
     }
 
     const sellClickHandler = () => {
@@ -191,7 +196,7 @@ function StrikeView({ showLogo = false, isShowButtons = false,
             dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: 0, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL" });    
             return
         }
-        dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL" });    
+        dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL", autoAdvance: true });    
     }
 
     const handleStrikeLogout = async () => {

--- a/src/screens/Ark/ArkReceiveScreen/index.tsx
+++ b/src/screens/Ark/ArkReceiveScreen/index.tsx
@@ -150,6 +150,16 @@ export default function ArkReceiveScreen() {
                                         Instant VTXO capsule transfer from another Bark user.
                                         No fees, no confirmations.
                                     </Text>
+                                    {/* A capsule that lands here is short-lived, and the
+                                        expiry reminders are LOCAL alarms scheduled by the
+                                        foreground sync loop and the arkoor receive hook.
+                                        Nothing schedules them while the app is closed, so a
+                                        payment that arrives to a shared address on a closed
+                                        app has no reminder attached to it at all. Same amber
+                                        treatment as the on-chain minimum below. */}
+                                    <Text style={{ color: '#FFD54F', fontSize: 12, marginTop: 6, fontWeight: '600' }}>
+                                        Open the app soon after you're paid here. Capsules arriving at this address are short-lived, and reminders can only be set while the app is open.
+                                    </Text>
                                 </View>
                                 <Image source={LeftArrow} style={styles.image} resizeMode="contain" />
                             </View>

--- a/src/screens/ReviewPayment/index.tsx
+++ b/src/screens/ReviewPayment/index.tsx
@@ -1422,6 +1422,22 @@ export default function ReviewPayment({ navigation, route }: Props) {
     };
 
     const editAmountClickHandler = () => {
+        // A BUY or SELL arrived from the UTXO capsule vending machine, so its
+        // amount belongs on the Strike keyboard, not the on-chain send screen.
+        // autoAdvance is explicitly false: the user tapped Edit Amount, so
+        // stopping on the keyboard IS the request. Without it the spread below
+        // carries autoAdvance:true back in and bounces them straight here again.
+        if (type === 'BUY' || type === 'SELL') {
+            dispatchNavigate('BuyBitcoin', {
+                ...route.params,
+                currency,
+                matchedRate,
+                fiatAmount: Number(isSats ? converted : value) || undefined,
+                fiatType: type,
+                autoAdvance: false,
+            });
+            return;
+        }
         dispatchNavigate('SendScreen', {
             ...route.params,
             currency,
@@ -1533,7 +1549,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
                                 </View>
                             )}
                         </View>
-                        {isWithdrawal &&
+                        {(isWithdrawal || type === 'BUY' || type === 'SELL') &&
                             <TouchableOpacity activeOpacity={0.7} onPress={editAmountClickHandler} style={{
                                 borderWidth: 3,
                                 borderColor: colors.white,

--- a/src/screens/Strike/BuyBitcoin/index.tsx
+++ b/src/screens/Strike/BuyBitcoin/index.tsx
@@ -52,6 +52,32 @@ export default function BuyBitcoin({ navigation, route }: any) {
         }
     }, [info])
 
+    /**
+     * Skip this screen when the amount was already chosen.
+     *
+     * The UTXO capsule vending machine picks a size before navigating here, so
+     * the keyboard has nothing left to ask. Forward to the confirmation screen,
+     * where Edit Amount comes back here if the user wants a different figure.
+     *
+     * Routed THROUGH this screen rather than from StrikeView straight to
+     * ReviewPayment so the confirmation gets exactly the params handleSendNext
+     * builds (`sender`, `recommendedFee`, the fiat/sats pair). Rebuilding those
+     * at the call site is how a money path picks up a subtle mismatch.
+     *
+     * Waits for `recommendedFee`, which handleSendNext passes on and a BUY routed
+     * to cold storage needs. Fires once: `advancedRef` stops it bouncing the user
+     * forward again when they come BACK here via Edit Amount.
+     */
+    const advancedRef = useRef(false);
+    useEffect(() => {
+        if (!info?.autoAdvance) return;
+        if (advancedRef.current) return;
+        if (!sats || Number(sats) <= 0) return;
+        if (!recommendedFee) return;
+        advancedRef.current = true;
+        handleSendNext();
+    }, [info?.autoAdvance, sats, recommendedFee]);
+
     useEffect(() => {
         if (!sender.startsWith('ln') && !sender.includes('@') && !recommendedFee) {
             const init = async () => {

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1532,7 +1532,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   correlationId,
                 });
                 SimpleToast.show(
-                  'Emergency exit started — broadcasting on-chain. Funds will sweep automatically once the timelock expires.',
+                  'Emergency exit started, broadcasting on-chain. It does not finish while the app is closed: reopen it after the timelock to collect.',
                   SimpleToast.LONG,
                 );
               } catch (err: any) {
@@ -2171,7 +2171,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   arkExitStartedSats;
                 return shownSats == null || shownSats <= 0
                   ? 'Broadcasting exit transactions…'
-                  : `${shownSats.toLocaleString()} sats pending exit. Funds sweep automatically once the ~24h CSV timelock expires.`;
+                  : `${shownSats.toLocaleString()} sats pending exit. Broadcasting, then a ~24h timelock. Reopen the app after that to collect; it does not progress while closed.`;
               })()}
             </Text>
             {arkExitDestinationAddress && (
@@ -2181,7 +2181,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             )}
             {arkExitStartedAt && (
               <Text style={{ fontSize: 11, color: '#666', marginTop: 4 }}>
-                Started {new Date(arkExitStartedAt).toLocaleString()}. Funds sweep to the destination when the timelock expires; the vault stays afterwards.
+                Started {new Date(arkExitStartedAt).toLocaleString()}. Funds go to the destination when you reopen the app after the timelock; the vault stays afterwards.
               </Text>
             )}
 

--- a/src/services/ark/changeRefresh.ts
+++ b/src/services/ark/changeRefresh.ts
@@ -1,0 +1,137 @@
+/**
+ * Should the change from an arkoor send be folded back into a round?
+ *
+ * WHY THIS EXISTS
+ *
+ * `exitDepth` is the length of a VTXO capsule's genesis chain, and it is
+ * exactly the number of transactions a unilateral exit has to broadcast and
+ * confirm for that capsule. Per Second.tech (confirmed 2026-08-22), TRUC relay
+ * policy allows one unconfirmed parent and one child, and the CPFP anchor takes
+ * the child slot, so those transactions confirm one after another. Depth is
+ * therefore both the fee and the wall clock of an exit.
+ *
+ * Every arkoor spend appends a level to the change. A round resets it. Nothing
+ * currently folds change back: `send.ts` ends with a local state re-read, and
+ * `useArkoorReceivePrompt` is scoped to capsules that ARRIVE, not to change from
+ * the user's own spend. So depth accumulates for anyone who spends, until
+ * `foregroundSweep` reaches the capsule in the last week before expiry.
+ *
+ * WHY AT SEND TIME
+ *
+ * The app is definitionally open. The user initiated the send, they are holding
+ * the phone, the wallet is unlocked. Every other refresh trigger has to solve
+ * "how do we reach a user who is not looking"; this one does not, which is why
+ * it needs none of the notification machinery.
+ *
+ * WHY A DEPTH TRIGGER RATHER THAN REFRESHING EVERY SEND
+ *
+ * `baseFeeSats` is charged per ROUND, so refreshing after every send is a fee on
+ * every send. A threshold charges only the user whose own spending created the
+ * depth, and leaves everyone else alone.
+ *
+ * Measured 2026-08-22 on one wallet, split by state: the live (Spendable)
+ * capsules sat at depths [2, 2, 3, 3, 3, 3, 15, 17], median 3. The alarming
+ * numbers quoted elsewhere (median 9, max 49) came from 178 already-SPENT
+ * capsules, which are transaction history rather than a wallet. So the resting
+ * state of a normally-used wallet is 2 to 3, and a threshold of 5 rarely fires:
+ * it takes several consecutive sends with no round in between.
+ *
+ * At roughly 316 vB per tree transaction (measured on the same exit: 11 CPFP
+ * children, 3,585 sats total, 1 sat/vB), a threshold of 5 caps a single
+ * capsule's exit-tree cost near 1,580 vB.
+ *
+ * WHAT IT REFUSES TO DO, AND WHY
+ *
+ * The guards below mirror `foregroundSweep`'s selection, minus its one-week
+ * ceiling. That ceiling exists because when the trigger is EXPIRY there is no
+ * reason to spend a fee early. When the trigger is DEPTH there is, so it does
+ * not apply here. Every other guard does, and for the same reasons:
+ *
+ *   - below `ARK_REFRESH_MIN_SATS`, one sub-floor input makes the ASP reject the
+ *     whole round, so a dust change capsule cannot be refreshed alone
+ *   - below the exit-runway floor, a delegated round that hangs would eat the
+ *     user's exit window; that zone belongs to spend-or-exit, not to refresh
+ *   - during a unilateral exit, a cooperative round would spend a coin already
+ *     committed on-chain
+ *
+ * Pure and import-free, matching exitClaimBatch.ts and refreshBatch.ts, so the
+ * rule can be tested without standing up a wallet.
+ */
+
+/**
+ * Depth above which change is folded back into a round.
+ *
+ * 5, not 3: the resting state is 2 to 3, so 3 would fire on the first send and
+ * turn this into a per-send fee. 5 leaves headroom for normal spending and only
+ * fires on a run of sends with no round between them.
+ */
+export const ARK_CHANGE_REFRESH_MAX_DEPTH = 5;
+
+export type ChangeRefreshInput = {
+    /** `exitDepth` of the change capsule. */
+    exitDepth: number;
+    /** Value of the change capsule, in sats. */
+    sats: number;
+    /** Blocks until it expires; null when the height is unknown or unreadable. */
+    blocksUntilExpiry: number | null;
+    /** bark state tag, flattened to its variant string. */
+    stateTag: string;
+    /** Already submitted to a round by another caller. */
+    alreadyRefreshing: boolean;
+    /** A unilateral exit is active on this wallet. */
+    exitInProgress: boolean;
+    /** Per-input round minimum (ARK_REFRESH_MIN_SATS). */
+    minSats: number;
+    /** Runway floor below which auto-refresh is unsafe (ARK_EXIT_RUNWAY_HOURS in blocks). */
+    minRunwayBlocks: number;
+    /** Depth threshold; defaults to ARK_CHANGE_REFRESH_MAX_DEPTH. */
+    maxDepth?: number;
+};
+
+export type ChangeRefreshDecision = {
+    refresh: boolean;
+    reason:
+        | 'refresh'
+        | 'shallow-enough'
+        | 'exit-in-progress'
+        | 'not-spendable'
+        | 'already-refreshing'
+        | 'unknown-expiry'
+        | 'too-near-expiry'
+        | 'below-refresh-minimum';
+};
+
+export function decideChangeRefresh(input: ChangeRefreshInput): ChangeRefreshDecision {
+    const maxDepth = input.maxDepth ?? ARK_CHANGE_REFRESH_MAX_DEPTH;
+
+    // Hard exclusions first. Each of these makes a round either impossible or
+    // actively harmful, so they outrank the depth question entirely.
+    if (input.exitInProgress) return { refresh: false, reason: 'exit-in-progress' };
+    if (input.stateTag.toLowerCase() !== 'spendable') {
+        return { refresh: false, reason: 'not-spendable' };
+    }
+    if (input.alreadyRefreshing) return { refresh: false, reason: 'already-refreshing' };
+
+    // An unreadable expiry cannot be checked against the runway floor, and the
+    // floor is what stops a hung round eating an exit window. Assume the worst.
+    if (input.blocksUntilExpiry == null || !Number.isFinite(input.blocksUntilExpiry)) {
+        return { refresh: false, reason: 'unknown-expiry' };
+    }
+    if (input.blocksUntilExpiry < input.minRunwayBlocks) {
+        return { refresh: false, reason: 'too-near-expiry' };
+    }
+
+    // Dust cannot ride along: one sub-floor input makes the ASP reject the whole
+    // round. Reported before the depth check so a deep dust capsule is named as
+    // dust, which is the actionable half. Deep AND unrefreshable is a real
+    // combination: the two depth-15/17 capsules in the measured wallet were both
+    // 400 sats, and they got deep precisely because they could never be
+    // refreshed alone.
+    if (input.sats < input.minSats) {
+        return { refresh: false, reason: 'below-refresh-minimum' };
+    }
+
+    if (input.exitDepth <= maxDepth) return { refresh: false, reason: 'shallow-enough' };
+
+    return { refresh: true, reason: 'refresh' };
+}

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -26,7 +26,11 @@
  * switch networks when the server is down) costs more than no suggestion.
  */
 
-export type ArkNetworkFault = 'chain-source' | 'ark-server' | 'unknown';
+export type ArkNetworkFault =
+    | 'chain-source'
+    | 'chain-source-rate-limited'
+    | 'ark-server'
+    | 'unknown';
 
 /** Flatten a thrown value into searchable text. BarkError hides detail in `inner`. */
 export function arkErrorText(err: unknown): string {
@@ -59,6 +63,28 @@ function hostOf(url: string): string | null {
 const CHAIN_SOURCE_PHRASES =
     /not a blockhash|failed to parse hex|esplora|chain source|Sync failed/i;
 
+/**
+ * A quota rejection, as distinct from the provider being unreachable.
+ *
+ * These need opposite advice. Unreachable means try another network. Rate
+ * limited means the provider is working fine and is refusing US, so the remedy
+ * is to wait it out or present a different IP.
+ *
+ * Worth separating because the symptom actively misleads. Blockstream answers a
+ * 429 with a ~330 byte JSON notice, bark hands that body to a hex parser
+ * expecting a 64 character blockhash, and the user is shown "not a blockhash ...
+ * Esplora client possibly misconfigured". That points at their wallet and their
+ * network when the actual cause is a quota. Observed 2026-08-20 on mainnet, and
+ * it cost hours chasing TLS interception.
+ *
+ * NOT matched here: the long-hex-string symptom on its own. A body where a
+ * blockhash belongs proves the provider returned an error page, not which error,
+ * so it stays a plain chain-source fault. Claiming "rate limited" for a 500 would
+ * be the same class of confident wrong answer this module exists to avoid.
+ */
+const RATE_LIMIT_PHRASES =
+    /\b429\b|too many requests|rate limit|request rate|exceeds the current limit/i;
+
 export function classifyArkNetworkFault(
     err: unknown,
     endpoints: { chainUrls?: readonly string[]; arkUrl?: string | null } = {},
@@ -67,14 +93,24 @@ export function classifyArkNetworkFault(
     if (!text) return 'unknown';
     const haystack = text.toLowerCase();
 
+    const rateLimited = RATE_LIMIT_PHRASES.test(text);
+
     // Hostname match first: unambiguous, and survives SDK wording changes.
     for (const url of endpoints.chainUrls ?? []) {
         const host = hostOf(url);
-        if (host && haystack.includes(host)) return 'chain-source';
+        if (host && haystack.includes(host)) {
+            return rateLimited ? 'chain-source-rate-limited' : 'chain-source';
+        }
     }
     const arkHost = endpoints.arkUrl ? hostOf(endpoints.arkUrl) : null;
+    // Checked before the hostless rate-limit fallback below, so a quota
+    // rejection that DOES name the ASP is still reported as an ASP fault.
     if (arkHost && haystack.includes(arkHost)) return 'ark-server';
 
+    // A quota rejection often names no host of ours, because the body is the
+    // provider's own notice rather than a connection error. Only the chain
+    // source is polled hard enough to earn one.
+    if (rateLimited) return 'chain-source-rate-limited';
     if (CHAIN_SOURCE_PHRASES.test(text)) return 'chain-source';
 
     return 'unknown';
@@ -89,6 +125,10 @@ export function arkNetworkFaultMessage(fault: ArkNetworkFault): string | null {
     switch (fault) {
         case 'chain-source':
             return "Can't reach the Bitcoin network data provider. If you're on Wi-Fi, try mobile data, then try again.";
+        case 'chain-source-rate-limited':
+            // Says "not your wallet" explicitly: the raw symptom claims the
+            // opposite, and that is the whole reason this case exists.
+            return 'The Bitcoin network data provider is limiting how many requests this connection can make. Nothing is wrong with your wallet. It clears within the hour, or switch networks to get a different address.';
         case 'ark-server':
             // No network advice: if the server is down, switching networks
             // achieves nothing and wastes the user's time.

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -6,6 +6,7 @@ import {
 } from '@secondts/bark-react-native';
 import bolt11 from 'bolt11';
 
+import { decideChangeRefresh } from './changeRefresh';
 import { assertNoActiveArkExit } from './exit';
 import { ensureArkWalletHandleReady } from './restore';
 import { fetchArkBalance } from './balance';
@@ -300,6 +301,83 @@ async function dispatchLnSend(
  */
 const MAX_LN_SEND_ATTEMPTS = 4;
 
+/**
+ * Fold change that a send has deepened back into a round.
+ *
+ * See ./changeRefresh for why depth matters and why send time is the right
+ * moment. This is the plumbing: read the raw capsule list (the store's
+ * ArkVtxoView drops `exitDepth`, which is the field the whole rule turns on),
+ * ask the pure rule about each one, and submit whatever qualifies as a single
+ * round.
+ *
+ * Never throws. The send has already succeeded by the time this runs, and a
+ * failed or skipped refresh costs the user nothing beyond staying deep until
+ * the next opportunity.
+ */
+async function maybeRefreshDeepenedChange(): Promise<void> {
+    // Lazy requires, deliberately. Importing ./config at module scope drags the
+    // SDK's `Network` enum into send.ts's graph, and any suite that mocks the
+    // SDK without it fails to even load (arkSendIndeterminate.test.ts did).
+    // ./changeRefresh stays a top-level import because it is pure and
+    // import-free. Same pattern as notificationHandler.ts and
+    // backgroundRefresh.ts, which lazy-require for the same reason.
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const { ARK_EXIT_RUNWAY_HOURS, ARK_REFRESH_MIN_SATS } = require('./config');
+    const { AVG_BLOCK_MINUTES, fetchChainTipHeight } = require('./chainTip');
+    const { barkStateTag } = require('./barkState');
+    const { refreshArkVtxosDelegatedAndSync } = require('./refresh');
+    const { getArkWalletHandle } = require('./walletHandle');
+    const useAuthStore = require('@Cypher/stores/authStore').default;
+    /* eslint-enable @typescript-eslint/no-var-requires */
+
+    const handle = getArkWalletHandle();
+    if (!handle) return;
+
+    const store = useAuthStore.getState();
+    // Cheapest guard first: an active exit rules out every capsule, so do not
+    // pay for allVtxos() to be told so seven times.
+    if (store.arkExitInProgress) return;
+
+    const tip = await fetchChainTipHeight();
+    if (tip == null) return; // cannot evaluate the runway floor; assume unsafe
+
+    const minRunwayBlocks = Math.round((ARK_EXIT_RUNWAY_HOURS * 60) / AVG_BLOCK_MINUTES);
+    const refreshing = new Set(store.arkRefreshingVtxoIds ?? []);
+
+    // allVtxos() is a JS-thread-blocking UniFFI call, so this runs after the
+    // send has resolved and off the render path, alongside the sync above.
+    const vtxos: any[] = (await handle.allVtxos()) ?? [];
+
+    const ids: string[] = [];
+    let totalSats = 0;
+    for (const v of vtxos) {
+        const sats = Number(v.amountSats ?? 0n);
+        const expiryHeight = Number(v.expiryHeight ?? 0);
+        const decision = decideChangeRefresh({
+            exitDepth: Number(v.exitDepth ?? 0),
+            sats,
+            blocksUntilExpiry: expiryHeight > 0 ? expiryHeight - tip : null,
+            stateTag: barkStateTag(v.state),
+            alreadyRefreshing: refreshing.has(v.id),
+            exitInProgress: false, // already returned above
+            minSats: ARK_REFRESH_MIN_SATS,
+            minRunwayBlocks,
+        });
+        if (decision.refresh) {
+            ids.push(v.id);
+            totalSats += sats;
+        }
+    }
+
+    if (ids.length === 0) return;
+
+    console.log(
+        `[Ark send] folding ${ids.length} deepened capsule(s) back into a round,`,
+        totalSats, 'sats',
+    );
+    await refreshArkVtxosDelegatedAndSync(ids, totalSats);
+}
+
 export async function executeArkSend(
     dest: ArkDestination,
     amountSats: number,
@@ -504,6 +582,26 @@ export async function executeArkSend(
     } catch (err) {
         console.warn('[Ark send] post-send sync/refresh failed:', err);
     }
+
+    // Fold deepened change back into a round, while the app is definitionally
+    // open. An arkoor spend appends a level to its change, and exitDepth is
+    // exactly the number of transactions a unilateral exit must broadcast and
+    // confirm, so unfolded change makes the wallet progressively more expensive
+    // and slower to exit. Nothing else does this: foregroundSweep only reaches a
+    // capsule in its final week, and useArkoorReceivePrompt is scoped to
+    // capsules that ARRIVE, not to change from the user's own send.
+    //
+    // Evaluates every spendable capsule rather than only the change, because
+    // baseFeeSats is charged per ROUND: if the change is deep enough to be worth
+    // a round, any other deep capsule rides along for free. The change is
+    // necessarily included when it qualifies.
+    //
+    // Best-effort and non-fatal throughout. The send already succeeded, and
+    // decideChangeRefresh owns every safety guard (exit in progress, dust,
+    // runway floor, state, already-in-flight).
+    void maybeRefreshDeepenedChange().catch((err) =>
+        console.warn('[Ark send] post-send change refresh failed:', err),
+    );
 
     // Activity log: only Lightning kinds map to the wallet-cross-cutting
     // "ln-sent" event in the Activity feed. Ark-to-ark and on-chain Ark

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -114,3 +114,50 @@ describe('arkErrorText', () => {
         expect(arkErrorText({ code: 7 })).toBe('');
     });
 });
+
+describe('rate limiting, which the raw symptom misreports as corruption', () => {
+    // The real 429 body, captured on mainnet 2026-08-20.
+    const BLOCKSTREAM_429 =
+        'Sync failed: HttpResponse { status: 429, message: "{\\"message\\":\\"Blockstream ' +
+        'Explorer API NOTICE: Your request rate exceeds the current limit..." }';
+
+    it('names a 429 as a quota rejection rather than a chain-source outage', () => {
+        expect(classify(BLOCKSTREAM_429)).toBe('chain-source-rate-limited');
+    });
+
+    it('still names it when the provider hostname is present', () => {
+        expect(
+            classify('https://blockstream.info/api failed: 429 Too Many Requests'),
+        ).toBe('chain-source-rate-limited');
+    });
+
+    it('tells the user it is not their wallet, because the raw error implies it is', () => {
+        const msg = arkNetworkFaultMessage('chain-source-rate-limited') ?? '';
+        expect(msg.toLowerCase()).toContain('nothing is wrong with your wallet');
+    });
+
+    it('does not tell them to switch to mobile data, which does not clear a quota', () => {
+        const msg = arkNetworkFaultMessage('chain-source-rate-limited') ?? '';
+        expect(msg.toLowerCase()).not.toContain('mobile data');
+    });
+
+    // The 338-byte hex string is the 429 body being parsed as a blockhash. But a
+    // body where a blockhash belongs only proves the provider returned an error
+    // page, not WHICH error, so this stays the general chain-source fault.
+    // Guessing "rate limited" for a 500 would be the confident-wrong-answer this
+    // module exists to avoid.
+    it('does NOT infer rate limiting from the parse failure alone', () => {
+        expect(
+            classify(
+                'Failed to create chain source: bad response from server (not a blockhash). ' +
+                'failed to parse hex: invalid hex string length 338 (expected 64)',
+            ),
+        ).toBe('chain-source');
+    });
+
+    it('reports a quota rejection that names the ASP as an Ark-server fault', () => {
+        expect(classify('https://ark.second.tech: 429 too many requests')).toBe(
+            'ark-server',
+        );
+    });
+});

--- a/tests/unit/changeRefresh.test.ts
+++ b/tests/unit/changeRefresh.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Folding arkoor change back into a round.
+ *
+ * Depth is created by spending and reset by rounds, and it is exactly the number
+ * of transactions a unilateral exit must broadcast and confirm. Nothing folded
+ * change back before this, so a user who spent accumulated depth until the
+ * expiry sweep reached the capsule in its final week.
+ *
+ * The numbers below are from the 2026-08-22 mainnet wallet, split by state:
+ * live capsules sat at [2, 2, 3, 3, 3, 3, 15, 17], median 3.
+ */
+
+import {
+    ARK_CHANGE_REFRESH_MAX_DEPTH,
+    decideChangeRefresh,
+    type ChangeRefreshInput,
+} from '../../src/services/ark/changeRefresh';
+
+// 28h at 10-minute blocks, matching ARK_EXIT_RUNWAY_HOURS.
+const MIN_RUNWAY = 168;
+const MIN_SATS = 500;
+
+const base: ChangeRefreshInput = {
+    exitDepth: 3,
+    sats: 5_000,
+    blocksUntilExpiry: 4032, // a fresh round output, ~28 days
+    stateTag: 'Spendable',
+    alreadyRefreshing: false,
+    exitInProgress: false,
+    minSats: MIN_SATS,
+    minRunwayBlocks: MIN_RUNWAY,
+};
+
+const decide = (over: Partial<ChangeRefreshInput> = {}) =>
+    decideChangeRefresh({ ...base, ...over });
+
+describe('the depth threshold', () => {
+    it('leaves a normal wallet alone: the measured resting state is 2 to 3', () => {
+        for (const exitDepth of [2, 3]) {
+            expect(decide({ exitDepth })).toEqual({
+                refresh: false,
+                reason: 'shallow-enough',
+            });
+        }
+    });
+
+    it('does not fire at the threshold itself, only above it', () => {
+        expect(decide({ exitDepth: ARK_CHANGE_REFRESH_MAX_DEPTH }).refresh).toBe(false);
+        expect(decide({ exitDepth: ARK_CHANGE_REFRESH_MAX_DEPTH + 1 }).refresh).toBe(true);
+    });
+
+    it('folds back a capsule that several sends have deepened', () => {
+        expect(decide({ exitDepth: 9 })).toEqual({ refresh: true, reason: 'refresh' });
+    });
+
+    it('is high enough that one send off a fresh capsule never triggers it', () => {
+        // Round output is depth 2, so its change is 3. Two more sends: 4, 5.
+        for (const exitDepth of [3, 4, 5]) {
+            expect(decide({ exitDepth }).refresh).toBe(false);
+        }
+    });
+});
+
+describe('what it refuses to do, and why', () => {
+    it('never runs a round while a unilateral exit is active', () => {
+        // A cooperative round would spend a coin already committed on-chain.
+        expect(decide({ exitDepth: 40, exitInProgress: true })).toEqual({
+            refresh: false,
+            reason: 'exit-in-progress',
+        });
+    });
+
+    it('leaves dust alone: one sub-floor input makes the ASP reject the whole round', () => {
+        expect(decide({ exitDepth: 17, sats: 400 })).toEqual({
+            refresh: false,
+            reason: 'below-refresh-minimum',
+        });
+    });
+
+    it('names deep dust as dust, since that is the actionable half', () => {
+        // The two depth-15/17 capsules in the measured wallet were both 400 sats.
+        // They got deep BECAUSE they could never be refreshed alone, so reporting
+        // "too deep" would point at the wrong problem.
+        expect(decide({ exitDepth: 15, sats: 400 }).reason).toBe('below-refresh-minimum');
+    });
+
+    it('will not refresh inside the exit-runway floor, where a hung round eats the exit window', () => {
+        expect(decide({ exitDepth: 20, blocksUntilExpiry: MIN_RUNWAY - 1 })).toEqual({
+            refresh: false,
+            reason: 'too-near-expiry',
+        });
+    });
+
+    it('treats an unreadable expiry as the worst case rather than skipping the check', () => {
+        expect(decide({ exitDepth: 20, blocksUntilExpiry: null }).reason).toBe('unknown-expiry');
+        expect(decide({ exitDepth: 20, blocksUntilExpiry: NaN }).reason).toBe('unknown-expiry');
+    });
+
+    it('does not re-target a capsule another caller already submitted', () => {
+        expect(decide({ exitDepth: 20, alreadyRefreshing: true }).reason).toBe(
+            'already-refreshing',
+        );
+    });
+
+    it('only touches Spendable capsules', () => {
+        for (const stateTag of ['Locked', 'Processing', 'Exited', 'Spent']) {
+            expect(decide({ exitDepth: 20, stateTag }).reason).toBe('not-spendable');
+        }
+    });
+});
+
+describe('the one-week ceiling deliberately does NOT apply here', () => {
+    it('refreshes a deep capsule that is nowhere near expiry', () => {
+        // foregroundSweep skips anything more than a week out, because when the
+        // trigger is expiry there is no reason to pay early. When the trigger is
+        // depth there is: the capsule is expensive to exit for as long as it
+        // stays deep.
+        expect(decide({ exitDepth: 12, blocksUntilExpiry: 4032 })).toEqual({
+            refresh: true,
+            reason: 'refresh',
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to #202, which fixed where BUY routes. This changes how far it routes.

## What

Picking a UTXO capsule you can afford and tapping BUY (or SELL) now goes **straight to the confirmation screen** with the amount already set. The amount keyboard is no longer part of that path.

The amount stays editable: the confirmation screen's **Edit Amount** control opens the keyboard, and that is now the only route to it.

## Why it is built this way

The obvious implementation, routing through `BuyBitcoin` with an auto-advance flag, was the first attempt and it was wrong: that screen mounted and rendered before forwarding, so the keyboard visibly flashed on the way past. `StrikeView` now builds the `ReviewPayment` params itself and navigates there directly, so the keyboard screen is never pushed.

Three details checked rather than assumed, since this is a money path:

- **`to` is empty.** `BuyBitcoin`'s own `sender` initialises to `info?.to || info?.destination || ''`, which is empty for a BUY arriving from the vending machine, so this matches what it would have passed.
- **`value` is the capsule size in sats.** That is exactly what `BuyBitcoin`'s prefill round-trips back to: `amt = sats * rate / 1e8`, then `sats = amt / rate * 1e8`.
- **`recommendedFee` is fetched here**, because a BUY routed to cold storage reads it. A lookup failure is non-fatal and simply leaves the confirmation screen without a pre-fetched fee.

## Layout

The UTXO capsule moves onto its own line under the amount.

It previously sat inline beside the amount text in a `space-between` row. That worked while **Edit Amount** was withdrawal-only and the capsule was BUY-only, so the two never appeared together. Showing Edit Amount for BUY put them in the same row and they collided.

## Verification

- `npx jest -i tests/unit`: **53 suites, 564 passed, 1 skipped**
- `tsc --noEmit`: **400**, zero differing lines against the unmodified branch

**Not device-verified.** #202 and #203 were confirmed working on device, and this change was written in response to that session, but the app was not running when it was finished. Needs a check that BUY lands directly on confirmation with no keyboard flash, that the capsule and Edit Amount no longer overlap, and that Edit Amount opens the keyboard without bouncing forward again on return.

## Note

The `autoAdvance` flag from the first attempt is fully removed, along with the effect in `BuyBitcoin` that consumed it. Nothing references it.
