### PR TITLE
refactor(ark): name the exit economics for what they measure, and pin the rule

### DIFF
--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -145,7 +145,7 @@ export const ASSUMED_EXIT_DELTA_BLOCKS = 288;
  *  It is scale-aware without being fee-rate-blind, because both sides move with
  *  the fee rate and the claim side eats the value: the same 698 at depth 2 is
  *  1.0x under water at 1 sat/vB, 9.9x at 5, and returns nothing at all at 20. */
-export const MAX_RESERVE_MULTIPLE = 2;
+export const MAX_FEE_MULTIPLE = 2;
 
 /** VTXO states that hold nothing to exit. `Exited` matters as much as `Spent`
  *  here: bark keeps returning a completed exit's VTXO from `allVtxos()` as
@@ -190,8 +190,11 @@ export type ExitExclusionReason =
     | 'refresh-before-exiting'
     /** Economic: its own claim fee is at least its whole value. */
     | 'returns-nothing'
-    /** Economic: the reserve it consumes dwarfs what it returns. */
-    | 'reserve-dwarfs-value';
+    /** Economic: the fees it costs dwarf what it returns. Named for FEES, not
+     *  for the reserve: the test is against this capsule's own exit-tree cost
+     *  at the bare rate, never against `reserveSats`. See the two-pot rule
+     *  above `ExitEconomicVerdict`. */
+    | 'fees-dwarf-value';
 
 /** Disclosures that do not change the decision but the user should still see. */
 export type ExitTriageNote =
@@ -203,6 +206,33 @@ export type ExitTriageNote =
     /** Included despite costing more reserve than it returns. */
     | 'under-water';
 
+/**
+ * THE TWO-POT RULE. Read this before touching anything economic here.
+ *
+ * An exit spends from two different pots and they must never be conflated:
+ *
+ *   EXPECTED SPEND   `exitTreeCostSats`, this capsule's own exit-tree vsize at
+ *                    the BARE fee rate. What the CPFP children actually pay.
+ *                    This, and only this, decides the verdict below.
+ *
+ *   RESERVE          `reserveSats`, what the user must have AVAILABLE. Carries
+ *                    SPIKE_MULT volatility headroom and a RESERVE_FLOOR_SATS
+ *                    minimum, is summed wallet-wide rather than per capsule,
+ *                    and whatever is not spent stays in their on-chain wallet.
+ *                    It is a funding requirement, NOT a cost, and it must never
+ *                    enter a profitability test.
+ *
+ * The gap is not small. On a single 971 sat capsule at 1 sat/vB the expected
+ * spend is 632 while the reserve is the 5,000 floor, eight times larger. On the
+ * measured 2026-08-22 mainnet exit, 3,585 was spent against a 12,072 reserve.
+ *
+ * This was not a hypothetical distinction. Everything here used to be NAMED for
+ * the reserve while being COMPUTED from spend, and `netLossSats` was duly
+ * implemented as `reserveSats - netRecoverableSats`. The confirm dialog then
+ * told a user that recovering 971 sats would cost 4,105 more than it was worth,
+ * on an exit that was mildly profitable. The names now match the arithmetic so
+ * the next reader is not misled the same way.
+ */
 export type ExitEconomicVerdict = 'profitable' | 'marginal' | 'uneconomic';
 
 /**
@@ -221,10 +251,10 @@ export type ExitEconomicVerdict = 'profitable' | 'marginal' | 'uneconomic';
  * one in does not cost the user money to rescue funds, it wedges the batch and
  * rescues nothing. So no policy includes it.
  *
- *   'profitable-only'     only capsules whose reserve cost comes back
+ *   'profitable-only'     only capsules whose fee cost comes back
  *   'default'             the above, plus capsules under water by less than
- *                         MAX_RESERVE_MULTIPLE
- *   'recover-everything'  the above, plus capsules whose reserve cost dwarfs
+ *                         MAX_FEE_MULTIPLE
+ *   'recover-everything'  the above, plus capsules whose fee cost dwarfs
  *                         what they return. This is spec principle 4: the user
  *                         may knowingly spend more than the funds are worth,
  *                         for instance to deny a hostile server a hostage.
@@ -740,7 +770,7 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
                 ? 'uneconomic'
                 : exitTreeCostSats <= netRecoveredSats
                   ? 'profitable'
-                  : exitTreeCostSats <= netRecoveredSats * MAX_RESERVE_MULTIPLE
+                  : exitTreeCostSats <= netRecoveredSats * MAX_FEE_MULTIPLE
                     ? 'marginal'
                     : 'uneconomic';
 
@@ -798,13 +828,13 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         }
         if (economic === 'uneconomic') {
             if (policy !== 'recover-everything') {
-                exclude('reserve-dwarfs-value');
+                exclude('fees-dwarf-value');
                 continue;
             }
             notes.push('under-water');
         } else if (economic === 'marginal') {
             if (policy === 'profitable-only') {
-                exclude('reserve-dwarfs-value');
+                exclude('fees-dwarf-value');
                 continue;
             }
             notes.push('under-water');
@@ -851,7 +881,7 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         0,
     );
     const overridable = excluded.filter(
-        (e) => e.reason === 'reserve-dwarfs-value' || e.reason === 'refresh-before-exiting',
+        (e) => e.reason === 'fees-dwarf-value' || e.reason === 'refresh-before-exiting',
     );
 
     return {
@@ -916,7 +946,7 @@ export function describeExitExclusion(reason: ExitExclusionReason | undefined): 
             return 'expiring soon, refresh it instead of exiting it';
         case 'returns-nothing':
             return 'network fee is more than it holds';
-        case 'reserve-dwarfs-value':
+        case 'fees-dwarf-value':
             return 'costs far more in fees than it holds';
         default:
             return 'cannot be exited';

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -10,6 +10,7 @@ import {
   URGENCY_SOON_BLOCKS,
   ExitTriageVtxo,
   ExitTriageNote,
+  SPIKE_MULT,
   describeExitNote,
   RESERVE_FLOOR_SATS,
   perVtxoExitVb,
@@ -113,8 +114,8 @@ describe('the exit set on the live wallet', () => {
       expect(e.reason).toBeTruthy();
     }
     expect(r.excluded.map((e) => e.reason)).toEqual([
-      'reserve-dwarfs-value',
-      'reserve-dwarfs-value',
+      'fees-dwarf-value',
+      'fees-dwarf-value',
     ]);
   });
 
@@ -154,7 +155,7 @@ describe('the threshold is not a sat amount', () => {
     });
     // 6000 vB chain + 7350 CPFP = 13,350 vB to return 2,924 sats.
     expect(r.selectedIds).toEqual([]);
-    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+    expect(r.excluded[0].reason).toBe('fees-dwarf-value');
   });
 });
 
@@ -219,7 +220,7 @@ describe('economic axis across the fee-rate matrix', () => {
       vtxoExitDeltaBlocks: EXIT_DELTA,
     });
     expect(r.selectedIds).toEqual([]);
-    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+    expect(r.excluded[0].reason).toBe('fees-dwarf-value');
   });
 
   it('excludes a capsule its own claim fee would swallow, and says so', () => {
@@ -252,7 +253,7 @@ describe('economic axis across the fee-rate matrix', () => {
     // Same capsule, same fee spike, but the claim costs 380 rather than 1,520,
     // so it is dropped for consuming reserve, not for returning nothing.
     expect(r.excluded[0].marginalClaimSats).toBe(380);
-    expect(r.excluded[0].reason).toBe('reserve-dwarfs-value');
+    expect(r.excluded[0].reason).toBe('fees-dwarf-value');
   });
 
   it('keeps the two costs in separate pots', () => {
@@ -553,6 +554,76 @@ describe('economic policy: how far past the economics the user may go', () => {
     expect(r.reserveSats).toBe(5000);
     expect(r.expectedSpendSats).toBe(632);
     expect(r.netLossSats).toBe(0);
+  });
+
+  describe('the two-pot rule: the verdict is priced on spend, never on the reserve', () => {
+    // This is the invariant whose absence produced the 4,105 sat phantom loss.
+    // Everything economic here used to be NAMED for the reserve while being
+    // COMPUTED from spend, so netLossSats was written as
+    // `reserveSats - netRecoverableSats` and the confirm dialog condemned a
+    // profitable exit. These pin the separation so it cannot drift back.
+
+    it('does not let the reserve floor change any verdict', () => {
+      // The floor moves reserveSats by 8x on this wallet and must move the
+      // verdict by nothing at all.
+      const small = triageArkExit({
+        vtxos: [v({ id: 'small', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 })],
+        feeRateSatPerVb: 1,
+        chainTipHeight: TIP,
+        vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(small.reserveSats).toBe(RESERVE_FLOOR_SATS);
+      expect(small.reserveSats).toBeGreaterThan(small.expectedSpendSats * 7);
+      // Floor-dominated, and still profitable, because the floor is not a cost.
+      expect(small.selected[0].economic).toBe('profitable');
+      expect(small.netLossSats).toBe(0);
+    });
+
+    it('keeps expectedSpendSats free of SPIKE_MULT and of the floor', () => {
+      const r = triageArkExit({
+        vtxos: [
+          v({ id: 'a', sats: 500_000, exitDepth: 2, exitTxWeightWu: 1325 }),
+          v({ id: 'b', sats: 500_000, exitDepth: 3, exitTxWeightWu: 2337 }),
+        ],
+        feeRateSatPerVb: 3,
+        chainTipHeight: TIP,
+        vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      // Spend is exactly vsize x rate. No headroom, no floor.
+      expect(r.expectedSpendSats).toBe(r.totalExitVb * r.feeRateSatPerVb);
+      // The reserve is that same vsize with the headroom applied.
+      expect(r.reserveSats).toBe(r.expectedSpendSats * SPIKE_MULT);
+    });
+
+    it('prices each capsule verdict on its OWN spend, not a wallet-wide share', () => {
+      // A healthy capsule sharing a wallet with an expensive one must not be
+      // dragged under by it. Wallet-wide reserve thinking would do exactly that.
+      const alone = triageArkExit({
+        vtxos: [v({ id: 'healthy', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 })],
+        feeRateSatPerVb: 1, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      const withDeepNeighbour = triageArkExit({
+        vtxos: [
+          v({ id: 'healthy', sats: 971, exitDepth: 2, exitTxWeightWu: 1325 }),
+          v({ id: 'awful', sats: 400, exitDepth: 17, exitTxWeightWu: 2337 }),
+        ],
+        feeRateSatPerVb: 1, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      const healthyAlone = alone.selected.find((e) => e.id === 'healthy');
+      const healthyTogether = [...withDeepNeighbour.selected, ...withDeepNeighbour.excluded]
+        .find((e) => e.id === 'healthy');
+      expect(healthyAlone?.economic).toBe('profitable');
+      expect(healthyTogether?.economic).toBe('profitable');
+      expect(healthyTogether?.exitTreeCostSats).toBe(healthyAlone?.exitTreeCostSats);
+    });
+
+    it('never reports a loss larger than the exit can actually spend', () => {
+      // netLossSats is what the user is told they are giving up. It is bounded
+      // by expected spend by construction; against reserveSats it was not.
+      const forced = triage({ economicPolicy: 'recover-everything' });
+      expect(forced.netLossSats).toBeLessThanOrEqual(forced.expectedSpendSats);
+      expect(forced.netLossSats).toBeLessThan(forced.reserveSats);
+    });
   });
 
   it('includes a capsule whose runway it cannot check, and flags it', () => {
@@ -1049,8 +1120,8 @@ describe('freshness floor: refresh a stale capsule, do not exit it', () => {
     // which is the reason a user can act on: below the per-input round
     // minimum, they cannot be refreshed alone anyway.
     expect(r.excluded.map((e) => e.reason)).toEqual([
-      'reserve-dwarfs-value',
-      'reserve-dwarfs-value',
+      'fees-dwarf-value',
+      'fees-dwarf-value',
     ]);
   });
 });


### PR DESCRIPTION
**Stacked on #221. Merge that first, then this.** The base here is `fix/ark-exit-offline-disclosure`, so the diff will shrink to two files once #221 lands.

## Why this is not cosmetic

The phantom 4,105 sat loss fixed in #220 was not a slip in one expression. It was the predictable result of naming.

Every identifier on the economic axis was **named for the reserve** while being **computed from expected spend**. So `netLossSats`, documented as what the set "spends", was written as `reserveSats - netRecoverableSats`, and it read as correct to everyone who touched it, because everything around it said reserve.

The arithmetic was already right and is unchanged here. Only the names and the docs were lying.

| was | now | why |
|---|---|---|
| `MAX_RESERVE_MULTIPLE` | `MAX_FEE_MULTIPLE` | Multiplies `exitTreeCostSats`, never `reserveSats`. Its own docstring already reasoned purely in spend, "spends 632 to return 622", so the name was the only part claiming reserve. |
| `'reserve-dwarfs-value'` | `'fees-dwarf-value'` | The test is `exitTreeCostSats > netRecoveredSats * MAX_FEE_MULTIPLE`. No reserve appears in it. |
| "reserve cost" in `ExitEconomicPolicy` docs | "fee cost" | Twice. |

The user-facing string was already correct ("costs far more in fees than it holds"), so nothing the user reads changes.

## The rule, stated once

Adds a doc block above `ExitEconomicVerdict`:

> **EXPECTED SPEND** `exitTreeCostSats`, this capsule's own exit-tree vsize at the BARE fee rate. What the CPFP children actually pay. This, and only this, decides the verdict.
>
> **RESERVE** `reserveSats`, what the user must have AVAILABLE. Carries `SPIKE_MULT` headroom and a `RESERVE_FLOOR_SATS` minimum, is summed wallet-wide rather than per capsule, and whatever is not spent stays in their on-chain wallet. It is a funding requirement, NOT a cost, and it must never enter a profitability test.

With the measured size of the gap, so nobody assumes it is a rounding difference: 632 against a 5,000 floor on a single capsule, and 3,585 spent against a 12,072 reserve on the 2026-08-22 mainnet exit.

## The four tests are the actual deliverable

Renaming stops the next reader being misled. These stop the code drifting back:

- **The reserve floor moves `reserveSats` 8x on a small wallet and must move no verdict at all.** This is the exact configuration that produced the bug.
- **`expectedSpendSats` is exactly vsize times rate**, free of `SPIKE_MULT` and the floor, and `reserveSats` is that same figure with the headroom applied. Pins both definitions against each other.
- **Each capsule is priced on its OWN spend.** A healthy capsule sharing a wallet with a depth-17 dust capsule gets the same verdict it gets alone. Wallet-wide reserve thinking would drag it under, and that is the most tempting wrong refactor here.
- **`netLossSats` can never exceed what the exit can actually spend.** That bound is what was missing; against `reserveSats` there was none.

## Verification

- No behaviour change. Every existing assertion passes untouched apart from the renamed string literal.
- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **54 suites, 595 passed, 1 skipped**. Triage is now 100 tests.

## Deliberately not changed

`RESERVE_FLOOR_SATS` stays at 5,000. It has a real justification, enough for at least one CPFP child at a moderate rate, and it is capped below the 50k board minimum so it does not over-hoard. It over-demands 8x on a one-capsule exit, but over-reserving is safe, unspent sats come back, and #220 now says so at the point the number is read. Shared-ancestry double-counting in the reserve is a separate problem and stays in #201.
