### PR TITLE
fix(ark): actually use the network-fault classifier at the surfaces users hit

### DIFF
--- a/src/screens/Ark/ArkSendReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkSendReviewScreen/index.tsx
@@ -7,6 +7,9 @@ import { dispatchNavigate } from '@Cypher/helpers';
 import { getStrikeCurrency } from '@Cypher/helpers/coinosHelper';
 import { btc } from '@Cypher/helpers/bitcoinUnits';
 import {
+    describeArkFailure,
+    ESPLORA_URLS,
+    ARK_SERVER_URL,
     ARK_VTXO_DUST_SATS,
     classifyArkDestination,
     estimateArkSendFee,
@@ -115,7 +118,7 @@ export default function ArkSendReviewScreen({ route }: Props) {
                 if (cancelled) return;
                 setFee(null);
                 setErrorMsg(
-                    `Fee estimate failed: ${err?.message ?? 'unknown error'}`,
+                    describeArkFailure(err, 'Fee estimate failed', { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }),
                 );
             } finally {
                 if (!cancelled) setIsEstimating(false);
@@ -182,8 +185,12 @@ export default function ArkSendReviewScreen({ route }: Props) {
                 setSendIndeterminate(true);
                 setErrorMsg(err?.message ?? 'This payment may still be in flight. Do not send it again.');
             } else {
+                // Only reached once isArkSendIndeterminate has ruled out the
+                // ambiguous case above, so "not moved" is still a safe claim.
+                // Kept verbatim: the network sentence explains WHY, it does not
+                // replace the fund-safety assertion.
                 setErrorMsg(
-                    `Send failed: ${err?.message ?? 'unknown error'}. Your funds were not moved.`,
+                    `${describeArkFailure(err, 'Send failed', { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL })} Your funds were not moved.`,
                 );
             }
         } finally {

--- a/src/screens/Ark/ArkWithdrawReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkWithdrawReviewScreen/index.tsx
@@ -27,6 +27,8 @@ import {
     type ArkSendFeeView,
 } from '@Cypher/services/ark/send';
 import { fetchArkBalance } from '@Cypher/services/ark/balance';
+import { describeArkFailure } from '@Cypher/services/ark/networkFault';
+import { ARK_SERVER_URL, ESPLORA_URLS } from '@Cypher/services/ark/config';
 
 import TextViewV2 from '../../Invoice/TextView';
 import reviewStyles from '../../ReviewPayment/styles';
@@ -181,11 +183,7 @@ export default function ArkWithdrawReviewScreen({ route }: Props) {
             } catch (err: any) {
                 if (cancelled) return;
                 setFee(null);
-                setFeeError(
-                    err?.message
-                        ? `Fee estimate failed: ${err.message}`
-                        : 'Fee estimate failed.',
-                );
+                setFeeError(describeArkFailure(err, 'Fee estimate failed', { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }));
             } finally {
                 if (!cancelled) setIsEstimating(false);
             }
@@ -305,6 +303,12 @@ export default function ArkWithdrawReviewScreen({ route }: Props) {
             }
         } catch (err: any) {
             console.warn('[ArkWithdraw] send failed:', err);
+            // NOT routed through describeArkFailure, deliberately. Its
+            // 'ark-server' sentence asserts "Your funds are safe", and unlike
+            // ArkSendReviewScreen this path carries no isArkSendIndeterminate
+            // guard, so an ambiguous outcome would be reported as a definite
+            // one. That is the exact failure the indeterminate handling exists
+            // to prevent. Fix the guard first, then the copy.
             SimpleToast.show(
                 `Withdraw failed: ${err?.message ?? 'unknown error'}`,
                 SimpleToast.LONG,

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -12,6 +12,9 @@ import { dispatchNavigate } from "@Cypher/helpers";
 import { formatCapsuleAmount } from "@Cypher/helpers/bitcoinUnits";
 
 import {
+    describeArkFailure,
+    ESPLORA_URLS,
+    ARK_SERVER_URL,
     ARK_REFRESH_MIN_SATS,
     ARK_VTXO_DUST_SATS,
     AVG_BLOCK_MINUTES,
@@ -1705,8 +1708,13 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 /BarkError\.Internal/i.test(msg) && totalSats > 0 && totalSats < 500;
             SimpleToast.show(
                 isInternalLikelyDust
-                    ? `Refresh rejected by Ark server. ${totalSats}-sat capsule is likely below the round's minimum size — consolidate it via a self-send before refreshing.`
-                    : `Refresh failed: ${msg || 'unknown error'}`,
+                    ? `Refresh rejected by Ark server. The ${totalSats}-sat capsule is likely below the round's minimum size. Consolidate it via a self-send before refreshing.`
+                    // Classify before falling back to the raw SDK text. Observed
+                    // on device: a refresh that could not resolve blockstream
+                    // showed the user a full Reqwest/hyper error, naming the
+                    // chain source it could not reach, while the classifier that
+                    // would have said "try mobile data" sat unused.
+                    : describeArkFailure(err, 'Refresh failed', { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }),
                 SimpleToast.LONG,
             );
         } finally {

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -30,6 +30,9 @@ import SimpleToast from "react-native-simple-toast";
 import styles from "./styles";
 import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods, revokeStrikeToken } from "@Cypher/api/strikeAPIs";
 import {
+  describeArkFailure,
+  ESPLORA_URLS,
+  ARK_SERVER_URL,
   AUTO_BACKUP_PATH,
   areBgNotificationsEnabled,
   computeArkExitPlan,
@@ -1620,7 +1623,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
               } catch (err: any) {
                 console.warn('[Ark exit] start failed:', 'tag=', err?.tag, 'inner=', err?.inner?.errorMessage ?? err?.inner?.message, 'message=', err?.message ?? String(err));
                 SimpleToast.show(
-                  `Couldn't start exit: ${err?.message ?? 'unknown error'}`,
+                  describeArkFailure(err, "Couldn't start exit", { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }),
                   SimpleToast.LONG,
                 );
               } finally {

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -242,6 +242,7 @@ export type {
 export {
     arkErrorText,
     arkNetworkFaultMessage,
+    describeArkFailure,
     classifyArkNetworkFault,
 } from './networkFault';
 export type { ArkNetworkFault } from './networkFault';

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -137,3 +137,36 @@ export function arkNetworkFaultMessage(fault: ArkNetworkFault): string | null {
             return null;
     }
 }
+
+/**
+ * The whole pattern in one call: classify, and fall back to the raw SDK text
+ * only when the cause is not recognisable.
+ *
+ * This exists because the two-step version did not get used. `classifyArkNetworkFault`
+ * and `arkNetworkFaultMessage` shipped with unit tests and were wired into
+ * exactly ONE screen out of every Ark failure surface in the app, so a refresh
+ * that could not reach blockstream showed the user:
+ *
+ *     Refresh failed: Exception.Inner: Reqwest(reqwest::Error { kind: Request,
+ *     url: "https://blockstream.info/api/blocks/tip/height", source: ...
+ *     ConnectError("dns error", ...) })
+ *
+ * captured on device 2026-08-25. That string even names the chain source, so
+ * the classifier would have got it right had anyone asked it.
+ *
+ * Endpoints stay a parameter rather than being read from ./config, so this
+ * module keeps no import of the native bark binding and stays unit-testable.
+ *
+ * `context` is the action that failed, phrased so it reads before either
+ * ending: "Refresh failed", "Couldn't start exit".
+ */
+export function describeArkFailure(
+    err: unknown,
+    context: string,
+    endpoints: { chainUrls?: readonly string[]; arkUrl?: string | null },
+): string {
+    const fault = arkNetworkFaultMessage(classifyArkNetworkFault(err, endpoints));
+    if (fault) return `${context}. ${fault}`;
+    const raw = arkErrorText(err);
+    return raw ? `${context}: ${raw}` : `${context}: unknown error`;
+}

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -13,6 +13,7 @@ import {
     arkErrorText,
     arkNetworkFaultMessage,
     classifyArkNetworkFault,
+    describeArkFailure,
 } from '../../src/services/ark/networkFault';
 
 const ENDPOINTS = {
@@ -159,5 +160,61 @@ describe('rate limiting, which the raw symptom misreports as corruption', () => 
         expect(classify('https://ark.second.tech: 429 too many requests')).toBe(
             'ark-server',
         );
+    });
+});
+
+describe('describeArkFailure: the one-call form that call sites actually use', () => {
+    // The two-step form shipped tested and was wired into exactly ONE screen,
+    // so a refresh that could not reach blockstream showed the user a raw
+    // Reqwest error. These pin the shape that replaced it.
+
+    /** Verbatim from the device, 2026-08-25, airplane mode, tapping Refresh. */
+    const DEVICE_DNS_ERROR = {
+        tag: 'Inner',
+        message:
+            'Exception.Inner: Reqwest(reqwest::Error { kind: Request, url: ' +
+            '"https://blockstream.info/api/blocks/tip/height", source: ' +
+            'hyper_util::client::legacy::Error(Connect, ConnectError("dns error", ' +
+            'Custom { kind: Uncategorized, error: "failed to lookup address ' +
+            'information: nodename nor servname provided, or not known" })) })',
+    };
+
+    it('turns the exact error the user saw into advice, not a stack trace', () => {
+        const out = describeArkFailure(DEVICE_DNS_ERROR, 'Refresh failed', ENDPOINTS);
+        expect(out).toContain('Refresh failed.');
+        expect(out).toContain('try mobile data');
+        // The whole point: none of the SDK internals reach the user.
+        expect(out).not.toMatch(/Reqwest|hyper_util|ConnectError|Exception\.Inner/);
+    });
+
+    it('names the Ark server without suggesting a network switch', () => {
+        const out = describeArkFailure(
+            { message: 'error trying to connect to https://ark.second.tech' },
+            "Couldn't start exit",
+            ENDPOINTS,
+        );
+        expect(out).toContain("Couldn't start exit.");
+        expect(out).toContain('Ark server is not responding');
+        expect(out).not.toContain('mobile data');
+    });
+
+    it('falls back to the raw text when the cause is not recognisable', () => {
+        const out = describeArkFailure({ message: 'something odd' }, 'Send failed', ENDPOINTS);
+        expect(out).toBe('Send failed: something odd');
+    });
+
+    it('never renders an empty tail for a null error', () => {
+        expect(describeArkFailure(null, 'Send failed', ENDPOINTS)).toBe('Send failed: unknown error');
+        expect(describeArkFailure(undefined, 'Refresh failed', ENDPOINTS)).toBe(
+            'Refresh failed: unknown error',
+        );
+    });
+
+    it('keeps context and advice as separate sentences, so both survive', () => {
+        // Callers append their own clauses (for instance "Your funds were not
+        // moved."), so the string must end cleanly rather than mid-phrase.
+        const out = describeArkFailure(DEVICE_DNS_ERROR, 'Send failed', ENDPOINTS);
+        expect(out.startsWith('Send failed. ')).toBe(true);
+        expect(out.trim().endsWith('.')).toBe(true);
     });
 });


### PR DESCRIPTION
Reproduced on device: airplane mode, tap **Refresh** on the Bark Vault.

```
Refresh failed: Exception.Inner: Reqwest(reqwest::Error { kind: Request,
url: "https://blockstream.info/api/blocks/tip/height", source:
hyper_util::client::legacy::Error(Connect, ConnectError("dns error",
Custom { kind: Uncategorized, error: "failed to lookup address
information: nodename nor servname provided, or not known" })) })
```

## The logic existed. The wiring did not.

`classifyArkNetworkFault` and `arkNetworkFaultMessage` already shipped, with 24 unit tests, exported from the barrel. They were wired into **exactly one screen**: `ArkInvoiceScreen`. Every other Ark failure surface pasted the raw SDK string.

The error above even **names `blockstream.info`**, so the classifier would have answered correctly had anyone asked it. The user should have seen "Can't reach the Bitcoin network data provider. If you're on Wi-Fi, try mobile data, then try again."

This is the third instance of the same shape recently: `ExitTriageNote` computed and rendered nowhere, a copy fix landed on the unreachable `ArkReceiveScreen`, and now this. **The logic lands, the wiring does not.**

So the fix is a one-call form rather than another two-step invitation to forget:

```ts
describeArkFailure(err, 'Refresh failed', { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL })
```

Classifies, and falls back to the raw text only when the cause is unrecognisable. Endpoints stay a parameter so `networkFault.ts` keeps no import of the native bark binding and stays unit-testable.

## Where it was applied

Checked with a navigation audit rather than assumed. `ArkReceiveScreen` is registered in `Navigation.js` but navigated to from **zero** places, so it is left alone.

| surface | applied |
|---|---|
| `ArkCapsules` refresh failure | yes, the reported one |
| `Settings` "Couldn't start exit" | yes, emergency exit path |
| `ArkSendReviewScreen` fee estimate | yes |
| `ArkSendReviewScreen` determinate send failure | yes |
| `ArkWithdrawReviewScreen` fee estimate | yes |
| `ArkWithdrawReviewScreen` withdraw failure | **no, see below** |
| `ArkSendReviewScreen` indeterminate branch | **no, see below** |

## Two places deliberately left alone, both on fund safety

The `ark-server` sentence asserts **"Your funds are safe"**. That is fine when the failure is known to be clean. It is not fine where the outcome is unknown.

**`ArkSendReviewScreen`'s indeterminate branch.** "This payment may still be in flight. Do not send it again." is the honest answer when `isArkSendIndeterminate` fires. Overwriting it with a funds-are-safe claim would invert its meaning.

**`ArkWithdrawReviewScreen`'s withdraw failure.** Same problem, and worse: unlike the send screen, this path carries **no `isArkSendIndeterminate` guard at all**, so an ambiguous outcome would be reported as a definite one. Routing it through the classifier would have introduced exactly the bug the indeterminate handling exists to prevent. A comment records why, and **the missing guard is worth fixing before the copy** — flagging that as a follow-up rather than fixing a fund-safety path in a copy PR.

Where the network sentence sits alongside an existing fund claim, the claim is kept verbatim rather than replaced. The classifier explains **why** something failed; it does not get to say what happened to the money.

## Also

Drops an em dash from user-facing copy in the same catch block, the sub-minimum-capsule refresh message.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **55 suites, 606 passed, 1 skipped**
- 5 new tests, including one that pins the **verbatim device error** above and asserts that none of `Reqwest`, `hyper_util`, `ConnectError` or `Exception.Inner` reaches the user

Device-verifiable the same way it was found: airplane mode, tap Refresh, expect advice rather than a stack trace.
