### PR TITLE
fix(ark): open the vault instead of reporting it shut, and say what to do

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -13,6 +13,8 @@ import { formatCapsuleAmount } from "@Cypher/helpers/bitcoinUnits";
 
 import {
     describeArkFailure,
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
     ESPLORA_URLS,
     ARK_SERVER_URL,
     ARK_REFRESH_MIN_SATS,
@@ -1706,17 +1708,34 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 .reduce((acc, r) => acc + r.sats, 0);
             const isInternalLikelyDust =
                 /BarkError\.Internal/i.test(msg) && totalSats > 0 && totalSats < 500;
-            SimpleToast.show(
-                isInternalLikelyDust
-                    ? `Refresh rejected by Ark server. The ${totalSats}-sat capsule is likely below the round's minimum size. Consolidate it via a self-send before refreshing.`
-                    // Classify before falling back to the raw SDK text. Observed
-                    // on device: a refresh that could not resolve blockstream
-                    // showed the user a full Reqwest/hyper error, naming the
-                    // chain source it could not reach, while the classifier that
-                    // would have said "try mobile data" sat unused.
-                    : describeArkFailure(err, 'Refresh failed', { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }),
-                SimpleToast.LONG,
-            );
+            // Classify before falling back to the raw SDK text. Observed on
+            // device: a refresh that could not resolve blockstream showed the
+            // user a full Reqwest/hyper error, naming the chain source it could
+            // not reach, while the classifier that would have said "try mobile
+            // data" sat unused.
+            const fault = classifyArkNetworkFault(err, {
+                chainUrls: ESPLORA_URLS,
+                arkUrl: ARK_SERVER_URL,
+            });
+            const faultAdvice = arkNetworkFaultMessage(fault);
+            if (!isInternalLikelyDust && faultAdvice) {
+                // A three-second toast is the wrong surface for a failure the
+                // user has to DO something about. This one has a specific
+                // remedy (change network, or wait out a quota), and a chip that
+                // disappears before it is read leaves them tapping Refresh
+                // again into the same wall. Alert stays until dismissed.
+                Alert.alert('Refresh failed', faultAdvice);
+            } else {
+                SimpleToast.show(
+                    isInternalLikelyDust
+                        ? `Refresh rejected by Ark server. The ${totalSats}-sat capsule is likely below the round's minimum size. Consolidate it via a self-send before refreshing.`
+                        : describeArkFailure(err, 'Refresh failed', {
+                              chainUrls: ESPLORA_URLS,
+                              arkUrl: ARK_SERVER_URL,
+                          }),
+                    SimpleToast.LONG,
+                );
+            }
         } finally {
             setRefreshing(false);
         }

--- a/src/services/ark/backup.ts
+++ b/src/services/ark/backup.ts
@@ -623,7 +623,7 @@ async function _packDatadirIntoBlob(
 
     const relPaths = await listFilesRelative(datadir);
     if (relPaths.length === 0) {
-        throw new Error('Ark datadir is empty — nothing to back up');
+        throw new Error('Ark datadir is empty, so there is nothing to back up');
     }
 
     const files: BackupFileEntry[] = [];
@@ -909,7 +909,7 @@ async function decryptBackupBlob(blob: string, mnemonic: string): Promise<Backup
     try {
         envelope = JSON.parse(blob);
     } catch (err) {
-        throw new Error('Backup file is not valid JSON — wrong file?');
+        throw new Error('That backup file is not valid JSON. Is it the right file?');
     }
     if (typeof envelope !== 'object' || envelope === null) {
         throw new Error('Backup file is malformed');
@@ -937,20 +937,20 @@ async function decryptBackupBlob(blob: string, mnemonic: string): Promise<Backup
     try {
         plaintext = await Aes.decrypt(envelope.ct, keyHex, envelope.iv, 'aes-256-cbc');
     } catch (err) {
-        throw new Error('Decryption failed — seed may not match this backup');
+        throw new Error('Decryption failed. The seed may not match this backup.');
     }
 
     if (!plaintext) {
         // Aes.decrypt typically throws on key/padding mismatch, but defend
         // against an empty-output edge case the same way the prior code did.
-        throw new Error('Decryption produced empty output — seed does not match this backup');
+        throw new Error('Decryption produced nothing. That seed does not match this backup.');
     }
 
     let manifest: BackupManifest;
     try {
         manifest = JSON.parse(plaintext) as BackupManifest;
     } catch (err) {
-        throw new Error('Decrypted manifest is not valid JSON — backup may be corrupted');
+        throw new Error('The decrypted manifest is not valid JSON. The backup may be corrupted.');
     }
 
     if (!manifest || !Array.isArray(manifest.files)) {

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -73,7 +73,9 @@ export function assertNoActiveArkExit(): void {
 
 function requireWallet() {
     const handle = getArkWalletHandle();
-    if (!handle) throw new Error('Ark wallet not open — cannot run exit flow');
+    if (!handle) throw new Error(
+        'The vault is not open yet. It needs a connection to open, so check yours and reopen the vault, then try again.',
+    );
     return handle;
 }
 

--- a/src/services/ark/googleDrive.ts
+++ b/src/services/ark/googleDrive.ts
@@ -310,7 +310,7 @@ async function getAccessToken(): Promise<string> {
     if (!GoogleSignin) throw new Error('GoogleSignin module not loaded');
     const tokens = await GoogleSignin.getTokens();
     if (!tokens?.accessToken) {
-        throw new Error('Drive access token not available — re-connect Google Drive');
+        throw new Error('Google Drive access has expired. Reconnect Google Drive and try again.');
     }
     return tokens.accessToken as string;
 }

--- a/src/services/ark/offboard.ts
+++ b/src/services/ark/offboard.ts
@@ -16,7 +16,9 @@ import { getArkWalletHandle } from './walletHandle';
  */
 function requireHandle() {
     const handle = getArkWalletHandle();
-    if (!handle) throw new Error('Ark wallet not open, cannot offboard');
+    if (!handle) throw new Error(
+            'The vault is not open yet. It needs a connection to open, so check yours and reopen the vault, then try again.',
+        );
     return handle;
 }
 

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -1,4 +1,5 @@
 import { getArkWalletHandle, getCachedArkMnemonic } from './walletHandle';
+import { ensureArkWalletHandleReady } from './restore';
 import { assertNoActiveArkExitAsync } from './exit';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
@@ -17,14 +18,22 @@ export type ArkRefreshResult = {
     roundId: string | null;
 };
 
-function requireHandle() {
+/**
+ * The handle, opening it first if it is not up yet.
+ *
+ * This used to throw "Ark wallet not open" on the spot, which is the message a
+ * user meets most often offline: opening the bark handle needs a connection,
+ * and a JS reload drops it. It named an internal state, suggested nothing, and
+ * threw away any chance of finding out WHY.
+ *
+ * ensureArkWalletHandleReady both self-heals and, now that it keeps the open
+ * error, propagates a failure that NAMES the unreachable host. That is what
+ * lets the UI say "switch to mobile data" from evidence rather than a guess.
+ */
+async function requireHandle() {
     const handle = getArkWalletHandle();
-    if (!handle) {
-        throw new Error(
-            'The vault is not open yet. It needs a connection to open, so check yours and reopen the vault, then try again.',
-        );
-    }
-    return handle;
+    if (handle) return handle;
+    return await ensureArkWalletHandleReady();
 }
 
 /**
@@ -60,7 +69,7 @@ let refreshSubmissionInFlight = false;
 export async function estimateArkRefreshFee(
     vtxoIds: string[],
 ): Promise<ArkRefreshFeeView> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
     const estimate: FeeEstimate = await handle.estimateRefreshFee(vtxoIds);
     return {
         feeSats: Number(estimate.feeSats),
@@ -85,7 +94,7 @@ export async function refreshArkVtxos(
     vtxoIds: string[],
     totalSats?: number,
 ): Promise<ArkRefreshResult> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
 
     // A refresh is a COOPERATIVE round: it spends the VTXO and hands the ASP a
     // new one. Running it against a coin that is mid-unilateral-exit commits
@@ -196,7 +205,7 @@ export async function refreshArkVtxosAndSync(
     vtxoIds: string[],
     totalSats?: number,
 ): Promise<ArkRefreshResult> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
     const result = await refreshArkVtxos(vtxoIds, totalSats);
     // Pull the round outcome into the local datadir before we re-read.
     await handle.sync();
@@ -251,7 +260,7 @@ export async function refreshArkVtxosDelegated(
     vtxoIds: string[],
     totalSats?: number,
 ): Promise<ArkDelegatedRefreshResult> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
 
     // Same exit guard as the self-signed path: a delegated round is still a
     // cooperative spend of the VTXO. See refreshArkVtxos.
@@ -358,7 +367,7 @@ export async function refreshArkVtxosDelegatedAndSync(
     vtxoIds: string[],
     totalSats?: number,
 ): Promise<ArkDelegatedRefreshResult> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
     const result = await refreshArkVtxosDelegated(vtxoIds, totalSats);
     await handle.sync();
     await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
@@ -391,7 +400,7 @@ export async function refreshArkVtxosDelegatedAndSync(
  * swallows.
  */
 export async function maintenanceArkDelegated(): Promise<void> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
 
     // The highest-risk caller of the exit guard. `maintenanceDelegated()`
     // chooses its own VTXOs inside bark, so there is no input list to filter:
@@ -572,7 +581,7 @@ export async function fetchArkMinBoardSats(): Promise<number | null> {
  * in which case `wallet.sync()` will pick up the result.
  */
 export async function cancelArkPendingRound(roundId: number): Promise<void> {
-    const handle = requireHandle();
+    const handle = await requireHandle();
     try {
         await handle.cancelPendingRound(roundId);
     } catch (err: any) {

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -20,7 +20,9 @@ export type ArkRefreshResult = {
 function requireHandle() {
     const handle = getArkWalletHandle();
     if (!handle) {
-        throw new Error('Ark wallet not open — cannot refresh VTXOs');
+        throw new Error(
+            'The vault is not open yet. It needs a connection to open, so check yours and reopen the vault, then try again.',
+        );
     }
     return handle;
 }

--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -276,7 +276,18 @@ export async function ensureArkWalletHandleReady(
     // Nudge a self-heal re-open. No-op when a boot open is already in flight
     // (we just wait for it) or the seed isn't cached yet (the boot hook owns
     // the first, biometric, Keychain read — don't trigger FaceID from here).
-    void reopenArkWalletFromCache().catch(() => {});
+    // KEEP the failure. This was `.catch(() => {})`, which discarded the only
+    // error that names the unreachable host, so every caller downstream could
+    // say nothing better than "wallet not open", with no cause and no advice.
+    // openWithRetry already returns it as `error` on 'open-failed'.
+    let openError: Error | undefined;
+    void reopenArkWalletFromCache()
+        .then((r) => {
+            if (!r.restored && r.error) openError = r.error;
+        })
+        .catch((e) => {
+            openError = e as Error;
+        });
     const start = Date.now();
     const POLL_MS = 300;
     while (!handle && Date.now() - start < timeoutMs) {
@@ -284,7 +295,15 @@ export async function ensureArkWalletHandleReady(
         handle = getArkWalletHandle();
     }
     if (!handle) {
-        throw new Error('Ark wallet is still starting up. Please try again in a moment.');
+        // Prefer the REAL failure. It names the chain source or the ASP, which
+        // is what lets the caller turn this into "switch to mobile data"
+        // instead of a shrug. "Try again in a moment" is actively WRONG advice
+        // when the cause is no connectivity: waiting never succeeds.
+        if (openError) throw openError;
+        throw new Error(
+            'The vault could not be opened. It needs a connection, so check yours, ' +
+            'or switch between Wi-Fi and mobile data, then try again.',
+        );
     }
     return handle;
 }

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -466,7 +466,7 @@ export async function ensureArkOnchainHandle(): Promise<OnchainWalletInterface> 
     if (!mnemonic) {
         const creds = await Keychain.getGenericPassword({ service: KEYCHAIN_SERVICE });
         if (!creds || !creds.password) {
-            throw new Error('Ark seed not in Keychain — cannot spawn onchain wallet');
+            throw new Error('Ark seed not in Keychain, so the onchain wallet cannot start');
         }
         mnemonic = creds.password;
     }

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -218,3 +218,39 @@ describe('describeArkFailure: the one-call form that call sites actually use', (
         expect(out.trim().endsWith('.')).toBe(true);
     });
 });
+
+describe('the vault-not-open message users actually hit offline', () => {
+    // Second device round, 2026-08-25: with the classifier wired in, airplane
+    // mode no longer shows a Reqwest trace. It surfaces the layer underneath,
+    // because opening the bark handle itself needs a connection and a JS reload
+    // drops it. The old string read "Ark wallet not open", then an em dash,
+    // then "cannot refresh VTXOs": jargon, a banned character, and no
+    // suggestion of what the user should actually do.
+    const NOT_OPEN = {
+        message:
+            'The vault is not open yet. It needs a connection to open, so check ' +
+            'yours and reopen the vault, then try again.',
+    };
+
+    it('passes through intact rather than being overwritten with a guess', () => {
+        // It names no host, so classification is 'unknown' and describeArkFailure
+        // must fall back to the message rather than inventing a cause. Claiming
+        // "your funds are safe" or "try mobile data" here would be a guess.
+        expect(classify(NOT_OPEN)).toBe('unknown');
+        const out = describeArkFailure(NOT_OPEN, 'Refresh failed', ENDPOINTS);
+        expect(out).toContain('Refresh failed:');
+        expect(out).toContain('reopen the vault');
+    });
+
+    it('never tells the user their wallet is corrupt or to reinstall', () => {
+        // The documented trap: "wallet will not open" is almost always the chain
+        // source, and reinstalling wipes the datadir.
+        const out = describeArkFailure(NOT_OPEN, 'Refresh failed', ENDPOINTS);
+        expect(out).not.toMatch(/corrupt|reinstall|delete|recover the vault/i);
+    });
+
+    it('carries no em dash, which is banned in user-facing copy', () => {
+        const out = describeArkFailure(NOT_OPEN, 'Refresh failed', ENDPOINTS);
+        expect(out).not.toContain('\u2014');
+    });
+});

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -219,38 +219,62 @@ describe('describeArkFailure: the one-call form that call sites actually use', (
     });
 });
 
-describe('the vault-not-open message users actually hit offline', () => {
-    // Second device round, 2026-08-25: with the classifier wired in, airplane
-    // mode no longer shows a Reqwest trace. It surfaces the layer underneath,
-    // because opening the bark handle itself needs a connection and a JS reload
-    // drops it. The old string read "Ark wallet not open", then an em dash,
-    // then "cannot refresh VTXOs": jargon, a banned character, and no
-    // suggestion of what the user should actually do.
-    const NOT_OPEN = {
+describe('an offline refresh must produce ADVICE, not an internal state name', () => {
+    // Device round 3, 2026-08-25. After the classifier was wired in, airplane
+    // mode stopped showing a Reqwest trace and started showing "Ark wallet not
+    // open", because opening the bark handle needs a connection and a JS reload
+    // drops it. Renaming that string was not enough: it names no host, so it
+    // classifies as 'unknown' and no advice can be derived from it. The fix is
+    // to stop discarding the OPEN error, which does name the host.
+
+    /** What openWithRetry captures when the handle cannot open offline. */
+    const OPEN_FAILURE = {
+        tag: 'Inner',
         message:
-            'The vault is not open yet. It needs a connection to open, so check ' +
-            'yours and reopen the vault, then try again.',
+            'Exception.Inner: Reqwest(reqwest::Error { kind: Request, url: ' +
+            '"https://blockstream.info/api/blocks/tip/height", source: ' +
+            'ConnectError("dns error", "failed to lookup address information") })',
     };
 
-    it('passes through intact rather than being overwritten with a guess', () => {
-        // It names no host, so classification is 'unknown' and describeArkFailure
-        // must fall back to the message rather than inventing a cause. Claiming
-        // "your funds are safe" or "try mobile data" here would be a guess.
-        expect(classify(NOT_OPEN)).toBe('unknown');
-        const out = describeArkFailure(NOT_OPEN, 'Refresh failed', ENDPOINTS);
-        expect(out).toContain('Refresh failed:');
-        expect(out).toContain('reopen the vault');
+    it('turns the real open failure into a network instruction', () => {
+        expect(classify(OPEN_FAILURE)).toBe('chain-source');
+        const out = describeArkFailure(OPEN_FAILURE, 'Refresh failed', ENDPOINTS);
+        expect(out).toContain('try mobile data');
+        expect(out).not.toMatch(/Reqwest|ConnectError|wallet not open/i);
     });
 
-    it('never tells the user their wallet is corrupt or to reinstall', () => {
-        // The documented trap: "wallet will not open" is almost always the chain
-        // source, and reinstalling wipes the datadir.
-        const out = describeArkFailure(NOT_OPEN, 'Refresh failed', ENDPOINTS);
-        expect(out).not.toMatch(/corrupt|reinstall|delete|recover the vault/i);
+    it('yields advice a caller can show on its own, without a prefix', () => {
+        // The Alert path shows arkNetworkFaultMessage alone, so it has to read
+        // as a complete instruction rather than a fragment.
+        const advice = arkNetworkFaultMessage(classify(OPEN_FAILURE));
+        expect(advice).toBeTruthy();
+        expect(advice as string).toMatch(/mobile data/);
+        expect((advice as string).trim().endsWith('.')).toBe(true);
     });
 
-    it('carries no em dash, which is banned in user-facing copy', () => {
-        const out = describeArkFailure(NOT_OPEN, 'Refresh failed', ENDPOINTS);
-        expect(out).not.toContain('\u2014');
+    it('still refuses to invent advice when nothing names a host', () => {
+        // The generic last-resort message must not be dressed up as a
+        // diagnosis: "not open" can also mean locked or never created.
+        const generic = {
+            message:
+                'The vault could not be opened. It needs a connection, so check yours, ' +
+                'or switch between Wi-Fi and mobile data, then try again.',
+        };
+        expect(classify(generic)).toBe('unknown');
+        const out = describeArkFailure(generic, 'Refresh failed', ENDPOINTS);
+        expect(out).toContain('switch between Wi-Fi and mobile data');
+        expect(out).not.toMatch(/corrupt|reinstall|delete/i);
+    });
+
+    it('never tells the user to wait when waiting cannot work', () => {
+        // "Try again in a moment" was the old timeout text. Offline it is
+        // wrong: no amount of waiting opens the wallet.
+        const generic = {
+            message:
+                'The vault could not be opened. It needs a connection, so check yours, ' +
+                'or switch between Wi-Fi and mobile data, then try again.',
+        };
+        expect(generic.message).not.toMatch(/in a moment/i);
     });
 });
+


### PR DESCRIPTION
Device feedback said renaming the string was not the fix, and that was right. This PR now does two things: the em dash cleanup it started as, and the actual fix underneath it.

## Renaming was not enough

"Ark wallet not open" became "The vault is not open yet", which is still useless to someone offline because it does not tell them to **switch networks**. And it appeared in a toast that vanishes before it can be read, so the user taps Refresh again into the same wall.

## The real defect: we were deleting the evidence

`ensureArkWalletHandleReady` nudges a self-heal re-open and then did:

```js
void reopenArkWalletFromCache().catch(() => {});
```

That `.catch(() => {})` throws away **the only error that names the unreachable host**. `openWithRetry` already captures it and returns it as `error` on `'open-failed'`.

So at every one of these failures, the information needed to say "you are offline, switch to mobile data" existed and was discarded one frame later, leaving callers with nothing better than an internal state name to show.

## Three changes

**1. Keep the open error.** `ensureArkWalletHandleReady` now rethrows it. Its timeout text also read *"Please try again in a moment"*, which is **actively wrong** advice offline: waiting never opens the wallet. The last-resort text now names the remedy without claiming a cause, since "not open" can also mean locked or never created.

**2. Open the vault instead of reporting it shut.** `refresh.ts`'s `requireHandle` no longer throws on a missing handle; it calls `ensureArkWalletHandleReady`. A refresh arriving before the handle is up now **opens it**. When the open genuinely fails, the propagated error names blockstream or the ASP, and `describeArkFailure` turns that into the instruction. All seven call sites were already `async`.

**3. Alert, not toast, for actionable faults.** A three-second chip is the wrong surface for a failure with a specific remedy. Network faults now use `Alert`, which stays until dismissed. Non-network failures keep the toast.

## What the reported case does now

Airplane mode, tap Refresh. Instead of "Ark wallet not open" flashing past, the app tries to open, fails against blockstream, and shows a dialog reading:

> Can't reach the Bitcoin network data provider. If you're on Wi-Fi, try mobile data, then try again.

## Also, from the first commit

Nine thrown `Error` strings across the Ark service carried em dashes, every one reaching users through a toast: `refresh`, `exit`, `offboard`, five in `backup`, `googleDrive`, `walletHandle`. All fixed. That one is on me: I audited `src/screens`, `src/components` and `loc/` earlier and never looked at thrown errors in the service layer, which is exactly where the reported one lived.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **55 suites, 610 passed, 1 skipped**
- 4 tests replacing the earlier copy-only ones: the real open failure classifies as `chain-source` and yields the instruction; the advice reads as a complete sentence so the Alert can show it alone; an unrecognisable cause still refuses to invent a diagnosis; and nothing tells the user to wait when waiting cannot work

Device-verifiable exactly as reported: airplane mode, tap Refresh.
