### PR TITLE
fix(strike): recover the confirmation-flash and capsule-overlap fix that never reached main

### DIFF
--- a/src/components/StrikeView/index.tsx
+++ b/src/components/StrikeView/index.tsx
@@ -13,6 +13,7 @@ import useAuthStore from '@Cypher/stores/authStore'
 import SimpleToast from "react-native-simple-toast";
 import { useNavigation } from '@react-navigation/native'
 import { getBankPaymentMethods, initiateDeposit, createPayout, initiatePayout, revokeStrikeToken } from '@Cypher/api/strikeAPIs'
+import { bitcoinRecommendedFee } from '@Cypher/api/coinOSApis'
 import { colors } from '@Cypher/style-guide'
 
 interface Props {
@@ -145,6 +146,45 @@ function StrikeView({ showLogo = false, isShowButtons = false,
       }
     }
 
+    /**
+     * Straight to the confirmation screen, skipping the amount keyboard.
+     *
+     * Mirrors what BuyBitcoin's handleSendNext passes, because that screen is
+     * still reachable via Edit Amount on the confirmation screen and both paths
+     * must land ReviewPayment in the same shape.
+     *
+     * `recommendedFee` is fetched rather than omitted: a BUY routed to cold
+     * storage reads it. A failure here is non-fatal, the confirmation screen
+     * simply has no pre-fetched fee.
+     */
+    const goToBuyConfirmation = async (
+      fiatAmount: number,
+      satsAmount: number,
+      fiatType: 'BUY' | 'SELL',
+      fiatTotal: number,
+    ) => {
+      let recommendedFee: any;
+      try {
+        recommendedFee = await bitcoinRecommendedFee();
+      } catch (err) {
+        console.warn('[StrikeView] recommended fee lookup failed, continuing:', err);
+      }
+      dispatchNavigate('ReviewPayment', {
+        currency: safeCurrency,
+        matchedRate,
+        fiatAmount,
+        fiatTotal,
+        fiatType,
+        value: String(satsAmount),
+        converted: fiatAmount.toFixed(2),
+        isSats: true,
+        to: '',
+        fees: 0,
+        type: fiatType,
+        recommendedFee,
+      });
+    }
+
     const buyClickHandler = () => {
       const amt = Number(dollarStrikeText * (Number(matchedRate) || 0) * btc(1))
       console.log('amt: ', amt, strikeUser?.[1]?.available)
@@ -168,12 +208,13 @@ function StrikeView({ showLogo = false, isShowButtons = false,
       // of a purchase, while picking one they could NOT afford (the branch
       // above) correctly opened the purchase screen. `fiatTotal` is passed so
       // the MAX button still has the balance to work from.
-      // autoAdvance: the size is already chosen here, so the keyboard screen has
-      // nothing left to ask. BuyBitcoin forwards straight to the confirmation
-      // screen, where the amount stays editable. Routed through BuyBitcoin rather
-      // than jumping to ReviewPayment directly so the confirmation receives
-      // exactly the params BuyBitcoin already builds.
-      dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[1]?.available), fiatType: "BUY", autoAdvance: true });
+      // The size is already chosen here, so the keyboard screen has nothing left
+      // to ask. Go straight to confirmation. Routing via BuyBitcoin made it
+      // render first and flash on screen, so its ReviewPayment params are built
+      // here instead: `to` is '' because BuyBitcoin's `sender` defaults to '' for
+      // a BUY, and `value` is the capsule size, which is what its own prefill
+      // round-trips back to (amt = sats * rate / 1e8, then sats = amt / rate * 1e8).
+      goToBuyConfirmation(amt, dollarStrikeText, "BUY", Number(strikeUser?.[1]?.available));
     }
 
     const sellClickHandler = () => {
@@ -196,7 +237,7 @@ function StrikeView({ showLogo = false, isShowButtons = false,
             dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: 0, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL" });    
             return
         }
-        dispatchNavigate('BuyBitcoin', { currency: safeCurrency, matchedRate, fiatAmount: amt, fiatTotal: Number(strikeUser?.[0]?.available), fiatType: "SELL", autoAdvance: true });    
+        goToBuyConfirmation(amt, dollarStrikeText, "SELL", Number(strikeUser?.[0]?.available));
     }
 
     const handleStrikeLogout = async () => {

--- a/src/screens/ReviewPayment/index.tsx
+++ b/src/screens/ReviewPayment/index.tsx
@@ -1424,9 +1424,8 @@ export default function ReviewPayment({ navigation, route }: Props) {
     const editAmountClickHandler = () => {
         // A BUY or SELL arrived from the UTXO capsule vending machine, so its
         // amount belongs on the Strike keyboard, not the on-chain send screen.
-        // autoAdvance is explicitly false: the user tapped Edit Amount, so
-        // stopping on the keyboard IS the request. Without it the spread below
-        // carries autoAdvance:true back in and bounces them straight here again.
+        // This is the only way back to that keyboard now that the vending
+        // machine goes straight to confirmation.
         if (type === 'BUY' || type === 'SELL') {
             dispatchNavigate('BuyBitcoin', {
                 ...route.params,
@@ -1434,7 +1433,6 @@ export default function ReviewPayment({ navigation, route }: Props) {
                 matchedRate,
                 fiatAmount: Number(isSats ? converted : value) || undefined,
                 fiatType: type,
-                autoAdvance: false,
             });
             return;
         }
@@ -1537,17 +1535,6 @@ export default function ReviewPayment({ navigation, route }: Props) {
                     <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', marginRight: 15, marginTop: 10 }}>
                         <View style={{ flexDirection: 'row', alignItems: 'center', flexShrink: 1 }}>
                             <TextViewV2 keytext={type == 'SELL' ? "You will sell: " : type == 'BUY' ? "You will receive: " : "Recipient will get: "} text={isSats ? `${value} sats ~ ${getStrikeCurrency(currency || 'USD')}${converted}` : `${getStrikeCurrency(currency || 'USD')}${value} ~ ${converted} sats`} textStyle={styles.price} containerStyle={{ marginBottom: 10 }} />
-                            {type === 'BUY' && (
-                                // UTXO-tier capsule next to the amount —
-                                // visualizes the purchased sat-bucket
-                                // (white/orange/green/blue) so the user
-                                // sees what tier their purchase lands in
-                                // before they slide to confirm. Same
-                                // CustomProgressBar used in StrikeView.
-                                <View style={{ marginLeft: 8, marginTop: 2 }}>
-                                    <CustomProgressBar value={Number(isSats ? value : converted) || 0} />
-                                </View>
-                            )}
                         </View>
                         {(isWithdrawal || type === 'BUY' || type === 'SELL') &&
                             <TouchableOpacity activeOpacity={0.7} onPress={editAmountClickHandler} style={{
@@ -1563,6 +1550,17 @@ export default function ReviewPayment({ navigation, route }: Props) {
                             </TouchableOpacity>
                         }
                     </View>
+                    {type === 'BUY' && (
+                        // UTXO-tier capsule, on its own line under the amount.
+                        // It used to sit inline beside the amount text, which was
+                        // fine while Edit Amount was withdrawal-only and the two
+                        // never appeared together. Edit Amount now also shows for
+                        // BUY, and in a space-between row the capsule and the
+                        // button collided. Its own line keeps both readable.
+                        <View style={{ marginLeft: 15, marginBottom: 10 }}>
+                            <CustomProgressBar value={Number(isSats ? value : converted) || 0} />
+                        </View>
+                    )}
                     <TextViewV2 keytext={type === 'BUY' ? "Spent from: " : "Sent from: "} text={receiveType ? "Coinos Lightning Account" : type == 'SELL' || type == 'BUY' ? "Strike Fiat Account" : "Strike Lightning Account"} containerStyle={{ marginBottom: 10 }} />
                     {isWithdrawal && to.length > 0 ?
                         <View style={{

--- a/src/screens/Strike/BuyBitcoin/index.tsx
+++ b/src/screens/Strike/BuyBitcoin/index.tsx
@@ -51,33 +51,6 @@ export default function BuyBitcoin({ navigation, route }: any) {
             setSats(String(sats))
         }
     }, [info])
-
-    /**
-     * Skip this screen when the amount was already chosen.
-     *
-     * The UTXO capsule vending machine picks a size before navigating here, so
-     * the keyboard has nothing left to ask. Forward to the confirmation screen,
-     * where Edit Amount comes back here if the user wants a different figure.
-     *
-     * Routed THROUGH this screen rather than from StrikeView straight to
-     * ReviewPayment so the confirmation gets exactly the params handleSendNext
-     * builds (`sender`, `recommendedFee`, the fiat/sats pair). Rebuilding those
-     * at the call site is how a money path picks up a subtle mismatch.
-     *
-     * Waits for `recommendedFee`, which handleSendNext passes on and a BUY routed
-     * to cold storage needs. Fires once: `advancedRef` stops it bouncing the user
-     * forward again when they come BACK here via Edit Amount.
-     */
-    const advancedRef = useRef(false);
-    useEffect(() => {
-        if (!info?.autoAdvance) return;
-        if (advancedRef.current) return;
-        if (!sats || Number(sats) <= 0) return;
-        if (!recommendedFee) return;
-        advancedRef.current = true;
-        handleSendNext();
-    }, [info?.autoAdvance, sats, recommendedFee]);
-
     useEffect(() => {
         if (!sender.startsWith('ln') && !sender.includes('@') && !recommendedFee) {
             const init = async () => {


### PR DESCRIPTION
Recovers work that never reached `main`. **These are two bugs you reported and that were fixed, but the fix did not ship.**

## What is wrong on main right now

`main` still carries the FIRST version of the straight-to-confirmation flow, the one routed through `BuyBitcoin` with an `autoAdvance` flag. That version has both defects reported during device testing:

- **the amount keyboard flashes** on the way to confirmation, because `BuyBitcoin` mounts and renders before forwarding
- **the UTXO capsule and the Edit Amount button overlap**, because showing Edit Amount for BUY put them in the same `space-between` row

## Why it did not ship

The fix was committed while checked out on `qa/integration-2026-08-23` rather than on `feat/strike-buy-straight-to-confirm`. The subsequent `git push origin feat/strike-buy-straight-to-confirm` pushed that branch's old tip, so #212 merged the version without the fix, and the commit survived only on the integration branch.

Found by a patch-id audit (`git cherry`) while checking whether that branch was safe to delete. A commit-level check would have missed it, since the tree diff was dominated by merge commits.

## What this restores

- `StrikeView` builds the `ReviewPayment` params itself and navigates directly, so the keyboard screen is never pushed
- the UTXO capsule moves onto its own line under the amount
- `autoAdvance` and the `BuyBitcoin` effect that consumed it are removed; **zero references remain** in any of the three files

## Verification

- `npx jest -i tests/unit`: 53 suites, 573 passed, 1 skipped
- `tsc --noEmit`: 400, matching baseline
- markers confirmed present after cherry-pick: `goToBuyConfirmation` x3, capsule-own-line x1, `autoAdvance` x0

Original commit `8ef4c67`, cherry-picked cleanly onto current `main`.
