### PR TITLE
fix(fees): bound the fee lookups so the fallback chain can actually reach the end

### DIFF
--- a/src/api/coinOSApis.ts
+++ b/src/api/coinOSApis.ts
@@ -395,7 +395,7 @@ export const sendInternalPayment = async (amount: number, hash: string) => {
 // Static mainnet fee tiers (sat/vB), used only when BOTH live sources are
 // unreachable. Conservative-but-usable so an on-chain withdraw is never
 // hard-blocked by a fee-endpoint outage. Same keys mempool.space returns.
-const FALLBACK_FEE_TIERS = {
+export const FALLBACK_FEE_TIERS = {
   fastestFee: 20,
   halfHourFee: 12,
   hourFee: 8,
@@ -410,15 +410,40 @@ const FALLBACK_FEE_TIERS = {
 // UNMOUNTED the whole fee selector in ReviewPayment and dead-ended the withdraw.
 // Now fall back to the blockstream esplora we already use, then to static tiers,
 // so the selector always has usable values and the flow never gets stuck.
+/**
+ * How long a single fee-source lookup may take before we move on.
+ *
+ * This is the load-bearing part of the fallback chain, not a nicety. Neither
+ * fetch below used to carry a timeout, and React Native's default is around 60s
+ * per request, so a source that HANGS rather than errors never yields. Observed
+ * on device 2026-08-25: mempool.space timed out, execution moved to blockstream,
+ * blockstream hung, and the static-tier return below was therefore unreachable.
+ * `recommendedFee` stayed at its initial empty value indefinitely and the fee
+ * selector rendered an empty list, which reads as a dead button.
+ *
+ * A three-tier fallback that can only ever reach tier one is not a fallback.
+ * 4s matches fetchExitFeeRates in services/ark/exitFunding.ts.
+ */
+const FEE_SOURCE_TIMEOUT_MS = 4000;
+
+const fetchWithTimeout = async (url: string) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FEE_SOURCE_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 export const bitcoinRecommendedFee = async () => {
   // Primary: mempool.space (native shape).
   try {
-    const response = await fetch(`https://mempool.space/api/v1/fees/recommended`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    const response = await fetchWithTimeout(`https://mempool.space/api/v1/fees/recommended`);
     if (response.ok) {
       const data = await response.json();
       if (data?.fastestFee != null) return data;
@@ -431,12 +456,7 @@ export const bitcoinRecommendedFee = async () => {
   // blocks) to sat/vB. Already a trusted endpoint (the Ark esplora). Map its
   // targets onto mempool's tier shape so the UI is unchanged.
   try {
-    const response = await fetch(`https://blockstream.info/api/fee-estimates`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    const response = await fetchWithTimeout(`https://blockstream.info/api/fee-estimates`);
     if (response.ok) {
       const est = await response.json();
       const pick = (target: string, fallback: number) =>

--- a/src/screens/ReviewPayment/index.tsx
+++ b/src/screens/ReviewPayment/index.tsx
@@ -15,7 +15,7 @@ import LinearGradient from "react-native-linear-gradient";
 import TextView from "./TextView";
 import TextViewV2 from "../Invoice/TextView"
 import useAuthStore from "@Cypher/stores/authStore";
-import { bitcoinRecommendedFee, bitcoinSendFee, getCurrencyRates, getMe, sendBitcoinPayment, sendCoinsViaUsername, sendLightningPayment } from "@Cypher/api/coinOSApis";
+import { FALLBACK_FEE_TIERS, bitcoinRecommendedFee, bitcoinSendFee, getCurrencyRates, getMe, sendBitcoinPayment, sendCoinsViaUsername, sendLightningPayment } from "@Cypher/api/coinOSApis";
 import { btc, formatNumber, getStrikeCurrency, matchKeyAndValue, SATS } from "@Cypher/helpers/coinosHelper";
 import { FeeSelection } from "./FeeSelection/FeeSelection";
 import bolt11 from "bolt11";
@@ -165,7 +165,12 @@ export default function ReviewPayment({ navigation, route }: Props) {
     // unreachable). Rendering the fee dropdown off an undefined object was
     // a hard crash in release builds. Self-heal: seed from the param, fetch
     // fresh rates if missing.
-    const [recommendedFee, setRecommendedFee] = useState<any>(recommendedFeeParam);
+    // Falls back to the static tiers when the caller did not pass any, for the
+    // same reason as ReviewWithdrawal: an absent value renders an empty
+    // selector, which is indistinguishable from a broken control.
+    const [recommendedFee, setRecommendedFee] = useState<any>(
+        recommendedFeeParam?.fastestFee != null ? recommendedFeeParam : FALLBACK_FEE_TIERS,
+    );
     useEffect(() => {
         if (recommendedFee?.fastestFee != null) return;
         let cancelled = false;

--- a/src/screens/ReviewWithdrawal/FeeSelection/FeeSelection.tsx
+++ b/src/screens/ReviewWithdrawal/FeeSelection/FeeSelection.tsx
@@ -30,10 +30,30 @@ export const FeeSelection: React.FC<FeeSelectionProps> = ({ disabled = false, se
     onFeeSelect(fee);
   };
 
+  // Last line of defence. Callers now seed with static tiers, but this component
+  // used to render Object.entries([]) whenever the fee lookup had not landed,
+  // which produces literally nothing: the sheet opens, the chevron animates, and
+  // there is no list and no explanation. Reported from the field as "the select
+  // fee button is not working". An empty selector must always say why it is
+  // empty rather than looking like a dead control.
+  const entries = Object.entries(fees ?? {}).filter(
+    ([feeKey, feeValue]) => feeKey !== 'minimumFee' && Number.isFinite(Number(feeValue)),
+  );
+
+  if (entries.length === 0) {
+    return (
+      <View>
+        <Text style={{ color: 'white', marginVertical: 10 }}>
+          Fee rates are still loading. If this does not clear, check your connection and try again.
+        </Text>
+      </View>
+    );
+  }
+
   return (
     <View>
-        {Object.entries(fees).map(([feeKey, feeValue]) => (
-            feeKey !== 'minimumFee' && (
+        {entries.map(([feeKey, feeValue]) => (
+            (
                 <TouchableOpacity
                 key={feeKey}
                 onPress={() => handleFeeSelection(feeKey as Fee)}
@@ -44,7 +64,7 @@ export const FeeSelection: React.FC<FeeSelectionProps> = ({ disabled = false, se
                     {/* Use selectedFee prop to determine if the fee is selected */}
                     {selectedName === feeKey && <View style={{ width: 14, height: 14, borderRadius: 7, backgroundColor: 'white' }} />}
                 </View>
-                <Text style={{color: 'white'}}>{feeNames[feeKey as Fee]} &mdash; {feeValue} sats</Text>
+                <Text style={{color: 'white'}}>{feeNames[feeKey as Fee]}: {feeValue} sat/vB</Text>
                 </TouchableOpacity>
             )
         ))}

--- a/src/screens/ReviewWithdrawal/index.tsx
+++ b/src/screens/ReviewWithdrawal/index.tsx
@@ -27,6 +27,7 @@ import TextViewV2 from '../Invoice/TextView';
 import useAuthStore from '@Cypher/stores/authStore';
 import {
     bitcoinRecommendedFee,
+    FALLBACK_FEE_TIERS,
     bitcoinSendFee,
     getCurrencyRates,
     getMe,
@@ -77,7 +78,14 @@ export default function ReviewWithdrawal({ route }: Props) {
     const [feeLoading, setFeeLoading] = useState<boolean>(false);
     const [isSendLoading, setIsSendLoading] = useState<boolean>(false);
     const [isModalVisible, setModalVisible] = useState(false);
-    const [recommendedFee, setRecommendedFee] = useState<any>([]);
+    // Seeded with the static tiers rather than []. handleUser() below awaits
+    // getMe() and getCurrencyRates() BEFORE the fee lookup, all in one try whose
+    // catch only logs, so anything slow or throwing up there leaves this state
+    // at its initial value. When that value was [] the selector rendered
+    // Object.entries([]) and produced no rows at all, which reads as a broken
+    // button rather than a network problem. Real tiers overwrite this the moment
+    // they arrive.
+    const [recommendedFee, setRecommendedFee] = useState<any>(FALLBACK_FEE_TIERS);
 
     const swipeButtonRef = useRef(null);
     const feeNames: Record<Fee, string> = {

--- a/tests/unit/feeSelection.test.tsx
+++ b/tests/unit/feeSelection.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * The fee selector must never render as a dead control.
+ *
+ * Field report 2026-08-25: on a second withdrawal the Select Fee button "did
+ * nothing", only the chevron animated. The sheet was opening correctly; the
+ * component was rendering `Object.entries([]).map(...)`, which produces no rows
+ * and no explanation, because the fee lookup had not landed. See the note in
+ * FeeSelection.tsx.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { FeeSelection } from '../../src/screens/ReviewWithdrawal/FeeSelection/FeeSelection';
+
+const TIERS = { fastestFee: 20, halfHourFee: 12, hourFee: 8, economyFee: 4, minimumFee: 1 };
+
+const textOf = (tree: any): string => {
+    const out: string[] = [];
+    const walk = (n: any) => {
+        if (n == null) return;
+        if (typeof n === 'string') { out.push(n); return; }
+        if (Array.isArray(n)) { n.forEach(walk); return; }
+        if (n.children) n.children.forEach(walk);
+    };
+    walk(tree);
+    return out.join(' ');
+};
+
+const render = (fees: any) =>
+    renderer.create(
+        <FeeSelection
+            fees={fees}
+            disabled={false}
+            selectedName={null}
+            onFeeSelect={() => {}}
+            onSelectFeeName={() => {}}
+        />,
+    ).toJSON();
+
+describe('an empty fee table', () => {
+    it('explains itself instead of rendering nothing', () => {
+        // This is the exact regression: [] is the initial state of the caller.
+        const text = textOf(render([]));
+        expect(text).toMatch(/loading|connection/i);
+        expect(text.trim().length).toBeGreaterThan(0);
+    });
+
+    it('survives undefined and null without throwing', () => {
+        expect(() => render(undefined)).not.toThrow();
+        expect(() => render(null)).not.toThrow();
+        expect(textOf(render(undefined))).toMatch(/loading|connection/i);
+    });
+
+    it('does not render an option row when there is nothing to pick', () => {
+        expect(textOf(render([]))).not.toMatch(/Fastest|Slow/);
+    });
+});
+
+describe('a populated fee table', () => {
+    it('renders every tier except minimumFee', () => {
+        const text = textOf(render(TIERS));
+        for (const name of ['Fastest', 'Fast', 'Medium', 'Slow']) {
+            expect(text).toContain(name);
+        }
+        // minimumFee has no display name, so a row for it would read "undefined".
+        expect(text).not.toContain('undefined');
+    });
+
+    it('labels rates as sat/vB, and carries no em dash', () => {
+        const text = textOf(render(TIERS));
+        expect(text).toContain('sat/vB');
+        expect(text).not.toContain('—');
+    });
+
+    it('drops a tier whose value is not a number rather than showing NaN', () => {
+        const text = textOf(render({ ...TIERS, halfHourFee: null }));
+        expect(text).toContain('Fastest');
+        expect(text).not.toContain('Fast:');
+        expect(text).not.toContain('NaN');
+    });
+});


### PR DESCRIPTION
Field report: on a second on-chain withdrawal the **Select Fee** button "did nothing", only the chevron moved. The sheet was opening correctly. It was rendering an empty list.

## Diagnosed on device, not from reading

Captured over 150s while the button was tapped:

```
[warning] bitcoinRecommendedFee: mempool.space failed, trying blockstream:
          TypeError: Network request timed out            (x3)
```

and in the same window, **zero** `recommendedFeesRes` logs and **zero** logs from `handleUser`'s catch. So `handleUser` neither completed nor threw, three separate times. It was **hanging**, not failing.

## That is the whole bug

`bitcoinRecommendedFee` has three tiers (mempool.space, blockstream, static) and **neither fetch carried a timeout**. React Native's default is around 60s per request, and a source that *hangs* rather than errors never yields at all, so execution never reached the static tiers.

The comment above them reads "Fallback 2: static tiers so the selector never disappears". That line is only reachable if blockstream returns or throws. When it hangs, it is dead code.

**A three-tier fallback that can only ever reach tier one is not a fallback.** Blockstream hanging is consistent with the rate-limit history in #194.

## Three layers, so no single failure reproduces it

**1. Bound both fetches.** A 4s `AbortController`, matching `fetchExitFeeRates` in `services/ark/exitFunding.ts`. This is the load-bearing change: it is what makes the existing fallback reachable at all.

**2. Never start empty.** `ReviewWithdrawal` seeded its state with `[]`, `ReviewPayment` with a route param that may be absent. Both now seed with `FALLBACK_FEE_TIERS`.

This matters beyond timeouts. `handleUser` awaits `getMe()` and `getCurrencyRates()` **before** the fee lookup, all in one try whose catch only logs, so anything throwing up there leaves the selector empty no matter how fast the fee source is.

**3. An empty selector must explain itself.** `FeeSelection` rendered `Object.entries(fees).map(...)`, which for an empty or absent table produces literally nothing: no rows, no message, no spinner. That is what reads as a dead button. It now says the rates are still loading and to check the connection.

## Also

Drops an em dash from user-facing copy, and labels tiers **sat/vB** rather than "sats", which is what the value actually is: it is passed straight to `bitcoinSendFee(amount, address, feeRate)` as a rate. Flagging that as a copy change rather than sneaking it in.

## Scope

**No new network endpoint.** The host set in `coinOSApis.ts` is byte-identical to `main`; this bounds two existing calls and adds none. No key material, storage, or signing path is touched.

Worth knowing: `bitcoinRecommendedFee` is used by **six** screens (`ReviewWithdrawal`, `ReviewPayment`, `Send`, `HomeScreen`, `StrikeView`, `Strike/BuyBitcoin`), so this was never confined to the CoinOS withdraw flow despite living in `coinOSApis.ts`. The Strike paths could hit the same hang.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **55 suites, 601 passed, 1 skipped**
- 6 new tests: the empty table explains itself, `undefined` and `null` do not throw, no option row is rendered when there is nothing to pick, every tier except `minimumFee` renders, a non-numeric tier is dropped rather than shown as `NaN`, and the copy carries no em dash

Not device-verified. The honest test is to hit it while mempool is slow, which is not reproducible on demand; the timeout is what makes that case survivable rather than permanent.
