### PR TITLE
perf(ark): back the exit drive off to 30 minutes while every capsule waits out its CSV

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -22,6 +22,8 @@ import {
     fetchChainTipHeight,
     fetchArkExitVtxos,
     decideExitClaimBatch,
+    decideExitDriveCadence,
+    type ExitDriveSnapshot,
     isVtxoMidRound,
     fetchClaimableExitVtxos,
     fetchPendingExitsTotalSats,
@@ -287,6 +289,9 @@ export default function useArkSync(): UseArkSync {
     // Last wall-clock ms the exit machinery (progressExits/syncExits) ran.
     // Drives the ~2 min exit-drive throttle — see the exit block below.
     const exitDriveLastRunMsRef = useRef(0);
+    // What the LAST drive saw. Lets the next one pick a cadence without
+    // spending a request to find out what phase the exit is in.
+    const exitDriveSnapshotRef = useRef<ExitDriveSnapshot | null>(null);
     // Counter used by the idle-skip heuristic. Increments every cycle that
     // returns balance=0 and vtxos.all.length=0; resets the moment either
     // turns non-zero. We use this to avoid the 2s Bark `syncArkWallet`
@@ -401,8 +406,15 @@ export default function useArkSync(): UseArkSync {
                 // cuts the esplora load 4x. Skipped ticks do nothing at all
                 // (normal sync stays skipped while an exit is running).
                 const nowMs = Date.now();
-                if (nowMs - exitDriveLastRunMsRef.current < 120_000) {
-                    _stamp('exit drive skipped (throttle)');
+                const cadence = decideExitDriveCadence({
+                    last: exitDriveSnapshotRef.current,
+                    now: nowMs,
+                    lastRunAt: exitDriveLastRunMsRef.current,
+                });
+                if (!cadence.run) {
+                    _stamp(
+                        `exit drive skipped (${cadence.phase}, every ${Math.round(cadence.waitMs / 1000)}s)`,
+                    );
                     return;
                 }
                 exitDriveLastRunMsRef.current = nowMs;
@@ -501,6 +513,18 @@ export default function useArkSync(): UseArkSync {
                         if (Number.isFinite(h) && h > 0) pendingClaimableHeights.push(h);
                         else unknownScheduleCount += 1;
                     }
+
+                    // Cache what this drive observed so the NEXT one can pace
+                    // itself. Free: every field here was already fetched above.
+                    // Deliberately carries no chain tip. Both available tips are
+                    // frozen during an exit (the store's per #204, and bark's
+                    // ExitState.inner.tipHeight because it is stamped once on
+                    // entry), so anything paced off one computes a constant.
+                    exitDriveSnapshotRef.current = {
+                        claimableCount: claimable.length,
+                        awaitingCount: pendingClaimableHeights.length,
+                        processingCount: unknownScheduleCount,
+                    };
 
                     const batchDecision = decideExitClaimBatch({
                         claimableCount: claimable.length,

--- a/src/services/ark/exitDriveCadence.ts
+++ b/src/services/ark/exitDriveCadence.ts
@@ -1,0 +1,132 @@
+/**
+ * How often the exit drive should actually run.
+ *
+ * THE PROBLEM
+ *
+ * The drive polls hard for an event whose block height it already knows. Once
+ * every leaf is confirmed and sitting in AwaitingDelta, `claimableHeight` is
+ * populated and fixed, and for the next vtxoExitDelta blocks (~24h) there is
+ * exactly one question worth asking: has the tip passed it. The drive instead
+ * ran a full syncArkWallet + progressExits + syncExits + listClaimableExits +
+ * allVtxos + balance every 120 seconds for that entire window, and
+ * `progressExits` had nothing to progress during any of it.
+ *
+ * Measured on the 2026-08-22 mainnet exit: 44 hours total, of which roughly 40
+ * were spent in AwaitingDelta with nothing to broadcast. At 120s that is ~1,200
+ * full drives to observe two block heights arriving. Blockstream's
+ * unauthenticated cap is 700 requests/hour/IP, and it is per IP, so a user
+ * behind CGNAT shares it with strangers. On 2026-08-24 that cap was hit and the
+ * wallet would not open at all. See #194.
+ *
+ * THE FIX, AND WHY IT IS A FLAT INTERVAL RATHER THAN A GRADUATED ONE
+ *
+ * Back the waiting phase off to a single long interval. Three phases with
+ * genuinely different needs previously shared one timer:
+ *
+ *   broadcasting  urgent, racing expiry, keep the fast cadence
+ *   waiting       ~95% of wall clock, nothing to do until the tip moves
+ *   claimable     one drainExits, fire promptly
+ *
+ * The obvious refinement is to taper: back off hard while ripening is hours
+ * away and tighten as it approaches. That needs a chain tip, and DURING AN EXIT
+ * THERE IS NO FREE ONE.
+ *
+ *   - `arkChainTipHeight` in the store is frozen for the duration of an exit,
+ *     because the sync loop returns before refreshing it (#204).
+ *   - `ExitState.inner.tipHeight` on the exit records is ALSO frozen. bark
+ *     stamps it once when the state is entered and never rewrites it: the
+ *     AwaitingDelta arm returns its state unchanged while `tip <
+ *     claimable_height`, and bark only persists a state that differs from the
+ *     stored one. Verified against bark 0.6.1 and confirmed on device, where
+ *     one capsule read 963510 across four captures spanning 21 hours while the
+ *     chain advanced to 963795. Only the Claimable transition restamps it.
+ *
+ * A taper driven off either value computes a CONSTANT blocks-remaining of about
+ * vtxoExitDelta and therefore never tapers, so it would be dead code wearing
+ * the label of a live optimisation. This module does not pretend otherwise.
+ *
+ * The cost of the flat interval is that a claim can fire up to one interval
+ * after its capsule ripens. That is safe: past its CSV an exit output is an
+ * ordinary UTXO only this wallet can spend, with no deadline and nobody to race.
+ *
+ * The real fix is to stop using the full drive as the unit of polling: check the
+ * tip with one `/blocks/tip/height` request on a tight cadence, and run the full
+ * drive only when the tip has crossed a `claimableHeight`. That is ~1 request
+ * per check instead of ~20, stays responsive at ripening, and unfreezes #204 as
+ * a side effect. It is a larger change than this one and wants verification
+ * against a live multi-day exit, so it is tracked as #219.
+ *
+ * WHY DECIDING NEEDS NO REQUESTS
+ *
+ * The decision reads a snapshot the PREVIOUS drive already fetched. Every field
+ * comes from calls the drive makes anyway for its claim-batching decision, so
+ * the cost of deciding is zero.
+ *
+ * Pure and import-free, matching exitClaimBatch.ts and changeRefresh.ts.
+ */
+
+/** State observed on the last drive. Costs nothing: the drive already had it. */
+export type ExitDriveSnapshot = {
+    /** Capsules ready to sweep now. */
+    claimableCount: number;
+    /** Capsules confirmed and waiting out the CSV, with a known ripening height. */
+    awaitingCount: number;
+    /** Capsules still broadcasting, so no ripening height yet. */
+    processingCount: number;
+};
+
+export type ExitDrivePhase = 'broadcasting' | 'claimable' | 'waiting' | 'unknown';
+
+/** Fast cadence, unchanged from the original flat throttle. */
+export const EXIT_DRIVE_FAST_MS = 120_000;
+/** Every capsule is waiting out its CSV. Nothing to do until the chain moves. */
+export const EXIT_DRIVE_WAITING_MS = 30 * 60_000;
+
+export type ExitDriveDecision = {
+    run: boolean;
+    phase: ExitDrivePhase;
+    /** Interval this phase warrants, for the log and the next comparison. */
+    waitMs: number;
+};
+
+export function decideExitDriveCadence(args: {
+    last: ExitDriveSnapshot | null;
+    now: number;
+    lastRunAt: number;
+}): ExitDriveDecision {
+    const { last, now, lastRunAt } = args;
+    const elapsed = now - lastRunAt;
+    const fast = (phase: ExitDrivePhase): ExitDriveDecision => ({
+        run: elapsed >= EXIT_DRIVE_FAST_MS,
+        phase,
+        waitMs: EXIT_DRIVE_FAST_MS,
+    });
+
+    // No snapshot yet (first drive of a session, or a cold launch mid-exit).
+    // Run: we cannot reason about a phase we have never observed.
+    if (last == null) {
+        return { run: true, phase: 'unknown', waitMs: EXIT_DRIVE_FAST_MS };
+    }
+
+    // Anything still broadcasting is racing expiry and needs the app's
+    // attention every tick, because each tree level needs the app to relay the
+    // next. This is the phase the old flat throttle was actually tuned for, and
+    // it keeps that cadence. Checked FIRST: a straggler still needs relaying
+    // even when other capsules have already ripened.
+    if (last.processingCount > 0) return fast('broadcasting');
+
+    // Something is ready to sweep. Fire promptly: the claim is the whole point
+    // and waiting on it strands recovered value.
+    if (last.claimableCount > 0) return fast('claimable');
+
+    // Everything is confirmed and waiting out its CSV. Nothing this app can do
+    // changes anything until the chain advances past a claimableHeight.
+    if (last.awaitingCount > 0) {
+        return { run: elapsed >= EXIT_DRIVE_WAITING_MS, phase: 'waiting', waitMs: EXIT_DRIVE_WAITING_MS };
+    }
+
+    // An exit is flagged active but the snapshot shows no capsule in any known
+    // phase. Erring toward more requests is wrong for THIS issue and right for
+    // not stalling an exit: a stalled exit costs the user far more than a quota.
+    return fast('unknown');
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -265,6 +265,8 @@ export type {
 } from './exitFundingCoinos';
 
 export { decideExitClaimBatch } from './exitClaimBatch';
+export { decideExitDriveCadence } from './exitDriveCadence';
+export type { ExitDriveSnapshot, ExitDrivePhase } from './exitDriveCadence';
 export type { ExitClaimBatchInput, ExitClaimBatchDecision } from './exitClaimBatch';
 
 export { resolveExitReserveTarget } from './exitReserveTarget';

--- a/tests/unit/exitDriveCadence.test.ts
+++ b/tests/unit/exitDriveCadence.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Backing off the exit drive when it has nothing to do.
+ *
+ * The 2026-08-22 mainnet exit ran 44 hours, roughly 40 of them in AwaitingDelta
+ * with nothing to broadcast, at a flat 120s cadence. Blockstream's cap is 700
+ * requests/hour/IP and it is shared behind CGNAT. On 2026-08-24 it was hit and
+ * the wallet would not open at all.
+ *
+ * The waiting interval is deliberately FLAT rather than tapering toward
+ * ripening: no live chain tip is available during an exit without spending a
+ * request, so a taper would compute a constant and never fire. See the module
+ * docblock.
+ */
+
+import {
+    decideExitDriveCadence,
+    EXIT_DRIVE_FAST_MS,
+    EXIT_DRIVE_WAITING_MS,
+    type ExitDriveSnapshot,
+} from '../../src/services/ark/exitDriveCadence';
+
+const NOW = 1_700_000_000_000;
+const snap = (o: Partial<ExitDriveSnapshot> = {}): ExitDriveSnapshot => ({
+    claimableCount: 0,
+    awaitingCount: 0,
+    processingCount: 0,
+    ...o,
+});
+const decide = (last: ExitDriveSnapshot | null, sinceMs: number) =>
+    decideExitDriveCadence({ last, now: NOW, lastRunAt: NOW - sinceMs });
+
+describe('phases that must stay fast', () => {
+    it('keeps the fast cadence while anything is still broadcasting', () => {
+        // Racing expiry, and each tree level needs the app to relay the next.
+        const d = decide(snap({ processingCount: 1, awaitingCount: 3 }), 0);
+        expect(d.phase).toBe('broadcasting');
+        expect(d.waitMs).toBe(EXIT_DRIVE_FAST_MS);
+    });
+
+    it('fires promptly once something is claimable', () => {
+        const d = decide(snap({ claimableCount: 1 }), EXIT_DRIVE_FAST_MS);
+        expect(d.phase).toBe('claimable');
+        expect(d.run).toBe(true);
+    });
+
+    it('holds the claimable phase to its own interval, not longer', () => {
+        expect(decide(snap({ claimableCount: 1 }), EXIT_DRIVE_FAST_MS - 1).run).toBe(false);
+    });
+
+    it('broadcasting outranks claimable, since a straggler still needs relaying', () => {
+        expect(decide(snap({ processingCount: 1, claimableCount: 3 }), 0).phase)
+            .toBe('broadcasting');
+    });
+});
+
+describe('backing off while every capsule waits out its CSV', () => {
+    it('waits half an hour when every capsule is confirmed and waiting', () => {
+        const d = decide(snap({ awaitingCount: 3 }), 0);
+        expect(d.phase).toBe('waiting');
+        expect(d.waitMs).toBe(EXIT_DRIVE_WAITING_MS);
+        expect(d.run).toBe(false);
+    });
+
+    it('still runs once the backed-off interval has elapsed', () => {
+        const waiting = snap({ awaitingCount: 3 });
+        expect(decide(waiting, EXIT_DRIVE_WAITING_MS - 1).run).toBe(false);
+        expect(decide(waiting, EXIT_DRIVE_WAITING_MS).run).toBe(true);
+    });
+
+    it('does not back off on a single waiting capsule any differently', () => {
+        // Count is not a cadence input: one capsule mid-CSV is as idle as five.
+        expect(decide(snap({ awaitingCount: 1 }), 0).waitMs).toBe(EXIT_DRIVE_WAITING_MS);
+    });
+});
+
+describe('what it refuses to back off on', () => {
+    it('runs when there is no snapshot yet, rather than guessing a phase', () => {
+        const d = decide(null, 0);
+        expect(d.run).toBe(true);
+        expect(d.phase).toBe('unknown');
+    });
+
+    it('keeps the fast cadence when no capsule is in any known phase', () => {
+        // Erring toward more requests is wrong for this issue and right for not
+        // stalling an exit. A stalled exit costs the user far more than a quota.
+        const d = decide(snap(), 0);
+        expect(d.phase).toBe('unknown');
+        expect(d.waitMs).toBe(EXIT_DRIVE_FAST_MS);
+    });
+
+    it('returns to the fast cadence as soon as a waiting capsule ripens', () => {
+        // The transition that ends the backed-off phase: the drive that
+        // observes a claimable capsule writes a snapshot the next one reads.
+        expect(decide(snap({ awaitingCount: 3 }), 0).waitMs).toBe(EXIT_DRIVE_WAITING_MS);
+        expect(decide(snap({ awaitingCount: 2, claimableCount: 1 }), 0).waitMs)
+            .toBe(EXIT_DRIVE_FAST_MS);
+    });
+});


### PR DESCRIPTION
Implements part of #194.

## The waste, measured

The drive polls hard for an event whose block height it already knows. Once every leaf sits in `AwaitingDelta`, `claimableHeight` is populated and fixed, and for the next ~24h there is exactly one question worth asking: has the tip passed it.

Instead it ran a full `syncArkWallet` + `progressExits` + `syncExits` + `listClaimableExits` + `allVtxos` + `balance` every 120 seconds for that entire window, with `progressExits` having nothing to progress during any of it.

From the 2026-08-22 mainnet exit: **44 hours total, roughly 40 of them waiting.** At 120s that is about **1,200 full drives to observe two block heights arriving.**

Blockstream's unauthenticated cap is **700 requests/hour/IP**, and it is per IP, so users behind CGNAT share it with strangers. On 2026-08-24 the cap was hit on the test device and the wallet would not open at all.

## Pacing

| phase | cadence | why |
|---|---|---|
| broadcasting | 120s | racing expiry, each tree level needs the app to relay the next |
| claimable | 120s | the claim is the point; waiting strands recovered value |
| waiting | **30 min** | every capsule is confirmed and sitting out its CSV |

## Why the waiting interval is flat, and not a taper

An earlier revision of this branch tapered by blocks remaining: 30 minutes beyond 20 blocks, 10 minutes from 6 to 20, 120s inside 6. **That does not work, and the tiers would have been dead code.**

A taper needs a chain tip, and during an exit there is no free one.

- `arkChainTipHeight` in the store is frozen for the duration of an exit, because the sync loop returns before refreshing it (#204).
- `ExitState.inner.tipHeight` on the exit records is **also frozen**. bark stamps it once when the state is entered and never rewrites it: `ExitAwaitingDeltaState::progress` returns its state unchanged while `tip < claimable_height`, and `update_state_if_newer` only persists a state that differs from the stored one. Read against bark 0.6.1, the version behind SDK 0.16.1.

Confirmed on device rather than inferred. One capsule in `AwaitingDelta` read `963510` across four captures spanning 21 hours while the chain advanced to `963795`. Two others restamped to a live `963632`, but only once they had transitioned to `Claimable`.

So a taper off either value computes a constant blocks-remaining of about `vtxoExitDelta` and never fires. The earlier revision would have pinned at 30 minutes straight through ripening while presenting itself as responsive. This revision drops the tip from the snapshot entirely and says what it actually does.

## What it costs

A claim can fire up to one interval after its capsule ripens. That is safe: past its CSV an exit output is an ordinary UTXO that only this wallet can spend, with no deadline and nobody to race.

## What it refuses to do

No snapshot yet, or no capsule in any known phase, keeps the **fast** cadence. Erring toward more requests is wrong for this issue and right for not stalling an exit: a stalled exit costs the user far more than a quota does. Tests pin both.

## It costs no extra requests to decide

The decision reads a snapshot the *previous* drive already fetched, built from calls the drive makes anyway for its claim-batching decision. Exit state only changes as the chain advances, so a cached view stays valid between drives.

## Verification

- `npx jest -b -i tests/unit`: **54 suites, 583 passed, 1 skipped** (10 new)
- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`

Not device-verified. Confirming it needs another multi-day exit, and the drive log states its phase on every skip, so the pacing is observable when one next runs.

## Follow-ups

**#219 supersedes this.** The real fix is to stop using the full drive as the unit of polling: check the tip with one `/blocks/tip/height` request on a tight cadence and run the full drive only when the tip has crossed a ripening height. That is about 1 request per check instead of 20, stays responsive at ripening, and closes #204 as a side effect. It is new machinery in a loop that has twice retired an exit early, so it wants a live exit to verify against rather than shipping alongside a release that already rebuilt the exit path.

**#194 fix 4** (an owned chain source) is still the only one that removes the cap rather than living within it. Note the asymmetry: this cuts one device about 15x during the phase that dominates an exit's wall clock, while an owned source cuts the entire fleet to roughly one call per interval.
