### PR TITLE
fix(ark): guard every broadcasting call against a mid-call connection loss

### DIFF
--- a/src/screens/Ark/ArkWithdrawReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkWithdrawReviewScreen/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
     ActivityIndicator,
+    Alert,
     Image,
     Linking,
     StyleSheet,
@@ -22,6 +23,7 @@ import { btc } from '@Cypher/helpers/bitcoinUnits';
 import {
     classifyArkDestination,
     estimateArkSendFee,
+    isArkSendIndeterminate,
     executeArkSend,
     type ArkDestination,
     type ArkSendFeeView,
@@ -118,6 +120,11 @@ export default function ArkWithdrawReviewScreen({ route }: Props) {
     const [feeError, setFeeError] = useState<string | null>(null);
     const [isEstimating, setIsEstimating] = useState<boolean>(false);
     const [isSendLoading, setIsSendLoading] = useState<boolean>(false);
+    // Set when a withdraw's outcome is UNKNOWN rather than failed. Latches the
+    // swipe control off for the rest of the screen's life: the contract on
+    // ArkSendIndeterminateError is that a caller MUST NOT re-arm its send
+    // control, because a retry can settle alongside the original.
+    const [sendIndeterminate, setSendIndeterminate] = useState<boolean>(false);
     const [isDone, setIsDone] = useState<boolean>(false);
     const [resultId, setResultId] = useState<string | null>(null);
 
@@ -237,6 +244,18 @@ export default function ArkWithdrawReviewScreen({ route }: Props) {
     // applicable so muscle memory carries over.
     const handleToggle = async (isToggled: boolean) => {
         if (!isToggled) return;
+        // HARD LATCH. Not re-arming the control is not achievable by simply
+        // declining to call swipeButtonRef.reset(): SwipeButton re-arms ITSELF
+        // three seconds after isLoading goes false, which the finally block
+        // always does. So the refusal has to live here, or the "do not send it
+        // again" instruction is advice the UI immediately contradicts.
+        if (sendIndeterminate) {
+            Alert.alert(
+                'Withdrawal may still be in flight',
+                'The previous attempt has not resolved yet. Sending again could pay twice. Wait for your balance to settle, then start a new withdrawal.',
+            );
+            return;
+        }
         if (!destinationLooksValid) {
             SimpleToast.show(
                 'Destination address is not a valid Bitcoin address',
@@ -303,17 +322,39 @@ export default function ArkWithdrawReviewScreen({ route }: Props) {
             }
         } catch (err: any) {
             console.warn('[ArkWithdraw] send failed:', err);
-            // NOT routed through describeArkFailure, deliberately. Its
-            // 'ark-server' sentence asserts "Your funds are safe", and unlike
-            // ArkSendReviewScreen this path carries no isArkSendIndeterminate
-            // guard, so an ambiguous outcome would be reported as a definite
-            // one. That is the exact failure the indeterminate handling exists
-            // to prevent. Fix the guard first, then the copy.
-            SimpleToast.show(
-                `Withdraw failed: ${err?.message ?? 'unknown error'}`,
-                SimpleToast.LONG,
-            );
-            swipeButtonRef.current?.reset();
+            if (isArkSendIndeterminate(err)) {
+                // Outcome UNKNOWN, not failed. Per the contract on
+                // ArkSendIndeterminateError: do not claim the funds are safe,
+                // and do NOT re-arm the swipe control. Re-arming is the whole
+                // danger, because a retry can settle alongside the original.
+                //
+                // Deliberately NOT routed through describeArkFailure: its
+                // 'ark-server' sentence asserts "Your funds are safe", which
+                // would invert the one thing this branch exists to say.
+                //
+                // Latent rather than live today, since this screen only ever
+                // sends to a Bitcoin address and the flag is raised solely on
+                // the Lightning HTLC-pending path. Guarded anyway: the contract
+                // is explicit, the cost is one branch, and the alternative is
+                // relying on a routing detail three modules away staying true.
+                setSendIndeterminate(true);
+                Alert.alert(
+                    'Withdrawal may still be in flight',
+                    err?.message ??
+                        'This withdrawal may still be in flight. Do not send it again: wait for your balance to settle before retrying.',
+                );
+            } else {
+                // Only reached once the ambiguous case is ruled out, so naming
+                // a definite outcome is safe here.
+                SimpleToast.show(
+                    describeArkFailure(err, 'Withdraw failed', {
+                        chainUrls: ESPLORA_URLS,
+                        arkUrl: ARK_SERVER_URL,
+                    }),
+                    SimpleToast.LONG,
+                );
+                swipeButtonRef.current?.reset();
+            }
         } finally {
             setIsSendLoading(false);
         }

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1242,7 +1242,10 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 Alert.alert('Release sent', `${res.sentSats.toLocaleString()} sats are on the way to your Hot Vault. They will appear there as a pending transaction.`);
               }
             } catch (e: any) {
-              Alert.alert('Release failed', String(e?.message || '') || 'The transaction could not be sent. Your funds are unchanged.');
+              // Same treatment as the top-up path: a dropped connection now
+              // arrives as a flagged message that says it may have gone
+              // through, so do not overwrite it with an "unchanged" claim.
+              Alert.alert('Release failed', String(e?.message || '') || 'The release could not be sent. Your funds are unchanged.');
             }
           },
         },
@@ -1272,9 +1275,16 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
         SimpleToast.LONG,
       );
     } catch (e: any) {
+      // "Could not convert" is kept: the tab the user is on says "Convert from
+      // balance", so it matches. What was wrong is the body. "Offboard" is
+      // bark's word and appears nowhere in this UI, and "Your Ark funds are
+      // unchanged" is a claim a dropped connection can falsify. The service now
+      // raises a flagged indeterminate error in that case, whose message is
+      // already user-facing, so the fallback below applies only to refusals.
       Alert.alert(
         'Could not convert',
-        String(e?.message || '') || 'The offboard failed. Your Ark funds are unchanged.',
+        String(e?.message || '') ||
+          'The transfer could not be sent. Your vault balance is unchanged.',
       );
     } finally {
       setFundingBusy(false);

--- a/src/services/ark/exit.ts
+++ b/src/services/ark/exit.ts
@@ -43,6 +43,7 @@ import useAuthStore from '@Cypher/stores/authStore';
 
 import { isActiveExit } from './barkState';
 import { ensureArkOnchainHandle, getArkWalletHandle } from './walletHandle';
+import { runBroadcastCall } from './indeterminate';
 
 /**
  * Hard gate for every OUTGOING spend path (send, offboard, convert, swap
@@ -315,7 +316,10 @@ export async function claimArkExitsToAddress(
     const txHex = await finalizeExitClaimPsbtToHex(claim.psbtBase64);
 
     // 4. Broadcast. This is the step that was missing entirely.
-    const txid = await handle.broadcastTx(txHex);
+    // If this dies mid-call the claim may already be in a mempool. Reporting a
+    // clean failure would invite a second claim attempt against outputs that
+    // are already being spent.
+    const txid = await runBroadcastCall(() => handle.broadcastTx(txHex), 'claim');
     console.log(`[Ark exit] claim broadcast txid=${txid}`);
 
     return { txid, feeSats, psbtBase64: claim.psbtBase64 };

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -43,6 +43,7 @@ import {
 import { getArkOnchainAddress } from './receive';
 import { ensureArkWalletHandleReady } from './restore';
 import { getArkWalletHandle } from './walletHandle';
+import { runBroadcastCall } from './indeterminate';
 
 // --- Tunable sizing constants ----------------------------------------------
 //
@@ -589,7 +590,13 @@ export async function convertToExitFees(
     }
     const handle = await ensureArkWalletHandleReady();
     const address = await getArkOnchainAddress();
-    const txid = await handle.sendOnchain(address, BigInt(Math.floor(amountSats)));
+    // 'conversion' matches the tab the user is on ("Convert from balance").
+    // Deliberately not "offboard", which is bark's word and appears nowhere in
+    // the UI.
+    const txid = await runBroadcastCall(
+        () => handle.sendOnchain(address, BigInt(Math.floor(amountSats))),
+        'conversion',
+    );
     if (__DEV__) {
         console.log(
             '[Ark exit-funding] convert offboard broadcast',

--- a/src/services/ark/indeterminate.ts
+++ b/src/services/ark/indeterminate.ts
@@ -1,0 +1,67 @@
+/**
+ * "It may already have gone through."
+ *
+ * Every call that hands a transaction to the ASP or to the chain shares one
+ * hazard: if the connection dies mid-call, we cannot tell whether it landed.
+ * Reporting that as a failure is a guess, and the copy that follows a guess is
+ * usually a lie. `ArkSendReviewScreen` said, verbatim, "Your funds were not
+ * moved"; the exit-fee sheet said "Your Ark funds are unchanged".
+ *
+ * Both can be false, and a user who is told their money is untouched while it
+ * is confirming goes looking for a balance that has legitimately gone.
+ *
+ * WHY THIS LIVES IN ITS OWN MODULE
+ *
+ * The first version of this guard sat inside `executeArkSend`, which covered
+ * the two call sites the bug was reported against and none of the four others:
+ * `exitFunding.convertToExitFees`, `offboard.offboardArkVtxos`,
+ * `exit.claimArkExitsToAddress`, and `recoverOnchainBoard`. Fixing a path
+ * rather than a capability leaves the next call site to reintroduce it.
+ *
+ * It imports nothing from the SDK on purpose, so any module can wrap a call
+ * without dragging the native binding into a unit test.
+ */
+
+import { looksLikeConnectionLoss } from './networkFault';
+
+/**
+ * Error marking an outcome as UNKNOWN rather than failed.
+ *
+ * Callers MUST check `isArkSendIndeterminate` before reporting an error, and
+ * when it is true they MUST NOT claim the funds are safe and MUST NOT re-enable
+ * their send control. Re-arming is the dangerous half: for Lightning a retry
+ * mints a fresh invoice and can pay twice.
+ */
+export type ArkSendIndeterminateError = Error & { arkSendIndeterminate: true };
+
+/** True when the outcome is unknown and a retry is not obviously safe. */
+export function isArkSendIndeterminate(err: unknown): boolean {
+    return !!err && (err as { arkSendIndeterminate?: boolean }).arkSendIndeterminate === true;
+}
+
+/** Build the flagged error with a caller-supplied, user-facing sentence. */
+export function makeIndeterminate(message: string): ArkSendIndeterminateError {
+    const e = new Error(message) as ArkSendIndeterminateError;
+    e.arkSendIndeterminate = true;
+    return e;
+}
+
+/**
+ * Wrap a call that may broadcast. A REFUSAL passes through untouched, because
+ * the money certainly did not move and saying so is both true and useful. Only
+ * a dropped connection becomes indeterminate.
+ *
+ * `what` names the operation in the user's own words, so the sentence reads as
+ * the thing they pressed: "withdrawal", "payment", "top-up", "release".
+ */
+export async function runBroadcastCall<T>(run: () => Promise<T>, what: string): Promise<T> {
+    try {
+        return await run();
+    } catch (err) {
+        if (!looksLikeConnectionLoss(err)) throw err;
+        throw makeIndeterminate(
+            `The connection dropped, so this ${what} may already have gone through. ` +
+            'Check your balance and your transaction history before trying again.',
+        );
+    }
+}

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -170,3 +170,31 @@ export function describeArkFailure(
     const raw = arkErrorText(err);
     return raw ? `${context}: ${raw}` : `${context}: unknown error`;
 }
+
+/**
+ * True when a failure looks like the connection dropped, rather than the
+ * operation being refused.
+ *
+ * The distinction matters at exactly one moment: a send call that hands a
+ * request to the ASP. If it was REFUSED (bad address, not enough funds) the
+ * money certainly did not move. If the CONNECTION died we cannot tell, because
+ * the server may already have signed and broadcast.
+ *
+ * Deliberately NOT built on `classifyArkNetworkFault`. That one answers "which
+ * side is unreachable", which is a different question and gives the wrong
+ * answer here: a 429 names a host but means the request was REFUSED, so the
+ * funds certainly did not move. Flagging that as ambiguous would tell users to
+ * go and check a balance that cannot have changed. Only the transport dying is
+ * ambiguous.
+ *
+ * Deliberately biased toward returning true. A false "may have gone through"
+ * costs a user one balance check. A false "your funds were not moved" costs
+ * them their trust that the wallet knows where their money is.
+ */
+export function looksLikeConnectionLoss(err: unknown): boolean {
+    const tag = (err as { tag?: string })?.tag ?? '';
+    const text = `${tag} ${arkErrorText(err)}`;
+    return /ServerConnection|connect|timed? ?out|network|unreachable|dns|socket|transport|aborted|reset by peer|broken pipe/i.test(
+        text,
+    );
+}

--- a/src/services/ark/offboard.ts
+++ b/src/services/ark/offboard.ts
@@ -1,5 +1,6 @@
 import { assertNoActiveArkExit } from './exit';
 import { getArkWalletHandle } from './walletHandle';
+import { runBroadcastCall } from './indeterminate';
 
 /**
  * Cooperative on-chain offboard of SPECIFIC VTXOs (coin control).
@@ -57,5 +58,8 @@ export async function offboardArkVtxos(
 ): Promise<string> {
     assertNoActiveArkExit();
     const handle = requireHandle();
-    return await handle.offboardVtxos(vtxoIds, address.trim());
+    return await runBroadcastCall(
+        () => handle.offboardVtxos(vtxoIds, address.trim()),
+        'transfer',
+    );
 }

--- a/src/services/ark/recoverOnchainBoard.ts
+++ b/src/services/ark/recoverOnchainBoard.ts
@@ -1,5 +1,6 @@
 import { ARK_VTXO_DUST_SATS, ESPLORA_URL } from './config';
 import { ensureArkOnchainHandle } from './walletHandle';
+import { runBroadcastCall } from './indeterminate';
 
 /**
  * F3 (.claude/ARK_STUCK_UTXO_UX_SPEC.md): sweep a stuck on-chain Ark *boarding*
@@ -150,7 +151,10 @@ export async function recoverArkOnchainBoard(
         '[Ark recover] draining onchain board:', confirmedSats,
         'sats; fee', feeSats, 'at', rate, 'sat/vB; sending', amount, 'to', destAddress,
     );
-    const txid = await onchain.send(destAddress, BigInt(amount), BigInt(rate));
+    const txid = await runBroadcastCall(
+        () => onchain.send(destAddress, BigInt(amount), BigInt(rate)),
+        'release',
+    );
     console.log('[Ark recover] drain broadcast, txid=', txid);
 
     // Best-effort: pull the spend into BDK's local state so the next balance

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -6,7 +6,7 @@ import {
 } from '@secondts/bark-react-native';
 import bolt11 from 'bolt11';
 
-import { looksLikeConnectionLoss } from './networkFault';
+import { makeIndeterminate, runBroadcastCall } from './indeterminate';
 import { decideChangeRefresh } from './changeRefresh';
 import { assertNoActiveArkExit } from './exit';
 import { ensureArkWalletHandleReady } from './restore';
@@ -43,69 +43,15 @@ export type ArkSendFeeView = {
 };
 
 /**
- * Error thrown when a send's outcome is UNKNOWN rather than failed: the HTLC is
- * still live and may yet settle.
+ * Re-exported from ./indeterminate, which owns this now.
  *
- * This is the single most dangerous state in the send path, because the natural
- * UI response to a thrown error ("it failed, try again") is exactly the wrong
- * one. Retrying an ln-address or ln-offer mints a fresh invoice with a new
- * payment hash, so the retry can settle alongside the original and pay the
- * recipient twice, irreversibly.
- *
- * Callers MUST use `isArkSendIndeterminate()` before reporting an error, and
- * when it is true they MUST NOT claim the funds are safe and MUST NOT re-enable
- * their send control.
+ * The guard used to live here, wrapping the two calls inside executeArkSend.
+ * That covered the paths the bug was reported against and missed four others
+ * that broadcast without going through this function. Moving it to the SDK
+ * boundary is what makes it apply to all of them.
  */
-export type ArkSendIndeterminateError = Error & { arkSendIndeterminate: true };
-
-/** True when the send's outcome is unknown and retrying risks paying twice. */
-export function isArkSendIndeterminate(err: unknown): boolean {
-    return !!err && (err as { arkSendIndeterminate?: boolean }).arkSendIndeterminate === true;
-}
-
-/**
- * Run the terminal send call, and report a connection failure as UNKNOWN rather
- * than as a definite failure.
- *
- * `sendOnchain` / `sendArkoorPayment` hand the request to the ASP, which signs
- * and broadcasts. If the connection dies during that call we cannot tell
- * whether it got there. Until now the throw propagated as an ordinary error and
- * the UI said, verbatim, "Your funds were not moved." That claim can be false:
- * the transaction may already be confirming.
- *
- * The LN case gets this treatment because a retry there mints a fresh invoice
- * and can pay twice. Onchain is NOT the same danger, and it is worth being
- * clear why: a retry rebuilds from the same VTXOs, so if the first send really
- * did land, the second fails on its own. Bitcoin's model blocks the
- * double-spend. What it does not block is the app telling someone their money
- * is untouched while it is on its way, which sends them looking for a balance
- * that has legitimately gone.
- *
- * Deliberately biased toward flagging. A false "may have gone through" costs a
- * user a balance check before retrying. A false "not moved" costs them their
- * trust that the wallet knows where their money is.
- */
-async function sendOrFlagIndeterminate<T>(
-    run: () => Promise<T>,
-    what: 'withdrawal' | 'payment',
-): Promise<T> {
-    try {
-        return await run();
-    } catch (err) {
-        // Refused means the money certainly did not move, so let it through as
-        // the definite failure it is. Only a dropped connection is ambiguous.
-        if (!looksLikeConnectionLoss(err)) {
-            throw err;
-        }
-
-        const indeterminate = new Error(
-            `This ${what} may already have gone through. Check your balance and your ` +
-            'transaction history before sending again.',
-        ) as ArkSendIndeterminateError;
-        indeterminate.arkSendIndeterminate = true;
-        throw indeterminate;
-    }
-}
+export type { ArkSendIndeterminateError } from './indeterminate';
+export { isArkSendIndeterminate } from './indeterminate';
 
 export type ArkSendResult = {
     /** Kind of send that was executed — helps callers route to the right toast. */
@@ -548,12 +494,10 @@ export async function executeArkSend(
                 // branch on it reliably. A caller MUST NOT tell the user their
                 // funds are safe, and MUST NOT re-arm its send control, when
                 // this flag is set.
-                const indeterminate = new Error(
+                throw makeIndeterminate(
                     'This payment may still be in flight. Do not send it again: wait for your ' +
                     'balance to settle, or confirm with the recipient before retrying.',
-                ) as ArkSendIndeterminateError;
-                indeterminate.arkSendIndeterminate = true;
-                throw indeterminate;
+                );
             }
             // outcome === 'failed' -> HTLC refunded, funds back. Retry if attempts remain.
             console.log(
@@ -572,14 +516,14 @@ export async function executeArkSend(
                 // 0.11.3 sendArkoorPayment returns void (no vtxo/tx id
                 // surfaced). No caller reads the id for ark-to-ark sends, so
                 // leave it empty.
-                await sendOrFlagIndeterminate(
+                await runBroadcastCall(
                     () => handle.sendArkoorPayment(dest.value, amount),
                     'payment',
                 );
                 id = '';
                 break;
             case 'onchain':
-                id = await sendOrFlagIndeterminate(
+                id = await runBroadcastCall(
                     () => handle.sendOnchain(dest.value, amount),
                     'withdrawal',
                 );

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -6,6 +6,7 @@ import {
 } from '@secondts/bark-react-native';
 import bolt11 from 'bolt11';
 
+import { looksLikeConnectionLoss } from './networkFault';
 import { decideChangeRefresh } from './changeRefresh';
 import { assertNoActiveArkExit } from './exit';
 import { ensureArkWalletHandleReady } from './restore';
@@ -60,6 +61,50 @@ export type ArkSendIndeterminateError = Error & { arkSendIndeterminate: true };
 /** True when the send's outcome is unknown and retrying risks paying twice. */
 export function isArkSendIndeterminate(err: unknown): boolean {
     return !!err && (err as { arkSendIndeterminate?: boolean }).arkSendIndeterminate === true;
+}
+
+/**
+ * Run the terminal send call, and report a connection failure as UNKNOWN rather
+ * than as a definite failure.
+ *
+ * `sendOnchain` / `sendArkoorPayment` hand the request to the ASP, which signs
+ * and broadcasts. If the connection dies during that call we cannot tell
+ * whether it got there. Until now the throw propagated as an ordinary error and
+ * the UI said, verbatim, "Your funds were not moved." That claim can be false:
+ * the transaction may already be confirming.
+ *
+ * The LN case gets this treatment because a retry there mints a fresh invoice
+ * and can pay twice. Onchain is NOT the same danger, and it is worth being
+ * clear why: a retry rebuilds from the same VTXOs, so if the first send really
+ * did land, the second fails on its own. Bitcoin's model blocks the
+ * double-spend. What it does not block is the app telling someone their money
+ * is untouched while it is on its way, which sends them looking for a balance
+ * that has legitimately gone.
+ *
+ * Deliberately biased toward flagging. A false "may have gone through" costs a
+ * user a balance check before retrying. A false "not moved" costs them their
+ * trust that the wallet knows where their money is.
+ */
+async function sendOrFlagIndeterminate<T>(
+    run: () => Promise<T>,
+    what: 'withdrawal' | 'payment',
+): Promise<T> {
+    try {
+        return await run();
+    } catch (err) {
+        // Refused means the money certainly did not move, so let it through as
+        // the definite failure it is. Only a dropped connection is ambiguous.
+        if (!looksLikeConnectionLoss(err)) {
+            throw err;
+        }
+
+        const indeterminate = new Error(
+            `This ${what} may already have gone through. Check your balance and your ` +
+            'transaction history before sending again.',
+        ) as ArkSendIndeterminateError;
+        indeterminate.arkSendIndeterminate = true;
+        throw indeterminate;
+    }
 }
 
 export type ArkSendResult = {
@@ -527,11 +572,17 @@ export async function executeArkSend(
                 // 0.11.3 sendArkoorPayment returns void (no vtxo/tx id
                 // surfaced). No caller reads the id for ark-to-ark sends, so
                 // leave it empty.
-                await handle.sendArkoorPayment(dest.value, amount);
+                await sendOrFlagIndeterminate(
+                    () => handle.sendArkoorPayment(dest.value, amount),
+                    'payment',
+                );
                 id = '';
                 break;
             case 'onchain':
-                id = await handle.sendOnchain(dest.value, amount);
+                id = await sendOrFlagIndeterminate(
+                    () => handle.sendOnchain(dest.value, amount),
+                    'withdrawal',
+                );
                 break;
             case 'unknown':
             default:

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -14,6 +14,7 @@ import {
     arkNetworkFaultMessage,
     classifyArkNetworkFault,
     describeArkFailure,
+    looksLikeConnectionLoss,
 } from '../../src/services/ark/networkFault';
 
 const ENDPOINTS = {
@@ -278,3 +279,53 @@ describe('an offline refresh must produce ADVICE, not an internal state name', (
     });
 });
 
+describe('telling a refusal apart from a dropped connection', () => {
+    // This decides whether a send reports "your funds were not moved" or "this
+    // may already have gone through". Getting it wrong in the second direction
+    // tells someone their money is untouched while it is confirming.
+    const loss = (e: unknown) => looksLikeConnectionLoss(e);
+
+    it('treats a dropped connection as ambiguous', () => {
+        expect(loss({ tag: 'ServerConnection', message: 'transport error' })).toBe(true);
+        expect(loss(new Error('operation timed out'))).toBe(true);
+        expect(loss(new Error('Network request timed out'))).toBe(true);
+        expect(loss(new Error('dns error: failed to lookup address information'))).toBe(true);
+        expect(loss(new Error('socket hang up'))).toBe(true);
+    });
+
+    it('treats a REFUSAL that merely names a host as definite', () => {
+        // A quota rejection is the server ANSWERING, not the line dropping. The
+        // request was refused, so the funds cannot have moved, and telling the
+        // user to go check a balance that cannot have changed is noise.
+        // This is why the rule is not built on classifyArkNetworkFault, which
+        // answers a different question.
+        expect(loss({ message: 'https://blockstream.info/api returned 429 Too Many Requests' })).toBe(false);
+    });
+
+    it('still catches a dropped connection that happens to name a host', () => {
+        expect(loss({ message: 'error connecting to https://ark.second.tech' })).toBe(true);
+    });
+
+    it('treats a REFUSAL as definite, so a real failure is still reported as one', () => {
+        // The server said no. The money certainly did not move, and claiming
+        // otherwise would make users hesitate to retry a send that plainly
+        // failed.
+        expect(loss(new Error('insufficient funds'))).toBe(false);
+        expect(loss(new Error('bad user input: invalid address'))).toBe(false);
+        expect(loss(new Error('amount below dust limit'))).toBe(false);
+        expect(loss({ tag: 'Internal', message: 'BarkError.Internal' })).toBe(false);
+    });
+
+    it('does not throw on null, undefined or a non-error', () => {
+        for (const v of [null, undefined, 0, '', {}, []]) {
+            expect(() => loss(v)).not.toThrow();
+        }
+    });
+
+    it('errs toward ambiguous, never toward a false all-clear', () => {
+        // The asymmetry is the point. A false "may have gone through" costs a
+        // balance check. A false "not moved" costs trust.
+        expect(loss(new Error('connection reset by peer'))).toBe(true);
+        expect(loss(new Error('request aborted'))).toBe(true);
+    });
+});

--- a/tests/unit/arkSendIndeterminateContract.test.ts
+++ b/tests/unit/arkSendIndeterminateContract.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The contract on ArkSendIndeterminateError, pinned.
+ *
+ * From its docstring in services/ark/send.ts:
+ *
+ *   "Callers MUST use isArkSendIndeterminate() before reporting an error, and
+ *    when it is true they MUST NOT claim the funds are safe and MUST NOT
+ *    re-enable their send control."
+ *
+ * ArkWithdrawReviewScreen honoured neither half until now. It reported a
+ * definite failure and called swipeButtonRef.reset(). The screens themselves
+ * are not unit-testable here (they pull the native bark binding), so these
+ * cover the predicate and the copy rules the screens depend on.
+ */
+
+// send.ts imports the native bark binding at module load, which a plain unit
+// test cannot resolve. Mock the surface it touches so the REAL predicate is
+// exercised rather than a copy of it drifting alongside the original.
+jest.mock('@secondts/bark-react-native', () => ({
+    LightningSendStatus: {},
+    LightningSendStatus_Tags: { Settled: 'Settled', Pending: 'Pending', Failed: 'Failed' },
+    validateArkAddress: () => false,
+    FeeEstimate: {},
+    Network: { Bitcoin: 'Bitcoin' },
+    Config: {},
+}));
+
+import { isArkSendIndeterminate } from '../../src/services/ark/send';
+import {
+    arkNetworkFaultMessage,
+    classifyArkNetworkFault,
+} from '../../src/services/ark/networkFault';
+
+const ENDPOINTS = {
+    chainUrls: ['https://blockstream.info/api', 'https://mempool.space/api'],
+    arkUrl: 'https://ark.second.tech',
+};
+
+const indeterminate = () => {
+    const e = new Error(
+        'This payment may still be in flight. Do not send it again: wait for your ' +
+        'balance to settle, or confirm with the recipient before retrying.',
+    ) as Error & { arkSendIndeterminate: true };
+    e.arkSendIndeterminate = true;
+    return e;
+};
+
+describe('recognising an indeterminate outcome', () => {
+    it('is true only for the flagged error', () => {
+        expect(isArkSendIndeterminate(indeterminate())).toBe(true);
+    });
+
+    it('is false for an ordinary failure, so the determinate branch still runs', () => {
+        expect(isArkSendIndeterminate(new Error('insufficient funds'))).toBe(false);
+    });
+
+    it('does not throw on null, undefined, or a non-error', () => {
+        for (const v of [null, undefined, 'string', 0, {}, []]) {
+            expect(() => isArkSendIndeterminate(v)).not.toThrow();
+            expect(isArkSendIndeterminate(v)).toBe(false);
+        }
+    });
+
+    it('is not fooled by a merely similar-looking message', () => {
+        // The flag is explicit precisely so callers never string-match this.
+        expect(isArkSendIndeterminate(new Error('This payment may still be in flight.'))).toBe(false);
+    });
+});
+
+describe('what an indeterminate outcome must never be told', () => {
+    it('carries its own instruction, so a caller need not invent one', () => {
+        const msg = indeterminate().message;
+        expect(msg).toMatch(/do not send it again/i);
+        expect(msg).not.toMatch(/funds are safe|were not moved|failed/i);
+    });
+
+    it('must not be overwritten by the network advice, which claims funds are safe', () => {
+        // This is why the indeterminate branch bypasses describeArkFailure: the
+        // 'ark-server' sentence would invert the one thing it exists to say.
+        const arkFault = arkNetworkFaultMessage(
+            classifyArkNetworkFault({ message: 'connect to https://ark.second.tech failed' }, ENDPOINTS),
+        );
+        expect(arkFault).toMatch(/funds are safe/i);
+        expect(indeterminate().message).not.toMatch(/funds are safe/i);
+    });
+});

--- a/tests/unit/arkSendIndeterminateContract.test.ts
+++ b/tests/unit/arkSendIndeterminateContract.test.ts
@@ -13,19 +13,13 @@
  * cover the predicate and the copy rules the screens depend on.
  */
 
-// send.ts imports the native bark binding at module load, which a plain unit
-// test cannot resolve. Mock the surface it touches so the REAL predicate is
-// exercised rather than a copy of it drifting alongside the original.
-jest.mock('@secondts/bark-react-native', () => ({
-    LightningSendStatus: {},
-    LightningSendStatus_Tags: { Settled: 'Settled', Pending: 'Pending', Failed: 'Failed' },
-    validateArkAddress: () => false,
-    FeeEstimate: {},
-    Network: { Bitcoin: 'Bitcoin' },
-    Config: {},
-}));
-
-import { isArkSendIndeterminate } from '../../src/services/ark/send';
+// No SDK mock needed any more: the guard now lives in its own module with no
+// bark imports, which is a large part of why it is usable from every call site.
+import {
+    isArkSendIndeterminate,
+    makeIndeterminate,
+    runBroadcastCall,
+} from '../../src/services/ark/indeterminate';
 import {
     arkNetworkFaultMessage,
     classifyArkNetworkFault,
@@ -82,5 +76,48 @@ describe('what an indeterminate outcome must never be told', () => {
         );
         expect(arkFault).toMatch(/funds are safe/i);
         expect(indeterminate().message).not.toMatch(/funds are safe/i);
+    });
+});
+
+describe('runBroadcastCall: the boundary every broadcasting call now goes through', () => {
+    it('passes a success straight through', async () => {
+        await expect(runBroadcastCall(async () => 'txid123', 'withdrawal')).resolves.toBe('txid123');
+    });
+
+    it('lets a REFUSAL through unchanged, so a real failure still reads as one', async () => {
+        const refusal = new Error('insufficient funds');
+        await expect(runBroadcastCall(async () => { throw refusal; }, 'withdrawal')).rejects.toBe(refusal);
+    });
+
+    it('converts a dropped connection into an indeterminate outcome', async () => {
+        let caught: unknown;
+        try {
+            await runBroadcastCall(async () => { throw new Error('transport error: connection reset'); }, 'withdrawal');
+        } catch (e) { caught = e; }
+        expect(isArkSendIndeterminate(caught)).toBe(true);
+        expect((caught as Error).message).toContain('may already have gone through');
+        expect((caught as Error).message).not.toMatch(/were not moved|are unchanged/i);
+    });
+
+    it('names the operation in the user\'s own words', async () => {
+        for (const what of ['withdrawal', 'payment', 'conversion', 'release', 'claim']) {
+            let caught: unknown;
+            try {
+                await runBroadcastCall(async () => { throw new Error('socket hang up'); }, what);
+            } catch (e) { caught = e; }
+            expect((caught as Error).message).toContain(what);
+        }
+    });
+
+    it('never leaks bark vocabulary into the sentence', async () => {
+        let caught: unknown;
+        try {
+            await runBroadcastCall(async () => { throw new Error('dns error'); }, 'conversion');
+        } catch (e) { caught = e; }
+        expect((caught as Error).message).not.toMatch(/offboard|vtxo|arkoor|bark|psbt/i);
+    });
+
+    it('makeIndeterminate always sets the flag callers branch on', () => {
+        expect(isArkSendIndeterminate(makeIndeterminate('anything'))).toBe(true);
     });
 });


### PR DESCRIPTION
Three commits. The first closes a latent contract violation, the second closes the reachable bug that pushing on "is that a nothing burger?" uncovered, and the third moves the guard to the SDK boundary after a blast-radius audit showed it was in the wrong place.

## The reachable one

The on-chain and arkoor send paths were one line each:

```ts
id = await handle.sendOnchain(dest.value, amount);
```

That call hands the request to the ASP, which signs and broadcasts. **If the connection dies during it, we cannot tell whether that happened.** The throw propagated as an ordinary failure, and `ArkSendReviewScreen` said, verbatim:

> Send failed: &lt;reason&gt;. **Your funds were not moved.**

That claim can be false, and unlike the Lightning case it is reachable **today**, with an ordinary Bitcoin withdrawal on a flaky connection.

### The harm is not a double payment

Worth being precise. A retry rebuilds from the same VTXOs, so if the first send did land, the second fails on its own. Bitcoin's model blocks the double-spend, which is exactly why Lightning gets the stronger treatment: there, a retry mints a fresh invoice and both can settle.

The harm here is **telling someone their money is untouched while it is confirming**. They check the balance, find it gone, and conclude the wallet lost their funds.

### The fix

Both terminal calls route through `sendOrFlagIndeterminate`, which converts a transport failure into the existing indeterminate error. The screens already branch on it: `ArkSendReviewScreen` has for a while, `ArkWithdrawReviewScreen` as of the first commit here. **That is what makes the first commit load-bearing rather than theoretical.**

## Why the rule is not `classifyArkNetworkFault`

`looksLikeConnectionLoss` lives in `networkFault.ts` so it is pure and testable, but it deliberately does **not** reuse the existing classifier.

That one answers "which side is unreachable", which is a different question with the wrong answer here. A **429 names a host but means the request was refused**, so the funds certainly did not move. Flagging it ambiguous would send users to check a balance that cannot have changed. Only the transport dying is ambiguous.

Biased toward flagging on purpose: a false "may have gone through" costs a balance check, a false "not moved" costs trust.

## A regression I caused and caught

My first attempt did route the rule through `classifyArkNetworkFault`, which pulled `./config` into `send.ts`. Its `Network` import broke the SDK mock in the **existing** `arkSendIndeterminate.test.ts` and stopped that suite loading entirely. The full run caught it; running the new file alone did not.

Narrowing the rule to transport-only removed the dependency and fixed the over-flagging in the same change, so the mistake improved the design.

Also verified the post-send path cannot produce the same false report: the sync and balance refresh after a successful send already sit in their own `try/catch`.

## The first commit, in brief

`ArkWithdrawReviewScreen` violated the documented contract on `ArkSendIndeterminateError` (do not claim funds are safe, do not re-arm the send control). Notably, **not calling `reset()` is not enough**: the shared `SwipeButton` re-arms itself three seconds after `isLoading` goes false, so the refusal has to live in `handleToggle`.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **56 suites, 622 passed, 1 skipped**
- 11 new tests across both commits: the predicate against `null`/non-errors/lookalike messages, dropped connections, a refusal that merely names a host, and the copy rules the screens rely on

No new network endpoint; the only URLs in the diff are pre-existing and appear in test fixtures.

---

## Third commit: the guard was in the wrong place

Prompted by "any way to check nothing went wrong elsewhere". The audit was the useful part.

Wrapping the calls **inside `executeArkSend`** covered the two paths the bug was reported against and missed **four others** that broadcast without going through that function:

| call site | SDK call | what the user pressed |
|---|---|---|
| `exitFunding.convertToExitFees` | `sendOnchain` | Convert from balance |
| `offboard.offboardArkVtxos` | `offboardVtxos` | transfer out |
| `exit.claimArkExitsToAddress` | `broadcastTx` | the exit claim itself |
| `recoverOnchainBoard` | `onchain.send` | Release |

Every one could report a definite failure after a mid-call connection drop, and two said so outright: *"Your Ark funds are unchanged"* and *"Your funds are unchanged"*.

**Grepping for callers of `executeArkSend` would never have found them.** Only grepping the underlying SDK methods did. Fixing a path instead of a capability is what left them behind.

The guard now lives in `src/services/ark/indeterminate.ts` and all six sites go through `runBroadcastCall`. That module imports nothing from the SDK on purpose, which also lets tests exercise it without mocking the native binding, and removes the mock that broke `arkSendIndeterminate.test.ts` earlier in this branch.

A **refusal still passes through untouched**. The money certainly did not move, and saying so is true and useful. Only a dropped connection is ambiguous.

## A correction to my own diagnosis

I claimed the exit-fee sheet used three names for one action and that "Could not convert" was disconnected from what the user tapped. **That was wrong.** The sheet has a tab labelled **"Convert from balance"**, so the title matches, and I checked before changing it. The title stays.

What was genuinely wrong is the body: **"offboard" is bark's word and appears nowhere in that UI**, and "Your Ark funds are unchanged" is a claim a dropped connection can falsify. The operation word passed to `runBroadcastCall` follows the user's vocabulary too: conversion, release, withdrawal, payment, claim.

## Audited and clean

- Nothing anywhere string-matches the error text from these paths.
- The Lightning swap provider classifies a `bolt11`, so it routes through the LN branch this does not touch.
- The post-send sync already sits in its own `try/catch` and cannot fake a failure.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **56 suites, 628 passed, 1 skipped**
- 6 further tests on the boundary: success passes through, a refusal stays a refusal, a dropped connection becomes indeterminate, the sentence names the operation in the user's words, and it never leaks `offboard`/`vtxo`/`arkoor`/`psbt` into user copy

