### PR TITLE
fix(ark): stop the change refresh firing twice for the same capsule

### DIFF
--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -314,7 +314,29 @@ const MAX_LN_SEND_ATTEMPTS = 4;
  * failed or skipped refresh costs the user nothing beyond staying deep until
  * the next opportunity.
  */
+/**
+ * One change-refresh at a time, per JS process.
+ *
+ * `decideChangeRefresh` takes an `alreadyRefreshing` flag sourced from
+ * `arkRefreshingVtxoIds` in the store, and that is NOT sufficient on its own:
+ * the store is written after the round is submitted, so two calls that arrive
+ * close together both read an empty set and both submit.
+ *
+ * Observed live 2026-08-24: a single send produced two `folding 1 deepened
+ * capsule(s)` calls 91 seconds apart for the same capsule, the second landing
+ * while the first round was still `finalising`. It happened to be accepted that
+ * time, but the identical race between the receive hook and foregroundSweep an
+ * hour earlier produced `bad user input: input vtxo(s) unusable` from the ASP
+ * and left the wallet showing a stuck refresh until the round was re-driven.
+ *
+ * So the store flag stays (it is what stops OTHER callers colliding with us),
+ * and this module-level latch stops us colliding with ourselves. Same shape as
+ * `sweepInFlight` in ./foregroundSweep.
+ */
+let changeRefreshInFlight = false;
+
 async function maybeRefreshDeepenedChange(): Promise<void> {
+    if (changeRefreshInFlight) return;
     // Lazy requires, deliberately. Importing ./config at module scope drags the
     // SDK's `Network` enum into send.ts's graph, and any suite that mocks the
     // SDK without it fails to even load (arkSendIndeterminate.test.ts did).
@@ -375,7 +397,12 @@ async function maybeRefreshDeepenedChange(): Promise<void> {
         `[Ark send] folding ${ids.length} deepened capsule(s) back into a round,`,
         totalSats, 'sats',
     );
-    await refreshArkVtxosDelegatedAndSync(ids, totalSats);
+    changeRefreshInFlight = true;
+    try {
+        await refreshArkVtxosDelegatedAndSync(ids, totalSats);
+    } finally {
+        changeRefreshInFlight = false;
+    }
 }
 
 export async function executeArkSend(


### PR DESCRIPTION
Follow-up to #211, which is already merged. **The race described below is on `main` right now.**

## What happened

Device testing #211 on mainnet, a single arkoor send produced **two** refresh submissions for the same VTXO capsule:

```
01:14:53  [Ark send] folding 1 deepened capsule(s) back into a round, 976 sats
01:14:53  [Ark refresh] refreshVtxosDelegated() calling for 1 vtxo(s)
01:16:24  [Ark send] folding 1 deepened capsule(s) back into a round, 976 sats
01:16:24  [Ark refresh] refreshVtxosDelegated() calling for 1 vtxo(s)
```

91 seconds apart, same capsule, same amount. The second landed while the first round was still `61(finalising)`.

## Why the existing guard did not hold

`decideChangeRefresh` takes an `alreadyRefreshing` flag sourced from `arkRefreshingVtxoIds`. That store is written **after** the round is submitted, so two calls arriving close together both read an empty set and both submit. The guard is correct in principle and simply too late in practice.

## Why it matters, despite being harmless on the day

That particular pair was accepted, so nothing broke. But the **identical race between the arkoor receive hook and `foregroundSweep`, an hour earlier on the same wallet**, produced:

```
error submitting round participation to server:
code: 'Client specified an invalid argument'
message: "unusable inputs: [e6e70446...]: bad user input: input vtxo(s) unusable"
```

and left the wallet showing a stuck refresh with `pendingRound = 1996` until the round was re-driven. Same shape, worse timing, real user impact.

Whether a collision is harmless or wedges the wallet depends purely on where the other round is in its lifecycle. That is not a property to leave to chance on a money path.

## The fix

A module-level latch so this path cannot collide with itself, mirroring `sweepInFlight` in `foregroundSweep.ts`. The store flag stays, since that is what keeps *other* callers from colliding with us; this only closes the self-collision.

Five lines plus the comment explaining the ordering, so the next person does not remove it believing the store flag is sufficient.

## Wider issue, not fixed here

`arkRefreshingVtxoIds` is not a usable mutual-exclusion primitive for round submission, because it is written too late. **Three paths now submit rounds**: the arkoor receive hook, `foregroundSweep`, and change refresh. Any pair of them can collide exactly this way, and one such pair already did today. Recorded in #206.

## Verification

- `npx jest -i tests/unit`: **53 suites, 564 passed, 1 skipped**
- `tsc --noEmit`: **400**, matching the baseline

Not separately device-verified. The behaviour it prevents was observed on device; the latch itself is a guard against that recurrence.
