### PR TITLE
fix(ark): price the exit on what it spends, not on the reserve it requires

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -45,6 +45,8 @@ import {
   recoverArkOnchainBoard,
   fetchArkExitVtxos,
   fetchPendingExitsTotalSats,
+  formatBlocksUntil,
+  formatExitCollectWait,
   findAutoBackupForRecovery,
   getArkOnchainAddress,
   getAutoBackupPath,
@@ -1445,13 +1447,45 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     // Principle: never silently spend more than the funds are worth. The
     // reserve sits next to what comes back, so a reserve larger than the value
     // is impossible to miss.
+    // Every selected capsule, named, so the user can see what the totals are
+    // made of. Listed only when there is more than one: with a single capsule
+    // the row would just restate the line above it. Capped, with the remainder
+    // counted rather than dropped silently.
+    const CAPSULE_LIST_MAX = 6;
+    const capsuleNotice =
+      plan.selected.length > 1
+        ? 'Capsules being exited:\n' +
+          plan.selected
+            .slice(0, CAPSULE_LIST_MAX)
+            .map(
+              (e) =>
+                `  ${e.sats.toLocaleString()} sats: about ${e.netRecoveredSats.toLocaleString()} sats reach you, ` +
+                `collectable ${formatExitCollectWait(e.requiredRunwayBlocks)}, ` +
+                `expires ${e.blocksUntilExpiry != null ? formatBlocksUntil(e.blocksUntilExpiry) : 'unknown'}`,
+            )
+            .join('\n') +
+          (plan.selected.length > CAPSULE_LIST_MAX
+            ? `\n  and ${plan.selected.length - CAPSULE_LIST_MAX} more`
+            : '') +
+          '\n\n'
+        : '';
+
+    // Three DIFFERENT numbers, kept apart on purpose.
+    //
+    // What reaches you, what the fees are expected to cost, and what you must
+    // have available. The reserve is not a cost: it carries spike headroom and
+    // a 5,000 sat floor, and whatever is not spent stays in the on-chain
+    // wallet. Pricing the loss against the reserve told a user exiting one 971
+    // sat capsule that it cost 4,105 sats more than it was worth, when the
+    // expected spend was about 632 against 895 recovered.
     const costNotice =
-      `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address, and it needs about ${plan.reserveSats.toLocaleString()} sats of on-chain miner fees to get there.\n\n` +
+      `Exiting ${plan.selected.length} capsule${plan.selected.length === 1 ? '' : 's'} holding ${plan.selectedSats.toLocaleString()} sats. About ${plan.netRecoverableSats.toLocaleString()} sats reach your address.\n\n` +
+      `Miner fees are expected to cost about ${plan.expectedSpendSats.toLocaleString()} sats. You need ${plan.reserveSats.toLocaleString()} sats sitting in your on-chain wallet as cover in case fees rise, and anything not spent stays yours.\n\n` +
       // The loss, in sats, whenever the exit spends more than it returns. This
       // is the sentence that makes an overridden exit a choice rather than a
       // surprise, so it is not conditional on how the policy got here.
       (plan.netLossSats > 0
-        ? `That is about ${plan.netLossSats.toLocaleString()} sats MORE in fees than the funds are worth.\n\n`
+        ? `That is about ${plan.netLossSats.toLocaleString()} sats MORE in expected fees than the funds are worth.\n\n`
         : '');
 
     const shortfall = Math.max(0, freshRecommended - onchainReserveSats);
@@ -1463,12 +1497,16 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       Alert.alert(
         'Emergency Exit',
         exclusionNotice +
+          capsuleNotice +
           costNotice +
           underfundedPrefix +
-          `Forces your VTXO capsules onto the Bitcoin chain. Funds arrive at your ${destLabel} after a ~24-hour wait set by Bitcoin. Once you start, this can't be cancelled.\n\n` +
+          `Forces your VTXO capsules onto the Bitcoin chain, into your ${destLabel}. Bitcoin enforces a waiting period first, ${formatExitCollectWait(exitPlan.collectableInBlocks)} for this exit. Once you start, this can't be cancelled.\n\n` +
           'Only start this if your soonest capsule is at least 1 day from expiry. The exit txs must confirm on-chain before then, so it is not a last-minute rescue.\n\n' +
           `${address}\n\n` +
-          'Cypher Box keeps the exit running in the background and sweeps the funds to this address when the timelock expires. The vault stays afterwards.',
+          // The wait does NOT run itself. The drive is foreground-only, so the
+          // claim fires when the user next opens the app. Saying otherwise was
+          // untrue for most of the 44 hours the 2026-08-22 exit ran.
+          `Come back and open the app ${formatExitCollectWait(exitPlan.collectableInBlocks)} to collect. It does not finish while the app is closed. The vault stays afterwards.`,
         [
           {
             text: 'Cancel',

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -311,9 +311,34 @@ export type ExitTriageResult = {
     /** Selected capsules that cost more reserve than they return. */
     underWaterCount: number;
     /**
+     * What the exit is expected to SPEND in miner fees, summed over the
+     * selected capsules at the bare rate.
+     *
+     * Deliberately different from `reserveSats`, and the distinction is the
+     * whole point. `reserveSats` is what the user must have AVAILABLE: it
+     * carries SPIKE_MULT headroom and a RESERVE_FLOOR_SATS minimum, and
+     * whatever is not spent stays in their on-chain wallet. Measured on the
+     * 2026-08-22 mainnet exit: 3,585 spent against a 12,072 reserve, so 8,487
+     * came back.
+     *
+     * Conflating the two told a user exiting a single 971 sat capsule that it
+     * would cost 4,105 sats more than it was worth, when the expected spend was
+     * about 632 against 895 recovered. The floor alone accounted for the whole
+     * apparent loss, and it would have talked them out of a rational exit.
+     */
+    expectedSpendSats: number;
+    /**
+     * Blocks before the LAST selected capsule can be collected: confirmation
+     * budget plus the CSV delta. Derived rather than hardcoded, because a
+     * deeper capsule needs more confirmations before its CSV even starts.
+     */
+    collectableInBlocks: number;
+    /**
      * Sats the selected set spends beyond what it recovers, 0 when it is not
      * under water. This is the number the user has to be shown before a
      * 'recover-everything' exit, since it IS the loss they are accepting.
+     *
+     * Priced against `expectedSpendSats`, NOT `reserveSats`. See above.
      */
     netLossSats: number;
     /**
@@ -781,6 +806,18 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
     const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
     const reserveSats = reserveSatsForExitVb(totalExitVb, feeRate);
     const netRecoverableSats = selected.reduce((acc, e) => acc + e.netRecoveredSats, 0);
+    // What the exit is actually expected to SPEND, as opposed to what the user
+    // must have available. Bare rate, no SPIKE_MULT and no floor: those two are
+    // headroom on the reserve, not costs anyone expects to pay.
+    const expectedSpendSats = selected.reduce((acc, e) => acc + e.exitTreeCostSats, 0);
+    // Runway the slowest selected capsule needs before it can be collected:
+    // its tree has to confirm and then sit out the CSV delta. This is the
+    // "come back at" figure, and it is why a hardcoded ~24h understates a deep
+    // wallet.
+    const collectableInBlocks = selected.reduce(
+        (acc, e) => Math.max(acc, e.requiredRunwayBlocks),
+        0,
+    );
     const overridable = excluded.filter(
         (e) => e.reason === 'reserve-dwarfs-value' || e.reason === 'refresh-before-exiting',
     );
@@ -796,7 +833,9 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         totalExitVb,
         reserveSats,
         underWaterCount: selected.filter((e) => e.economic !== 'profitable').length,
-        netLossSats: Math.max(0, reserveSats - netRecoverableSats),
+        expectedSpendSats,
+        collectableInBlocks,
+        netLossSats: Math.max(0, expectedSpendSats - netRecoverableSats),
         overridableCount: overridable.length,
         overridableSats: overridable.reduce((acc, e) => acc + e.sats, 0),
         economicPolicy: policy,

--- a/src/services/ark/expiry.ts
+++ b/src/services/ark/expiry.ts
@@ -86,6 +86,24 @@ export async function fetchArkNextRequiredRefreshHeight(): Promise<number | null
  * — block heights are reserved for console / activity-log emission, users
  * see time copy only.
  */
+/**
+ * How long before a unilateral exit can be COLLECTED. Hours precision below
+ * three days, deliberately different from {@link formatBlocksUntil}.
+ *
+ * The exit wait is derived from depth: a depth-2 capsule needs 12 + 144 = 156
+ * blocks (~26h) and a depth-9 one needs 54 + 144 = 198 (~33h). `formatBlocksUntil`
+ * switches to days at 24h and renders BOTH as "in ~1d", which throws away the
+ * only reason the figure is derived rather than hardcoded. Expiry copy, which
+ * deals in weeks, still wants the coarse version.
+ */
+export function formatExitCollectWait(blocks: number): string {
+    if (blocks <= 0) return 'now';
+    const hours = blocksToHours(blocks);
+    if (hours < 1) return 'shortly';
+    if (hours < 72) return `in about ${Math.round(hours)} hours`;
+    return `in about ${Math.round(blocksToDays(blocks))} days`;
+}
+
 export function formatBlocksUntil(blocks: number): string {
     if (blocks <= 0) return 'now';
     const hours = blocksToHours(blocks);

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -221,6 +221,8 @@ export {
     cancelVtxoStuckSwapWarnings,
 } from './backgroundNotifications';
 
+export { formatBlocksUntil, formatExitCollectWait } from './expiry';
+
 export { registerArkNotificationTapHandler } from './notificationHandler';
 
 export {

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -513,12 +513,80 @@ describe('economic policy: how far past the economics the user may go', () => {
     expect(triage({ economicPolicy: 'recover-everything' }).overridableCount).toBe(0);
   });
 
-  it('states the loss the override accepts', () => {
+  it('states the loss the override accepts, priced on spend not reserve', () => {
     const forced = triage({ economicPolicy: 'recover-everything' });
-    // 32,120 of reserve to recover 4,382 net. That gap is the choice.
     expect(forced.netRecoverableSats).toBe(4990 - 8 * 76);
-    expect(forced.netLossSats).toBe(32120 - (4990 - 8 * 76));
+    // The loss is what the exit is expected to SPEND beyond what it returns.
+    // Pricing it against reserveSats instead would charge the user for the
+    // spike headroom and the floor, neither of which anyone expects to pay.
+    expect(forced.expectedSpendSats).toBe(16060);
+    expect(forced.netLossSats).toBe(16060 - (4990 - 8 * 76));
+    expect(forced.netLossSats).toBeLessThan(forced.reserveSats - forced.netRecoverableSats);
     expect(forced.underWaterCount).toBe(8);
+  });
+
+  it('keeps the reserve requirement and the expected spend apart', () => {
+    const forced = triage({ economicPolicy: 'recover-everything' });
+    // reserveSats carries SPIKE_MULT on top of the same vsize, so it is
+    // strictly the larger of the two and must never be quoted as the cost.
+    expect(forced.reserveSats).toBe(32120);
+    expect(forced.expectedSpendSats).toBe(forced.totalExitVb * forced.feeRateSatPerVb);
+    expect(forced.reserveSats).toBeGreaterThan(forced.expectedSpendSats);
+  });
+
+  it('does not call a single small capsule a 4,105 sat loss', () => {
+    // The live case from the device: one 971 sat capsule at depth 2, 1 sat/vB.
+    // reserveSats is 5,000 because of the floor, so the old reserve-priced
+    // model reported a 4,105 sat loss on an exit whose expected spend was 632
+    // against 895 recovered. It is mildly PROFITABLE, and the copy said the
+    // opposite.
+    const r = triageArkExit({
+      vtxos: [v({ id: 'live', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(r.selectedIds).toEqual(['live']);
+    expect(r.netRecoverableSats).toBe(971 - 76);
+    expect(r.reserveSats).toBe(5000);
+    expect(r.expectedSpendSats).toBe(632);
+    expect(r.netLossSats).toBe(0);
+  });
+
+  it('derives the collect-at runway instead of assuming ~24h', () => {
+    // Confirmation budget (depth x 6, floored at 6) plus the CSV delta. A
+    // deeper capsule needs more confirmations before its CSV even starts, so a
+    // hardcoded 24h understates exactly where it matters most.
+    const shallow = triageArkExit({
+      vtxos: [v({ id: 'd2', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: 144,
+    });
+    expect(shallow.collectableInBlocks).toBe(12 + 144);
+
+    const deep = triageArkExit({
+      vtxos: [v({ id: 'd9', sats: 500_000, exitDepth: 9, exitTxWeightWu: 1325 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: 144,
+    });
+    expect(deep.collectableInBlocks).toBe(54 + 144);
+    expect(deep.collectableInBlocks).toBeGreaterThan(shallow.collectableInBlocks);
+  });
+
+  it('paces the collect-at off the SLOWEST selected capsule', () => {
+    const mixed = triageArkExit({
+      vtxos: [
+        v({ id: 'shallow', sats: 500_000, exitDepth: 2, exitTxWeightWu: 1325 }),
+        v({ id: 'deep', sats: 500_000, exitDepth: 9, exitTxWeightWu: 1325 }),
+      ],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: 144,
+    });
+    expect(mixed.selectedIds).toHaveLength(2);
+    expect(mixed.collectableInBlocks).toBe(54 + 144);
   });
 
   it('reports no loss when the selected set actually pays for itself', () => {
@@ -607,7 +675,10 @@ describe('economic policy: how far past the economics the user may go', () => {
     expect(forced.reserveSats).toBe(84504);
     // 84,504 sats of reserve to recover 2,330. The user has to see that.
     expect(forced.netRecoverableSats).toBe(2330);
-    expect(forced.netLossSats).toBe(82174);
+    // Expected spend is the same vsize at the bare rate; the reserve doubles it
+    // for spike cover. The loss the user is accepting is the former.
+    expect(forced.expectedSpendSats).toBe(6036 * 7);
+    expect(forced.netLossSats).toBe(6036 * 7 - 2330);
   });
 });
 


### PR DESCRIPTION
Found while reading the Emergency Exit confirmation on device.

## The screen contradicted itself

One 971 sat capsule, depth 2, 1 sat/vB. Triage **included** it, because its exit-tree cost of 632 sits comfortably under the 895 it returns. The same alert then said:

> That is about 4105 sats MORE in fees than the funds are worth.

Both sentences came from the same plan object. The exit was mildly positive and the copy said it destroyed four times the capsule's value.

## Why

`netLossSats` is documented as "sats the selected set **spends** beyond what it recovers" and was implemented as `reserveSats - netRecoverableSats`.

`reserveSats` is not a cost. It is what the user must have **available**: it carries a 2x `SPIKE_MULT` for volatility and a 5,000 sat `RESERVE_FLOOR_SATS` minimum, and anything unspent stays in their on-chain wallet. On the 2026-08-22 mainnet exit, **3,585 was spent against a 12,072 reserve**, so 8,487 came back untouched.

For a single small capsule the floor dominates completely: the 5,000 is 8x the 632 actually expected, and the entire apparent "loss" was the floor.

This matters beyond cosmetics. The copy would talk a user out of a rational exit, and it does so most strongly on exactly the small, fragmented wallets that have the least margin.

## The fix

Adds `expectedSpendSats`, the summed exit-tree cost over the selected set at the bare rate, and prices `netLossSats` against it. The reserve is still shown, now as a requirement rather than a cost, and the copy says unspent sats come back at the point the number is read.

Before and after, same wallet:

```
- About 895 sats reach your address, and it needs about 5,000 sats of
- on-chain miner fees to get there.
- That is about 4,105 sats MORE in fees than the funds are worth.

+ About 895 sats reach your address.
+ Miner fees are expected to cost about 632 sats. You need 5,000 sats
+ sitting in your on-chain wallet as cover in case fees rise, and
+ anything not spent stays yours.
```

## Also on the pre-commit disclosure

**Every selected capsule is now listed**, with what reaches you, when it can be collected, and when it expires. All of it was already computed per capsule and thrown away at the alert. Shown only above one capsule, where a row carries information the totals do not, and capped at six with the remainder counted rather than silently dropped.

**The wait is derived rather than hardcoded.** `collectableInBlocks` is the confirmation budget plus the CSV delta over the slowest selected capsule. Depth 2 reads 26 hours, depth 9 reads 33. The alert previously said "a ~24-hour wait" in three places, which understates exactly where the tree is deepest.

`formatExitCollectWait` gives that figure hours precision below three days. `formatBlocksUntil` switches to days at 24h and rendered both 26h and 33h as "in ~1d", which throws away the only reason the number is derived. Expiry copy, which deals in weeks, keeps the coarse version.

**The confirm alert no longer claims the exit finishes on its own.** It said Cypher Box "keeps the exit running in the background and sweeps the funds to this address when the timelock expires". The drive is foreground-only. #209 corrected this same false promise on the post-start toast, the exit panel line and the started-at line, but never touched the one screen the user reads **before** committing to a multi-day irreversible operation. It now says when to come back and open the app.

## What it reads like now

Single capsule:

```
Exiting 1 capsule holding 971 sats. About 895 sats reach your address.

Miner fees are expected to cost about 632 sats. You need 5,000 sats sitting in
your on-chain wallet as cover in case fees rise, and anything not spent stays yours.

Forces your VTXO capsules onto the Bitcoin chain, into your Hot Vault. Bitcoin
enforces a waiting period first, in about 26 hours for this exit. Once you
start, this can't be cancelled.
...
Come back and open the app in about 26 hours to collect. It does not finish
while the app is closed. The vault stays afterwards.
```

Fragmented:

```
Capsules being exited:
  877 sats: about 801 sats reach you, collectable in about 26 hours, expires in ~28d
  800 sats: about 724 sats reach you, collectable in about 26 hours, expires in ~27d
  700 sats: about 624 sats reach you, collectable in about 27 hours, expires in ~26d
  ...
```

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **54 suites, 587 passed, 1 skipped**
- 92 triage tests, 4 new: the spend/reserve split, the live 971 sat case asserting `netLossSats` is 0, the depth-derived runway, and that a mixed set paces off the slowest capsule

Copy is a draft for the product owner to rewrite. The intent is the constraint, not the wording.
