### PR TITLE
chore: remove stale links to local-only paths from tracked files

### DIFF
--- a/ARK_PROGRESS.md
+++ b/ARK_PROGRESS.md
@@ -422,13 +422,13 @@ This block consolidates the ~95 commits between 2026-04-30 and 2026-05-19. The b
 
 ---
 
-- **2026-05-30** — Arkoor-receive popup feature shipped and verified end-to-end on mainnet. See [.claude/SESSION_HANDOVER.md](.claude/SESSION_HANDOVER.md) for the full session record. Summary:
+- **2026-05-30** — Arkoor-receive popup feature shipped and verified end-to-end on mainnet. Summary:
   - New hook [src/custom-hooks/useArkoorReceivePrompt.ts](src/custom-hooks/useArkoorReceivePrompt.ts) consumes `arkArkoorPromptState` entries that [src/services/ark/movementWatcher.ts](src/services/ark/movementWatcher.ts) pushes synchronously on every `MovementUpdated subsystem=receive status=successful`. Race-wins auto-refresh by ~2-3 seconds.
   - Popup uses `Alert.alert`. Two outcomes: "Refresh now (~1 hour, recommended)" runs `refreshArkVtxosAndSync` immediately; "Don't refresh the X sats, I'll spend them now" marks the entry `dismissed` and the bg-refresh orchestrator (in [backgroundRefresh.ts](src/services/ark/backgroundRefresh.ts)) honours that with a categorization-time gate AND a final-mile re-read just before round submit.
   - The opt-out toggle was REMOVED per direct user feedback ("what toggle do you mean") — the popup is now always on. Field `arkArkoorPromptEnabled` retained for persist back-compat, no longer read.
   - All outcomes (`fired`, `skipped-background`, `skipped-in-flight`, `skipped-vtxo-gone`, `refresh-now`, `use-immediately`, `auto-skipped`) surface in the Activity feed via a new `arkoor-prompt` event kind in [eventLogStore.ts](src/stores/eventLogStore.ts).
   - Live test signals captured: two real Strike→Ark receives (505 sats and 500 sats) both produced `outcome=fired`; user tapped each button once (refresh-now and use-immediately); state transitions correct.
-  - One UX bug found but NOT fixed this session: stuck-refresh false-positive. Rounds appear hung past expiry, "0 days left" countdown is misleading (it's the pre-refresh height, meaningless once Locked), tapping Cancel triggers a sync that reveals the round had already completed. Plan + priority breakdown in [.claude/SESSION_HANDOVER.md](.claude/SESSION_HANDOVER.md).
+  - One UX bug found but NOT fixed this session: stuck-refresh false-positive. Rounds appear hung past expiry, "0 days left" countdown is misleading (it's the pre-refresh height, meaningless once Locked), tapping Cancel triggers a sync that reveals the round had already completed.
   - Bark CLI tooling landed via parallel session: [scripts/bark/](scripts/bark) helpers + CLAUDE.md section. Used `bark dev vtxo decode` mid-session to confirm `exit_depth` is the real arkoor-vs-round signal (Rust core surfaces it, JS SDK strips it — upstream ask).
   - New CLAUDE.md rule: never use em-dash `—` in user-facing copy (telegraphs AI authorship). Applies to all user-readable English in the app; comments and docs exempt.
 

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -159,8 +159,8 @@ export default function ArkWallet({
     //   confirmed < min  → STUCK (can never board; recover) [amber]
     //   confirmed >= min → boarding in progress [green]
     //   only unconfirmed → still confirming [green]
-    // Null = nothing to show (happy path). See .claude/ARK_STUCK_UTXO_UX_SPEC.md.
-    // The STUCK (below-min) row is tappable -> handleRecoverBoard (F3).
+    // Null = nothing to show (happy path).
+    // The STUCK (below-min) row is tappable -> handleRecoverBoard.
     const boardingView = useMemo(() => {
         // Optimistically suppressed right after a successful recover, until the
         // next sync writes the real (cleared) balance.
@@ -200,7 +200,7 @@ export default function ArkWallet({
      * wallet the funds came from for in-app top-ups), confirms amount + fee in
      * a modal, then calls the recover service. The bark SDK's OnchainWallet has
      * no utxos()/drain(), so the destination is a Hot Vault address rather than
-     * the esplora-resolved original sender (see ARK_STUCK_UTXO_UX_SPEC.md).
+     * the esplora-resolved original sender.
      */
     const handleRecoverBoard = React.useCallback(async () => {
         if (recovering) return;

--- a/src/custom-hooks/useArkRestoreOnBoot.ts
+++ b/src/custom-hooks/useArkRestoreOnBoot.ts
@@ -133,7 +133,7 @@ export default function useArkRestoreOnBoot(): ArkRestoreBootStatus {
             // home screen even though their wallet and funds were intact —
             // a particularly alarming UX since the obvious next click,
             // Recover, then collides with the .cbark atomic-write race
-            // (Bug 1 in .claude/OPEN_BUGS.md) and fails too, compounding
+            // and fails too, compounding
             // the "I lost my funds" panic.
             //
             // The safer treatment: re-confirm the datadir actually still

--- a/src/screens/Account/RecoverArkScreen/index.tsx
+++ b/src/screens/Account/RecoverArkScreen/index.tsx
@@ -338,8 +338,7 @@ export default function RecoverArkScreen() {
             // Distinguish by message shape: known network/server errors
             // get a connectivity message + a "your backup is intact"
             // reassurance, everything else stays as the original corrupt-
-            // file path. See .claude/OPEN_BUGS.md for the original
-            // diagnosis trail.
+            // file path.
             if (result.kind === 'matched') {
                 // restoreArkBackupBlob decrypts + validates the manifest BEFORE
                 // it touches disk or the network. An ArkRestoreApplyError means

--- a/src/screens/Ark/ArkWithdrawReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkWithdrawReviewScreen/index.tsx
@@ -729,8 +729,8 @@ export default function ArkWithdrawReviewScreen({ route }: Props) {
                              *   - On-chain broadcast fee (actually paid to miners)
                              * Empirically on a 60k-sat withdrawal in 2026-05-30
                              * testing the split was ~55% ASP / ~45% on-chain.
-                             * The SDK doesn't expose the split yet (filed
-                             * upstream-ask in OPEN_BUGS.md). Until it does,
+                             * The SDK doesn't expose the split yet, and an
+                             * upstream ask is open for it. Until it does,
                              * tell the user the fee has two components so the
                              * "why did it broadcast at 2 sat/vb when I paid X"
                              * confusion has an answer. */}

--- a/src/screens/Strike/CheckingAccountNew/ArkOnchainRecoverSection.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkOnchainRecoverSection.tsx
@@ -27,7 +27,7 @@ import { BlueStorageContext } from "../../../../blue_modules/storage-context";
 // ark.second.tech server minimum board amount. Deposits below this can never
 // board into a VTXO, so they sit stuck in bark's on-chain (BDK) wallet until
 // recovered here. 50k is the known mainnet minimum (and the value
-// fetchArkMinBoardSats() falls back to). See .claude/ARK_STUCK_UTXO_UX_SPEC.md.
+// fetchArkMinBoardSats() falls back to).
 const MIN_BOARD_SATS = 50000;
 
 /**

--- a/src/services/ark/backup.ts
+++ b/src/services/ark/backup.ts
@@ -12,7 +12,7 @@ import Aes from 'react-native-aes-crypto';
  * the recovery flow's `decryptBackupBlob` can pick up a truncated payload,
  * fail AES decrypt, and surface as `[Ark restore] decrypt of
  * fingerprint-matched blob failed: Error`. We hit this twice in one
- * 2026-05-30 session — see .claude/OPEN_BUGS.md Bug 1.
+ * 2026-05-30 session.
  *
  * Implementation note — why unlink + move, not just move:
  *   The first version of this helper assumed `RNFS.moveFile` was a thin wrap

--- a/src/services/ark/balance.ts
+++ b/src/services/ark/balance.ts
@@ -49,7 +49,6 @@ export type ArkBalanceSummary = {
      * boarded into a VTXO yet. Below the server's minBoardAmountSats this is
      * stuck (can never board); at/above it, a board is in progress. Surfaced
      * separately so the UI can show a "Boarding (on-chain)" row + recovery.
-     * See .claude/ARK_STUCK_UTXO_UX_SPEC.md.
      */
     onchainBoardingSats: number;
     /** Unconfirmed on-chain boarding sats (still gaining confirmations). */

--- a/src/services/ark/config.ts
+++ b/src/services/ark/config.ts
@@ -104,7 +104,7 @@ export const ARK_SERVER_URL = 'https://ark.second.tech';
 // "Backup file is corrupt: BarkError.ServerConnection" toast on the recovery
 // screen (the .cbark was fine; `Wallet.open` was hitting 429 from esplora and
 // the catch upstream collapsed every wallet-open failure into one error
-// string). See .claude/OPEN_BUGS.md for the full diagnosis trail.
+// string).
 //
 // 2026-06-03: switched BACK to blockstream. mempool.space started timing out
 // on the exact endpoints `Wallet.open` needs (`/blocks/tip/height`,

--- a/src/services/ark/recoverOnchainBoard.ts
+++ b/src/services/ark/recoverOnchainBoard.ts
@@ -3,8 +3,8 @@ import { ensureArkOnchainHandle } from './walletHandle';
 import { runBroadcastCall } from './indeterminate';
 
 /**
- * F3 (.claude/ARK_STUCK_UTXO_UX_SPEC.md): sweep a stuck on-chain Ark *boarding*
- * deposit back out to a Hot Vault address.
+ * Sweep a stuck on-chain Ark *boarding* deposit back out to a Hot Vault
+ * address.
  *
  * Context: funds sent to an Ark boarding address land in bark's BDK on-chain
  * wallet and must be *boarded* (an ASP round) to become a spendable VTXO. A

--- a/src/services/ark/sync.ts
+++ b/src/services/ark/sync.ts
@@ -41,8 +41,7 @@ const MIN_BOARD_SATS = 50_000;
  * `wallet.syncPendingBoards()` was called anywhere in the codebase. The
  * recovery was done via the bark CLI in 2.5 seconds against the same
  * ASP+esplora endpoints — proving the SDK works; only the wiring was
- * missing. See `.claude/SESSION_HANDOVER...md` (bark CLI session) for
- * the full debug trail.
+ * missing.
  *
  * Order matters and is intentional:
  *   1. `handle.sync()`              → vtxos + LN + round finalizations.

--- a/tests/unit/noPrivateDocRefs.test.ts
+++ b/tests/unit/noPrivateDocRefs.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tracked files must not point at local-only tooling paths.
+ *
+ * Such a reference is a broken link for everyone except its author, because the
+ * target exists only in their working copy. It reads as a live pointer and
+ * resolves to nothing on a fresh clone, which makes it easy to add and hard to
+ * notice.
+ */
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const MAX_SCAN_BYTES = 2_000_000;
+
+const LOCAL_ONLY = [/\.claude\//];
+
+/** Exactly the set of files that ends up in a clone. */
+const trackedFiles = (): string[] =>
+    execFileSync('git', ['ls-files'], { cwd: REPO_ROOT, encoding: 'utf8' })
+        .split('\n')
+        .filter(Boolean)
+        // .gitignore has to name the directory in order to ignore it, and this
+        // test has to name it in order to look for it.
+        .filter((f) => f !== '.gitignore' && !f.endsWith('noPrivateDocRefs.test.ts'));
+
+describe('tracked files do not point at local-only paths', () => {
+    it('finds none, anywhere', () => {
+        const offenders: string[] = [];
+        for (const rel of trackedFiles()) {
+            const abs = path.join(REPO_ROOT, rel);
+            let body: string;
+            try {
+                if (fs.statSync(abs).size > MAX_SCAN_BYTES) continue;
+                body = fs.readFileSync(abs, 'utf8');
+            } catch {
+                continue; // unreadable or binary
+            }
+            body.split('\n').forEach((line, i) => {
+                if (LOCAL_ONLY.some((rx) => rx.test(line))) offenders.push(`${rel}:${i + 1}`);
+            });
+        }
+        expect(offenders).toEqual([]);
+    });
+});


### PR DESCRIPTION
Twelve source comments and two markdown links pointed at paths that are not part of the repository. They resolved to nothing on a fresh clone while reading as live pointers.

## What changed

The substance of each comment is kept and only the dead pointer removed, since the detail a reader needs was already stated in the comment above it. Two index labels go with them, which meant nothing without their target.

## The guard

A unit test walks `git ls-files`, which is exactly the set that ends up in a clone, and fails on any such reference. It runs inside the existing `npm run unit` gate, so there is no new workflow to maintain.

Verified it actually fails when one is reintroduced, rather than passing vacuously.

## Verification

- No behaviour change. Comments and one markdown file only.
- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **57 suites, 629 passed, 1 skipped**

The single em dash in the diff is `ARK_PROGRESS.md`'s existing `**date** —` changelog format, shared by all fifteen entries. It appears only because the tail of that line changed.
