### PR TITLE
fix(ark): log every wallet-open attempt, and say why rotation stopped

### DIFF
--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -139,7 +139,14 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
             // on attempt 1 and never tries the working fallback, and the wallet
             // never opens (handle-not-ready spam, empty balance, exit gated).
             const transient = /ServerConnection|Connection|timeout|timed out|network|bad response from server|not a blockhash|failed to parse hex|Esplora client/i.test(detail);
-            if (!transient || attempt === OPEN_ATTEMPTS) break;
+            const stopping = !transient || attempt === OPEN_ATTEMPTS;
+            // LOG BEFORE DECIDING TO STOP. This used to break out of the loop
+            // before logging, so a non-transient failure left NO trace at all:
+            // the last thing on screen was "attempt 1/5 via blockstream", which
+            // reads as "it never rotated" when it may well have rotated and died
+            // silently on the next provider. Cost a live debugging session on
+            // 2026-08-24, where a rate-limited wallet would not open and the log
+            // could not say which providers had actually been tried.
             if (__DEV__) {
                 // Stringify the inner UniFFI payload inline: the tag alone
                 // (BarkError.ServerConnection) hides whether the failure was
@@ -149,9 +156,13 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
                     `[Ark restore] open attempt ${attempt}/${OPEN_ATTEMPTS} via ${esploraUrl} failed (${detail.trim()}); ` +
                     `inner=${e?.inner?.errorMessage ?? e?.inner?.message ?? 'n/a'} ` +
                     `raw=${JSON.stringify(e, Object.getOwnPropertyNames(e ?? {}))}; ` +
-                    `retrying in ${OPEN_RETRY_DELAY_MS}ms`,
+                    (stopping
+                        ? `GIVING UP (${!transient ? 'non-transient error' : 'attempts exhausted'}); ` +
+                          `providers tried: ${ESPLORA_URLS.slice(0, attempt).join(', ')}`
+                        : `retrying in ${OPEN_RETRY_DELAY_MS}ms via ${ESPLORA_URLS[attempt % ESPLORA_URLS.length]}`),
                 );
             }
+            if (stopping) break;
             await new Promise((r) => setTimeout(r, OPEN_RETRY_DELAY_MS));
         }
     }


### PR DESCRIPTION
Addresses the diagnosability half of #194 fix 2.

## What I thought the bug was

During a live 429 on 2026-08-24, the wallet would not open and the log read:

```
3 x  [Ark restore] open attempt 1/5 via https://blockstream.info/api failed
0 x  any attempt 2
```

I reported that as "the open path never rotates, despite four providers configured".

## What it actually is

The rotation logic is correct:

```js
const esploraUrl = ESPLORA_URLS[(attempt - 1) % ESPLORA_URLS.length];
```

The defect is ordering. The loop broke **before** logging:

```js
if (!transient || attempt === OPEN_ATTEMPTS) break;   // breaks first
if (__DEV__) { console.log(`open attempt ${attempt}/${OPEN_ATTEMPTS} ...`); }
```

So a non-transient failure produced **no log line at all**. Only attempts that were about to be retried ever printed. The loop may well have rotated to `mempool.space` and died there silently, which is indistinguishable from never rotating.

That is why I could not tell you which providers had been tried, and it is why I gave you a wrong diagnosis with confidence.

## Fix

Log first, then decide. Every attempt now prints, and the final line states:

- whether it stopped on a **non-transient error** or **exhausted attempts**
- **which providers were actually tried**

A retry also names the provider it is about to use, so rotation is visible as it happens rather than reconstructed afterwards.

## Deliberately no behaviour change

The open question this exposes is whether a non-transient failure from one provider should abort the whole loop, or whether the remaining providers deserve a try. Right now the first non-provider-shaped error ends it, so providers 3 and 4 may never be reached.

That could be wrong. It could also be correct, since a seed or datadir mismatch will fail identically everywhere and retrying five times just burns 30 seconds.

**I do not have the data to decide**, precisely because the old code discarded it. This PR is the instrumentation needed to answer it from evidence rather than by guessing, and the next 429 will produce that evidence.

## Verification

- `npx jest -i tests/unit`: **53 suites, 564 passed, 1 skipped**
- `tsc --noEmit`: **400**, matching baseline

DEV-only logging, no production path affected.

## Still open in #194

Fix 2 proper (budget requests per provider per rolling hour and rotate *before* the cap), fix 3 (cut exit-drive consumption), fix 4 (API key or own chain source). This only makes the existing rotation observable.
