### PR TITLE
fix(ark): route around a burned chain source instead of walking back into it

### DIFF
--- a/src/services/ark/esploraProviders.ts
+++ b/src/services/ark/esploraProviders.ts
@@ -60,3 +60,99 @@ export function esploraOperator(url: string): string {
     const host = url.replace(/^https?:\/\//, '').split('/')[0];
     return host.split('.').slice(-2).join('.');
 }
+
+/**
+ * How long a provider stays out of rotation after failing.
+ *
+ * Split by CAUSE, because the two failures have very different recovery times.
+ * A 429 from Blockstream is an hourly quota: coming back in five minutes just
+ * spends another request to be told the same thing. A connection failure is
+ * usually transient and the host may be back almost immediately.
+ *
+ * These are deliberately not equal, and that asymmetry is the whole point of
+ * tracking the cause rather than just "it failed".
+ */
+export const ESPLORA_RATE_LIMIT_COOLDOWN_MS = 60 * 60 * 1000;
+export const ESPLORA_UNREACHABLE_COOLDOWN_MS = 5 * 60 * 1000;
+
+export type EsploraFailureKind = 'rate-limited' | 'unreachable';
+
+/** When a provider last failed, and why. Absent means never failed. */
+export type EsploraHealth = Record<string, { failedAt: number; kind: EsploraFailureKind }>;
+
+/**
+ * Classify an open/fetch failure so the cooldown can be sized to it.
+ *
+ * A 429 body reaches us disguised: Blockstream answers with a ~330 byte JSON
+ * notice, bark feeds it to a hex parser expecting a blockhash, and the error
+ * says "not a blockhash ... invalid hex string length 338". So the hex-length
+ * complaint IS a rate-limit tell in this specific context, unlike in
+ * networkFault.ts where it stays ambiguous because any error page produces it.
+ * Here the cost of guessing wrong is only a longer cooldown on one provider.
+ */
+export function classifyEsploraFailure(detail: string): EsploraFailureKind {
+    if (/\b429\b|too many requests|rate limit|request rate|exceeds the current limit/i.test(detail)) {
+        return 'rate-limited';
+    }
+    if (/invalid hex string length|not a blockhash|failed to parse hex/i.test(detail)) {
+        return 'rate-limited';
+    }
+    return 'unreachable';
+}
+
+function cooldownFor(kind: EsploraFailureKind): number {
+    return kind === 'rate-limited'
+        ? ESPLORA_RATE_LIMIT_COOLDOWN_MS
+        : ESPLORA_UNREACHABLE_COOLDOWN_MS;
+}
+
+/**
+ * Pick the provider to try next, skipping any still cooling down.
+ *
+ * Rules, in order:
+ *
+ *  1. Prefer providers in list order that are NOT cooling down. A healthy
+ *     wallet therefore keeps talking to exactly one provider, which is the
+ *     privacy property the list ordering already documents.
+ *  2. Among those, skip one whose OPERATOR just failed, so a Blockstream 429
+ *     does not immediately retry another Blockstream host. Falls back to
+ *     allowing the same operator if that leaves nothing.
+ *  3. If everything is cooling down, return the one whose cooldown expires
+ *     SOONEST rather than nothing. A stale provider is worth more than no
+ *     chain source at all, and the caller has no better option.
+ *
+ * Never returns null: the caller always needs somewhere to point.
+ */
+export function chooseEsploraProvider(args: {
+    urls: readonly string[];
+    health: EsploraHealth;
+    now: number;
+}): { url: string; coolingDown: boolean } {
+    const { urls, health, now } = args;
+    const isCooling = (u: string) => {
+        const h = health[u];
+        return h != null && now - h.failedAt < cooldownFor(h.kind);
+    };
+
+    const available = urls.filter((u) => !isCooling(u));
+    if (available.length > 0) {
+        // Avoid an operator that failed recently, even if a different host of
+        // theirs has no record of its own: a quota is per IP-and-operator, not
+        // per hostname.
+        const burnedOperators = new Set(
+            urls.filter(isCooling).map((u) => esploraOperator(u)),
+        );
+        const clean = available.filter((u) => !burnedOperators.has(esploraOperator(u)));
+        return { url: (clean[0] ?? available[0]) as string, coolingDown: false };
+    }
+
+    // Everything is cooling. Take whichever recovers first.
+    const soonest = [...urls].sort((a, b) => {
+        const ha = health[a];
+        const hb = health[b];
+        const ea = ha ? ha.failedAt + cooldownFor(ha.kind) : 0;
+        const eb = hb ? hb.failedAt + cooldownFor(hb.kind) : 0;
+        return ea - eb;
+    })[0];
+    return { url: soonest as string, coolingDown: true };
+}

--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -2,7 +2,12 @@ import RNFS from 'react-native-fs';
 import * as Keychain from 'react-native-keychain';
 
 import { ESPLORA_URLS } from './config';
-import { ESPLORA_OPEN_ATTEMPTS } from './esploraProviders';
+import {
+    chooseEsploraProvider,
+    classifyEsploraFailure,
+    ESPLORA_OPEN_ATTEMPTS,
+    type EsploraHealth,
+} from './esploraProviders';
 import { ARK_DATADIR } from './datadir';
 import { cacheArkMnemonicForReopen, getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
 
@@ -113,10 +118,31 @@ export async function restoreArkWalletFromDisk(): Promise<ArkRestoreResult> {
  * (restoreArkWalletFromDisk, reopenArkWalletFromCache) own the openInFlight
  * guard around this.
  */
+/**
+ * Which providers have failed recently, and why.
+ *
+ * Module-level so it outlives a single open loop: the sync loop's self-heal
+ * calls this every tick, and without memory each call restarted at the first
+ * provider and re-earned the same 429. Resets on app restart, which is fine,
+ * the first failure re-learns it.
+ */
+const esploraHealth: EsploraHealth = {};
+
 async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
     let lastErr: Error | undefined;
     for (let attempt = 1; attempt <= OPEN_ATTEMPTS; attempt++) {
-        const esploraUrl = ESPLORA_URLS[(attempt - 1) % ESPLORA_URLS.length];
+        // Health-driven, not round-robin. The old `(attempt - 1) % len` walked
+        // the list blind, so a provider that had just answered 429 was tried
+        // again a few attempts later, spending a request to be told the same
+        // thing. Now a failure records WHY, and the chooser skips that provider
+        // for as long as the cause warrants: an hour for a quota, five minutes
+        // for an unreachable host.
+        const choice = chooseEsploraProvider({
+            urls: ESPLORA_URLS,
+            health: esploraHealth,
+            now: Date.now(),
+        });
+        const esploraUrl = choice.url;
         try {
             await openArkWallet(seed, { esploraUrl });
             if (__DEV__ && (attempt > 1 || esploraUrl !== ESPLORA_URLS[0])) {
@@ -138,6 +164,11 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
             // alongside the raw connection errors — otherwise the loop breaks
             // on attempt 1 and never tries the working fallback, and the wallet
             // never opens (handle-not-ready spam, empty balance, exit gated).
+            // Record the failure BEFORE deciding what to do, so the next
+            // attempt in this same loop already routes around this provider.
+            const kind = classifyEsploraFailure(detail);
+            esploraHealth[esploraUrl] = { failedAt: Date.now(), kind };
+
             const transient = /ServerConnection|Connection|timeout|timed out|network|bad response from server|not a blockhash|failed to parse hex|Esplora client/i.test(detail);
             const stopping = !transient || attempt === OPEN_ATTEMPTS;
             // LOG BEFORE DECIDING TO STOP. This used to break out of the loop
@@ -156,10 +187,11 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
                     `[Ark restore] open attempt ${attempt}/${OPEN_ATTEMPTS} via ${esploraUrl} failed (${detail.trim()}); ` +
                     `inner=${e?.inner?.errorMessage ?? e?.inner?.message ?? 'n/a'} ` +
                     `raw=${JSON.stringify(e, Object.getOwnPropertyNames(e ?? {}))}; ` +
+                    `classified=${kind}; ` +
                     (stopping
                         ? `GIVING UP (${!transient ? 'non-transient error' : 'attempts exhausted'}); ` +
-                          `providers tried: ${ESPLORA_URLS.slice(0, attempt).join(', ')}`
-                        : `retrying in ${OPEN_RETRY_DELAY_MS}ms via ${ESPLORA_URLS[attempt % ESPLORA_URLS.length]}`),
+                          `providers tried: ${Object.keys(esploraHealth).join(', ')}`
+                        : `retrying in ${OPEN_RETRY_DELAY_MS}ms`),
                 );
             }
             if (stopping) break;

--- a/tests/unit/esploraProviders.test.ts
+++ b/tests/unit/esploraProviders.test.ts
@@ -1,7 +1,11 @@
 import {
-  ESPLORA_FALLBACK_URLS,
-  ESPLORA_OPEN_ATTEMPTS,
-  esploraOperator,
+    ESPLORA_FALLBACK_URLS,
+    ESPLORA_OPEN_ATTEMPTS,
+    esploraOperator,
+    chooseEsploraProvider,
+    classifyEsploraFailure,
+    ESPLORA_RATE_LIMIT_COOLDOWN_MS,
+    type EsploraHealth,
 } from '../../src/services/ark/esploraProviders';
 
 describe('esplora fallback list', () => {
@@ -51,4 +55,86 @@ describe('esplora fallback list', () => {
     expect(esploraOperator('https://blockstream.info/api')).toBe('blockstream.info');
     expect(esploraOperator('https://mempool.emzy.de/api')).toBe('emzy.de');
   });
+});
+
+describe('provider health, so rotation does not walk back into a burned provider', () => {
+    const URLS = [
+        'https://blockstream.info/api',
+        'https://mempool.space/api',
+        'https://mempool.emzy.de/api',
+        'https://mempool.va1.mempool.space/api',
+    ];
+    const NOW = 1_700_000_000_000;
+    const pick = (health: EsploraHealth, now = NOW) =>
+        chooseEsploraProvider({ urls: URLS, health, now });
+
+    it('a healthy wallet keeps using exactly one provider', () => {
+        // The privacy property: extra entries only change who sees an address
+        // when the alternative is not working at all.
+        expect(pick({}).url).toBe(URLS[0]);
+        expect(pick({}).coolingDown).toBe(false);
+    });
+
+    it('skips a rate-limited provider instead of retrying into the quota', () => {
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW - 60_000, kind: 'rate-limited' },
+        };
+        expect(pick(h).url).not.toBe(URLS[0]);
+    });
+
+    it('keeps a 429 out of rotation far longer than an unreachable host', () => {
+        const rl: EsploraHealth = { [URLS[0]]: { failedAt: NOW, kind: 'rate-limited' } };
+        const un: EsploraHealth = { [URLS[0]]: { failedAt: NOW, kind: 'unreachable' } };
+        const tenMin = NOW + 10 * 60 * 1000;
+        // Ten minutes on: the unreachable host is back, the quota is not.
+        expect(pick(un, tenMin).url).toBe(URLS[0]);
+        expect(pick(rl, tenMin).url).not.toBe(URLS[0]);
+    });
+
+    it('returns a rate-limited provider once its hour is up', () => {
+        const h: EsploraHealth = { [URLS[0]]: { failedAt: NOW, kind: 'rate-limited' } };
+        expect(pick(h, NOW + ESPLORA_RATE_LIMIT_COOLDOWN_MS + 1).url).toBe(URLS[0]);
+    });
+
+    it('avoids another host from the operator that just failed', () => {
+        // mempool.space apex burned; the va1 node is the same operator, so the
+        // community mirror should win even though it is later in the list.
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW, kind: 'rate-limited' },
+            [URLS[1]]: { failedAt: NOW, kind: 'rate-limited' },
+        };
+        expect(pick(h).url).toBe('https://mempool.emzy.de/api');
+    });
+
+    it('never returns nothing: falls back to whichever recovers soonest', () => {
+        // A stale provider beats having no chain source, which is what left a
+        // wallet unopenable and an in-flight exit stalled.
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW, kind: 'rate-limited' },
+            [URLS[1]]: { failedAt: NOW, kind: 'rate-limited' },
+            [URLS[2]]: { failedAt: NOW - 4 * 60 * 1000, kind: 'unreachable' },
+            [URLS[3]]: { failedAt: NOW, kind: 'rate-limited' },
+        };
+        const got = pick(h);
+        expect(got.coolingDown).toBe(true);
+        expect(got.url).toBe(URLS[2]); // unreachable 4 min ago, 1 min left
+    });
+});
+
+describe('classifying an esplora failure', () => {
+    it('reads the disguised 429: a 338-byte "hex string" is the notice body', () => {
+        expect(
+            classifyEsploraFailure(
+                'bad response from server (not a blockhash). failed to parse hex: invalid hex string length 338 (expected 64)',
+            ),
+        ).toBe('rate-limited');
+    });
+
+    it('reads an explicit 429', () => {
+        expect(classifyEsploraFailure('HttpResponse { status: 429 }')).toBe('rate-limited');
+    });
+
+    it('treats a connection failure as unreachable, which cools down briefly', () => {
+        expect(classifyEsploraFailure('ServerConnection: timed out')).toBe('unreachable');
+    });
 });


### PR DESCRIPTION
Addresses the achievable half of #194 fix 2.

## What was wrong

The open loop chose its provider by position:

```js
const esploraUrl = ESPLORA_URLS[(attempt - 1) % ESPLORA_URLS.length];
```

That walks the list blind. A provider that had just answered 429 got tried again a few attempts later, spending another request to be told the same thing. Worse, the sync loop's self-heal calls this every tick with no memory between calls, so it restarted at the first provider and re-earned the same quota rejection indefinitely.

Observed live 2026-08-24: a rate-limited phone could not open its wallet at all, while the same endpoints answered instantly from a laptop on the same network.

## What it does now

Selection is driven by recorded health. Each failure is classified and remembered, and the chooser skips that provider for as long as the cause warrants:

| cause | cooldown |
|---|---|
| rate limited | **1 hour** |
| unreachable | **5 minutes** |

Deliberately unequal. A 429 is an hourly quota, so returning in five minutes just burns another request. A connection failure is usually transient. That asymmetry is the entire reason for tracking *why* something failed rather than just that it did.

Three further rules, each with a test:

- **A healthy wallet still uses exactly one provider.** Rotation only happens after a failure, preserving the privacy property the list ordering already documents.
- **Avoids another host from an operator that just failed.** A quota is per IP and operator, not per hostname, so a `mempool.space` 429 should not send us to `mempool.va1.mempool.space`.
- **Never returns nothing.** If everything is cooling down it returns whichever recovers soonest. A stale chain source beats none, and "none" is exactly what left a wallet unopenable with an in-flight exit stalled behind it.

## Classifying the disguised 429

Blockstream answers a rate-limited request with a ~330 byte JSON notice, which bark feeds to a hex parser expecting a blockhash. So `invalid hex string length 338` **is** the quota tell in this context.

Note this differs from `networkFault.ts` on purpose. There I refused to infer rate limiting from the same symptom, because a 500 or a Cloudflare page produces it too and a wrong message misleads the user. Here the only consequence of guessing wrong is a longer cooldown on one provider, so the trade runs the other way.

## What this is NOT

**It is not a request budget**, which is what #194 fix 2 literally asks for. bark makes its own esplora calls that JS cannot see, and the 700/hour cap is per IP across all of them, so counting from JS would only ever see a small fraction. A number that looked like a budget but tracked the wrong denominator would be worse than none.

This fixes the half that is reachable: not rotating into a provider already known to be refusing us. A real budget needs either bark exposing its request count or an API key removing the cap, which is fix 4.

## Verification

- `npx jest -i tests/unit`: **53 suites, 573 passed, 1 skipped** (9 new)
- `tsc --noEmit`: **400**, matching baseline

Not device-verified. Reproducing it needs a live 429, which we cannot force. The logging from #214 will show the routing when one next occurs.
