### PR TITLE
fix(vault): make vault address rows selectable on iOS

### DIFF
--- a/components/addresses/AddressItem.js
+++ b/components/addresses/AddressItem.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { ListItem } from 'react-native-elements';
 import PropTypes from 'prop-types';
@@ -59,6 +59,16 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage, isTo
     });
   };
 
+  // Exactly what the inline onPress did before. Selecting a row hands its
+  // PUBLIC receive address back to the caller and nothing else: no key
+  // material, no signing, no storage write. The sign/verify path is a menu
+  // action (onPressMenuItem -> navigateToSignVerify), gated on
+  // allowSignVerifyMessage, and is deliberately untouched by this.
+  const handleRowPress = () => {
+    menuRef.current?.dismissMenu();
+    navigateToReceive(item);
+  };
+
   const balance = formatBalance(item.balance, balanceUnit, true);
 
   const handleCopyPress = () => {
@@ -104,20 +114,28 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage, isTo
     return actions;
   };
 
+  // TooltipMenu is platform-split and the two builds disagree about onPress.
+  //
+  // components/TooltipMenu.android.js wraps children in a TouchableOpacity and
+  // forwards props.onPress, so Android taps work and a second touchable there
+  // would double-fire.
+  //
+  // components/TooltipMenu.js, the iOS build, is `props => props.children`. It
+  // discards every prop including onPress, so on iOS a row relying on it to
+  // deliver a tap is completely inert. That is why picking an address from
+  // Receive > vault > View all vault addresses did nothing on iOS: the whole
+  // chain after the tap is correct (navigateToReceive hands the address to
+  // HomeScreen, which consumes selectedVaultAddress), but the tap was thrown
+  // away before it could start.
+  //
+  // Fixed here rather than in the shared stub on purpose. Five other files
+  // import TooltipMenu, and all of them are legacy screens nothing in src/
+  // navigates to, so changing the stub would alter five call sites to fix zero
+  // reachable bugs.
+  const tooltipDeliversTap = Platform.OS === 'android';
+
   const render = () => {
-    return (
-      <TooltipMenu
-        title={item.address}
-        ref={menuRef}
-        actions={getAvailableActions()}
-        onPressMenuItem={onToolTipPress}
-        previewQRCode
-        previewValue={item.address}
-        {...isTouchable && { onPress: () => {
-          menuRef.current?.dismissMenu();
-          navigateToReceive(item) 
-        }}}
-      >
+    const row = (
         <ListItem key={item.key} containerStyle={stylesHook.container}>
           <ListItem.Content style={stylesHook.list}>
             <ListItem.Title style={stylesHook.list} numberOfLines={1} ellipsizeMode="middle">
@@ -135,6 +153,25 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage, isTo
             </Text>
           </View>
         </ListItem>
+    );
+
+    return (
+      <TooltipMenu
+        title={item.address}
+        ref={menuRef}
+        actions={getAvailableActions()}
+        onPressMenuItem={onToolTipPress}
+        previewQRCode
+        previewValue={item.address}
+        {...(isTouchable && tooltipDeliversTap && { onPress: handleRowPress })}
+      >
+        {isTouchable && !tooltipDeliversTap ? (
+          <TouchableOpacity onPress={handleRowPress} accessibilityRole="button">
+            {row}
+          </TouchableOpacity>
+        ) : (
+          row
+        )}
       </TooltipMenu>
     );
   };


### PR DESCRIPTION
Field report: Receive, pick a vault, **View all vault addresses**, then tapping a row does nothing. The list renders fine and the rows are simply inert.

## Cause

`TooltipMenu` is platform-split and the two builds disagree about `onPress`.

`components/TooltipMenu.android.js` wraps children in a `TouchableOpacity` and forwards `props.onPress`.

`components/TooltipMenu.js`, the iOS build, is the entire file:

```js
const ToolTipMenu = props => {
  return props.children;
};

export default ToolTipMenu;
```

It renders children and discards every prop, `onPress` included. `AddressItem` handed its tap to that component, so on iOS the tap was thrown away before it could start.

**Everything downstream was already correct**, which is why this presented as a rendering bug rather than a wiring one. `ReceivedListNew` navigates with `isTouchable: true` and `selectForReceive: true`, `navigateToReceive` returns the chosen address to HomeScreen, and HomeScreen consumes `selectedVaultAddress`. Only the first link in the chain was missing.

## The fix

The tap now goes to whichever build actually handles it: `TooltipMenu` on Android, a `TouchableOpacity` around the row on iOS. Adding the touchable unconditionally would **double-fire on Android**, since its `TooltipMenu` already provides one.

## Why not fix the stub

Five other files import `TooltipMenu`: `TransactionListItem`, `QRCodeComponent`, `TransactionsNavigationHeader`, `screen/transactions/details`, `screen/send/details`. Every one is a legacy screen that **nothing under `src/` navigates to**, so changing the stub would alter five call sites to fix zero reachable bugs. `TransactionsNavigationHeader` also nests seven touchables of its own, where a new wrapper could swallow or double their taps.

I initially assumed the stub was killing taps app-wide and said so. It is not. The reachable transaction list is `src/screens/HotStorageVault/History.tsx`, which uses its own `onPressHandler`. Confirmed on device: tapping a transaction row already worked, which is what ruled the wider theory out.

## Scope, since this is a wallet

The tap path is `dismissMenu()` then `navigateToReceive(item)`, carrying a **public receive address already rendered on screen**. No key material, no signing, no storage write, no network call.

The sign/verify action is a menu item (`onPressMenuItem` to `navigateToSignVerify`), still gated on `allowSignVerifyMessage`. Its wiring is byte-identical before and after: the only `sign`/menu lines in the diff are matched `-`/`+` pairs from the JSX block moving. Grepping the added lines for `seed|mnemonic|private|xprv|sign|keychain|Realm|AsyncStorage|setItem|fetch(|eval(|child_process` matches nothing but comment text.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **54 suites, 595 passed, 1 skipped**
- Parses under the project babel config

Not device-verified yet. Worth a look on Android too, since that path is the one that could regress: taps there must fire exactly once.
