### PR TITLE
fix(ark): disclose what an exit could not verify instead of degrading silently

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1374,6 +1374,47 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       return;
     }
 
+    // What the plan could NOT verify. Built here, above every branch below,
+    // because all three of them mislead when it is non-empty, and the branch
+    // that misleads WORST is the one that reports nothing is recoverable: the
+    // fallback bands price at 10 sat/vB, which condemns a small wallet on a fee
+    // rate the app invented while unable to reach any fee source.
+    //
+    // The temporal axis is a hard exclusion when it can run: an exit that does
+    // not clear its CSV before expiry loses the capsule AND the reserve spent
+    // chasing it. Without a usable tip it cannot run, and triage deliberately
+    // includes rather than excludes, because refusing to exit on a failed tip
+    // read would disarm the emergency button for a network fault. That trade is
+    // only honest if the user is told, and until now they were not: the note
+    // was computed on every entry and rendered nowhere.
+    const buildUnverifiedNotice = (p: ExitTriageResult): string => {
+      const lines: string[] = [];
+      if (p.runwayUnverifiedCount > 0) {
+        lines.push(
+          `${p.runwayUnverifiedCount === p.selected.length ? 'These capsules' : `${p.runwayUnverifiedCount} of these capsules`} could not be checked against expiry, because there is no recent view of the chain. If one is closer to expiring than it looks, the exit can lose it and the fees spent on it.`,
+        );
+      } else if (p.tipUnavailable) {
+        lines.push(
+          'Your capsules could not be checked against expiry, because there is no recent view of the chain.',
+        );
+      }
+      if (p.feeRatesEstimated) {
+        lines.push(
+          'Fee estimates are unavailable, so the amounts here are a guess rather than the current market rate. Anything described as costing more than it is worth may be cheaper than this says.',
+        );
+      }
+      if (p.usedAssumedExitDelta) {
+        lines.push('The waiting period is assumed, not read from the server.');
+      }
+      if (lines.length === 0) return '';
+      return (
+        'You appear to be offline or unable to reach the chain.\n\n' +
+        lines.map((l) => `  ${l}`).join('\n\n') +
+        '\n\nReconnecting and trying again will give you real numbers. You can still go ahead: a network fault must not take away your way out.\n\n'
+      );
+    };
+    const unverifiedNotice = buildUnverifiedNotice(plan);
+
     // The override, offered only where it would change something. Re-planning
     // with 'recover-everything' is what actually applies it, so the figures in
     // the confirm dialog afterwards are the forced ones, not these.
@@ -1381,7 +1422,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       setExitStarting(false);
       Alert.alert(
         'Emergency Exit',
-        bodyPrefix +
+        unverifiedNotice +
+          bodyPrefix +
           `\n\nYou can exit ${plan!.overridableCount === 1 ? 'it' : 'them'} anyway. ` +
           'That is sometimes worth it, for instance to get your funds out of a server you no longer trust, ' +
           'but it costs more in miner fees than the funds are worth.',
@@ -1419,7 +1461,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       setExitStarting(false);
       Alert.alert(
         'Emergency Exit',
-        `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
+        unverifiedNotice +
+          `None of your ${plan.excluded.length} capsule${plan.excluded.length === 1 ? '' : 's'} can be recovered by an emergency exit right now:\n\n` +
           list +
           '\n\nThey stay in your vault and stay spendable.',
       );
@@ -1496,7 +1539,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     try {
       Alert.alert(
         'Emergency Exit',
-        exclusionNotice +
+        unverifiedNotice +
+          exclusionNotice +
           capsuleNotice +
           costNotice +
           underfundedPrefix +

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -176,6 +176,18 @@ export async function fetchClaimFeeRateSatPerVb(): Promise<number> {
  * takes more than one pass (see computeArkExitPlan) and refetching between them
  * would let the market move underneath the comparison.
  */
+/**
+ * How old the cached chain tip may be before triage refuses to reason about
+ * runway with it.
+ *
+ * One hour, so roughly six blocks. Normal foreground use refreshes the tip far
+ * more often than this, so the threshold never fires in practice; what it
+ * catches is the case it exists for, a cold launch with no connectivity
+ * rehydrating a persisted tip from an arbitrarily long time ago. Six blocks of
+ * drift against a runway of ~156 is tolerable slop; six hundred is not.
+ */
+export const MAX_TIP_AGE_FOR_TRIAGE_MS = 60 * 60 * 1000;
+
 export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
     const get = async (url: string): Promise<unknown | null> => {
         try {
@@ -210,6 +222,21 @@ export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
         );
     }
     return EXIT_FEE_FALLBACK_RATES;
+}
+
+/**
+ * Same fetch, but says whether the answer came from the market or from
+ * constants. `fetchExitFeeRates` cannot: its return type is a bare
+ * Record<band, number> with nowhere to put the provenance, so a total network
+ * failure was indistinguishable from a live quote at the call site. The exit
+ * confirm dialog prices real money against these, so it has to know.
+ */
+export async function fetchExitFeeRatesWithSource(): Promise<{
+    rates: ExitFeeRateTable;
+    estimated: boolean;
+}> {
+    const rates = await fetchExitFeeRates();
+    return { rates, estimated: rates === EXIT_FEE_FALLBACK_RATES };
 }
 
 export async function fetchExitTreeFeeRateSatPerVb(
@@ -303,10 +330,20 @@ export async function computeArkExitPlan(
     if (!vtxos) return null;
 
     const s = useAuthStore.getState();
-    const chainTipHeight = s.arkChainTipHeight ?? null;
+    // A STALE tip is worse than no tip. `arkChainTipHeight` is persisted, so a
+    // cold launch offline rehydrates one that may be days old, and
+    // `expiryHeight - staleTip` then overstates every capsule's runway by
+    // exactly that staleness. Overstating runway is the unsafe direction on the
+    // one axis that is a hard exclusion. Past the threshold we hand triage null
+    // instead, which makes it disclose the gap rather than quietly trust a
+    // number it cannot justify.
+    const tipAgeMs =
+        s.arkChainTipHeightAt != null ? Date.now() - s.arkChainTipHeightAt : Infinity;
+    const tipIsFresh = s.arkChainTipHeight != null && tipAgeMs <= MAX_TIP_AGE_FOR_TRIAGE_MS;
+    const chainTipHeight = tipIsFresh ? (s.arkChainTipHeight as number) : null;
     const vtxoExitDeltaBlocks = s.arkVtxoExitDeltaBlocks ?? null;
 
-    const rates = await fetchExitFeeRates();
+    const { rates, estimated: feeRatesEstimated } = await fetchExitFeeRatesWithSource();
     const runTriage = (feeRateSatPerVb: number) =>
         triageArkExit({
             vtxos,
@@ -363,6 +400,8 @@ export async function computeArkExitPlan(
             '; rates=', JSON.stringify(rates),
             '; netLoss=', plan.netLossSats, '; overridable=', plan.overridableCount,
             plan.usedAssumedExitDelta ? '; exit delta ASSUMED' : '',
+            feeRatesEstimated ? '; fee rates FALLBACK' : '',
+            tipIsFresh ? '' : `; tip UNUSABLE (age ${Math.round(tipAgeMs / 60000)}m)`,
         );
         for (const e of plan.excluded) {
             console.log(
@@ -372,7 +411,9 @@ export async function computeArkExitPlan(
         }
     }
 
-    return plan;
+    // Provenance the pure triage cannot know. Carried on the plan so the confirm
+    // dialog can say which of its numbers are market-priced and which are not.
+    return { ...plan, feeRatesEstimated };
 }
 
 /**

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -354,6 +354,38 @@ export type ExitTriageResult = {
     claimFeeRateSatPerVb: number;
     /** True when the temporal axis ran on ASSUMED_EXIT_DELTA_BLOCKS. */
     usedAssumedExitDelta: boolean;
+    /**
+     * Selected capsules whose runway could NOT be checked, because no usable
+     * chain tip was available.
+     *
+     * The temporal axis is a hard exclusion when it can run: an exit that does
+     * not clear its CSV before expiry loses the capsule AND the reserve spent
+     * chasing it. Without a tip it cannot run at all, and the deliberate choice
+     * is to include rather than exclude, because refusing to exit on a failed
+     * tip read would disarm the emergency button for a network fault.
+     *
+     * That choice is only defensible if the user is TOLD. This count is what
+     * makes the telling possible: before it existed the `expiry-unknown` note
+     * was computed and read by nothing.
+     */
+    runwayUnverifiedCount: number;
+    /**
+     * True when triage ran with no usable chain tip, independent of what got
+     * selected. `runwayUnverifiedCount` counts SELECTED capsules, so it reads 0
+     * in the very case that misleads hardest: offline, the fallback bands price
+     * at 10 sat/vB, a small wallet has everything excluded as uneconomic, and
+     * the app reports "none of your capsules can be recovered" on the strength
+     * of a fee rate it invented.
+     */
+    tipUnavailable: boolean;
+    /**
+     * True when every fee source was unreachable and the bands came from
+     * EXIT_FEE_FALLBACK_RATES. The reserve and the whole economic axis are then
+     * priced off constants rather than the market, which the user is committing
+     * real money against. Set by the caller that fetched the rates, since
+     * triage itself is pure and only ever sees a number.
+     */
+    feeRatesEstimated: boolean;
 };
 
 // --- Cost model helpers ----------------------------------------------------
@@ -842,6 +874,9 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         feeRateSatPerVb: feeRate,
         claimFeeRateSatPerVb: claimRate,
         usedAssumedExitDelta,
+        runwayUnverifiedCount: selected.filter((e) => e.notes.includes('expiry-unknown')).length,
+        tipUnavailable: tip == null,
+        feeRatesEstimated: false,
     };
 }
 
@@ -850,6 +885,27 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
  * product owner's to change; the contract this satisfies is that no capsule is
  * ever dropped without the user being told which one and why.
  */
+/**
+ * One-line text per disclosure note, for the confirm dialog.
+ *
+ * These do not change which capsules are exited, which is exactly why they were
+ * easy to leave unrendered: `ExitTriageNote` was defined, populated on every
+ * entry, and read by nothing at all. A note that reaches no user is not a
+ * disclosure, and the temporal axis explicitly relies on one.
+ */
+export function describeExitNote(note: ExitTriageNote): string {
+    switch (note) {
+        case 'expiry-unknown':
+            return 'could not check how close it is to expiry';
+        case 'beyond-server-depth-cap':
+            return 'past the server depth cap, so it can only be exited or refreshed';
+        case 'under-water':
+            return 'costs more in fees than it returns';
+        default:
+            return 'see details';
+    }
+}
+
 export function describeExitExclusion(reason: ExitExclusionReason | undefined): string {
     switch (reason) {
         case 'no-exit-chain':

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -198,6 +198,13 @@ export type AuthStateType = {
     // Current chain tip height (from esplora). Needed to convert VTXO
     // expiryHeight → blocks-until-expiry for the depletion ring.
     arkChainTipHeight: number | null;
+    // Epoch ms the tip above was read. The tip is PERSISTED, so a cold launch
+    // offline rehydrates one that may be days old, and
+    // `expiryHeight - staleTip` then OVERSTATES a capsule's remaining runway by
+    // exactly that staleness. That is the unsafe direction on the exit's one
+    // hard exclusion, so anything reasoning about runway must check this first.
+    // Stamped automatically by setArkChainTipHeight; never set it by hand.
+    arkChainTipHeightAt: number | null;
     // Timestamp (ms) of the last successful balance+vtxo sync. Used to
     // decide whether to block the UI on a fresh fetch or serve cached.
     arkLastSyncedAt: number | null;
@@ -560,6 +567,7 @@ const createAuthStore = (
     arkExpiryNotifsScheduleVersion: 0,
     arkPendingLnReceives: [],
     arkChainTipHeight: null,
+    arkChainTipHeightAt: null,
     arkLastSyncedAt: null,
     arkLastBackupAt: null,
     arkRoundIntervalSecs: null,
@@ -640,7 +648,9 @@ const createAuthStore = (
     setArkScheduledStuckSwapNotifs: (state: Record<string, number>) => set({ arkScheduledStuckSwapNotifs: state }),
     setArkExpiryNotifsScheduleVersion: (state: number) => set({ arkExpiryNotifsScheduleVersion: state }),
     setArkPendingLnReceives: (state: ArkLightningReceiveView[]) => set({ arkPendingLnReceives: state }),
-    setArkChainTipHeight: (state: number | null) => set({ arkChainTipHeight: state }),
+    // Stamps the read time with the value, so the two can never drift apart.
+    setArkChainTipHeight: (state: number | null) =>
+        set({ arkChainTipHeight: state, arkChainTipHeightAt: state == null ? null : Date.now() }),
     setArkLastSyncedAt: (state: number | null) => set({ arkLastSyncedAt: state }),
     setArkLastBackupAt: (state: number | null) => set({ arkLastBackupAt: state }),
     setArkRoundIntervalSecs: (state: number | null) => set({ arkRoundIntervalSecs: state }),
@@ -692,6 +702,7 @@ const createAuthStore = (
             arkExpiryNotifsScheduleVersion: 0,
             arkPendingLnReceives: [],
             arkChainTipHeight: null,
+            arkChainTipHeightAt: null,
             arkLastSyncedAt: null,
             arkLastBackupAt: null,
             arkRoundIntervalSecs: null,

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -9,6 +9,8 @@ import {
   ratesFromMempoolRecommended,
   URGENCY_SOON_BLOCKS,
   ExitTriageVtxo,
+  ExitTriageNote,
+  describeExitNote,
   RESERVE_FLOOR_SATS,
   perVtxoExitVb,
   requiredRunwayBlocks,
@@ -551,6 +553,63 @@ describe('economic policy: how far past the economics the user may go', () => {
     expect(r.reserveSats).toBe(5000);
     expect(r.expectedSpendSats).toBe(632);
     expect(r.netLossSats).toBe(0);
+  });
+
+  it('includes a capsule whose runway it cannot check, and flags it', () => {
+    // A network fault must not disarm the emergency button, so an unknown tip
+    // includes rather than excludes. That is only defensible if it is
+    // disclosed, which is what runwayUnverifiedCount exists for: before it, the
+    // expiry-unknown note was computed on every entry and read by nothing.
+    const offline = triageArkExit({
+      vtxos: [v({ id: 'live', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: null,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(offline.selectedIds).toEqual(['live']);
+    expect(offline.runwayUnverifiedCount).toBe(1);
+    expect(offline.selected[0].notes).toContain('expiry-unknown');
+    expect(offline.selected[0].blocksUntilExpiry).toBeNull();
+  });
+
+  it('does not flag runway when the tip is usable', () => {
+    const online = triageArkExit({
+      vtxos: [v({ id: 'live', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 })],
+      feeRateSatPerVb: 1,
+      chainTipHeight: TIP,
+      vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(online.runwayUnverifiedCount).toBe(0);
+    expect(online.selected[0].notes).not.toContain('expiry-unknown');
+  });
+
+  it('loses the temporal exclusion entirely without a tip, which is why it must disclose', () => {
+    // Same capsule, one block from expiry. With a tip it is a HARD exclusion,
+    // because an exit that does not clear its CSV loses the capsule and the
+    // reserve. Without one it sails through, so the disclosure is the only
+    // thing standing between the user and that trade.
+    const doomed = v({ id: 'doomed', sats: 971, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: TIP + 1 });
+    const withTip = triageArkExit({
+      vtxos: [doomed], feeRateSatPerVb: 1, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(withTip.selectedIds).toEqual([]);
+    expect(withTip.excluded[0].reason).toBe('too-close-to-expiry');
+
+    const withoutTip = triageArkExit({
+      vtxos: [doomed], feeRateSatPerVb: 1, chainTipHeight: null, vtxoExitDeltaBlocks: EXIT_DELTA,
+    });
+    expect(withoutTip.selectedIds).toEqual(['doomed']);
+    expect(withoutTip.runwayUnverifiedCount).toBe(1);
+  });
+
+  it('describes every note, so none can be added and left invisible', () => {
+    const notes: ExitTriageNote[] = ['expiry-unknown', 'beyond-server-depth-cap', 'under-water'];
+    for (const n of notes) {
+      const text = describeExitNote(n);
+      expect(typeof text).toBe('string');
+      expect(text.length).toBeGreaterThan(0);
+      expect(text).not.toBe('see details');
+    }
   });
 
   it('derives the collect-at runway instead of assuming ~24h', () => {


### PR DESCRIPTION
Found by putting the phone in airplane mode and opening Emergency Exit.

## The intent was right, the follow-through was missing

Triage deliberately includes a capsule whose runway it cannot check, and the reasoning at [exitTriage.ts:754](https://github.com/CypherBoxLLC/Cypher-Box/blob/main/src/services/ark/exitTriage.ts#L754) is correct:

> Unknown runway is not evidence of a problem, and refusing to exit on a failed tip read would disarm the emergency button for a network fault. **Include and disclose.**

The disclose half did not exist. `ExitTriageNote` defined `expiry-unknown`, `beyond-server-depth-cap` and `under-water`, every entry carried a `notes` array, and **nothing in the app ever read `.notes`**. No describer, no UI reference. `usedAssumedExitDelta` reached a dev log line only.

## Three things went quiet offline, all in the unsafe direction

**1. A stale tip was trusted.** `arkChainTipHeight` is persisted and the store has no `partialize`, so a cold launch offline rehydrates a tip that may be days old. `expiryHeight - staleTip` then **overstates** every capsule's runway by exactly that staleness.

That matters because the temporal axis is the one hard exclusion in triage. Its own comment: "an exit that does not clear its CSV before expiry loses the capsule AND the reserve spent chasing it." Erring optimistic there is the wrong way round.

`setArkChainTipHeight` now stamps `arkChainTipHeightAt` with the value so the two cannot drift apart, and `computeArkExitPlan` hands triage `null` past `MAX_TIP_AGE_FOR_TRIAGE_MS` (1 hour, about six blocks) rather than reasoning from a number it cannot justify. Six blocks of drift against a runway of ~156 is tolerable slop. Six hundred is not.

**2. A null tip skipped the temporal exclusion with no user-visible trace.** Now counted as `runwayUnverifiedCount` and stated in the dialog.

**3. Fee rates fell back to constants and were presented as live.** `fetchExitFeeRates` returns a bare `Record<band, number>` with nowhere to put provenance, so total network failure was indistinguishable from a real quote at the call site. Adds `fetchExitFeeRatesWithSource`, and the plan now carries `feeRatesEstimated`.

## The branch that misleads worst was the one with no notice at all

The disclosure covers **all three** alert branches, not just the confirm dialog.

The dangerous one is "none of your capsules can be recovered". The fallback bands price at 10 sat/vB, which condemns a small wallet on a fee rate the app invented while unable to reach any fee source. On the live 971 sat vault that is the difference between **profitable at 1 sat/vB** and **nothing is recoverable**, decided by a guess and previously stated flatly.

`runwayUnverifiedCount` counts SELECTED capsules and therefore reads 0 in exactly that case, so `tipUnavailable` is carried separately.

## What it reads like

Offline, fallback rates, nothing selected. This case previously said only the last three lines:

```
You appear to be offline or unable to reach the chain.

  Your capsules could not be checked against expiry, because there is no
  recent view of the chain.

  Fee estimates are unavailable, so the amounts here are a guess rather than
  the current market rate. Anything described as costing more than it is
  worth may be cheaper than this says.

  The waiting period is assumed, not read from the server.

Reconnecting and trying again will give you real numbers. You can still go
ahead: a network fault must not take away your way out.

None of your 1 capsule can be recovered by an emergency exit right now:
  971 sats: costs more in fees than it holds
They stay in your vault and stay spendable.
```

Online the dialog is byte-for-byte unchanged.

## The button stays armed

Nothing here blocks an exit, and that is deliberate. A network fault must not take away the trustless path, which is the emergency exit's first principle. This only stops the app presenting guesses as measurements.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **54 suites, 591 passed, 1 skipped**
- 96 triage tests, 4 new: an unknown tip includes and flags; a usable tip does not flag; the temporal exclusion is genuinely lost without a tip, proven with a capsule one block from expiry that sails through; and every note has non-placeholder text, so none can be added and left invisible again

Copy is a draft for the product owner to rewrite. The intent is the constraint, not the wording.
