### PR TITLE
feat(vault): choose which address the Vault tab shows

### DIFF
--- a/screen/wallets/addresses.js
+++ b/screen/wallets/addresses.js
@@ -10,6 +10,7 @@ import { AddressTypeTabs, TABS } from '../../components/addresses/AddressTypeTab
 import { WatchOnlyWallet } from '../../class';
 import { useTheme } from '../../components/themes';
 import { dispatchNavigate } from '@Cypher/helpers';
+import useAuthStore from '@Cypher/stores/authStore';
 
 export const totalBalance = ({ c, u } = { c: 0, u: 0 }) => c + u;
 
@@ -60,12 +61,14 @@ const WalletAddresses = () => {
   const [currentTab, setCurrentTab] = useState(TABS.EXTERNAL);
 
   const { wallets } = useContext(BlueStorageContext);
+  const { setVaultDisplayAddress } = useAuthStore();
 
   const {
     walletID,
     isTouchable,
     selectForReceive,
     selectForBuyDeposit,
+    selectForVaultDisplay,
     value,
     converted,
     isSats,
@@ -184,6 +187,16 @@ const WalletAddresses = () => {
         selectedVaultAddress: item.address,
         selectedVaultType: vaultTab ? 'cold' : 'hot',
       });
+      return;
+    }
+    // Vault-display picker: pin this address as the one the vault's Vault tab
+    // shows, then go back to that tab so the choice is visible immediately.
+    // Same CommonActions merge as the buy-deposit case below, which keeps the
+    // HotStorageVault instance (and its `wallet` param) rather than pushing a
+    // second one.
+    if (selectForVaultDisplay) {
+      setVaultDisplayAddress(walletID, item.address);
+      dispatchNavigate('HotStorageVault', { tapTab: 0 });
       return;
     }
     // BUY-flow deposit picker: navigate back to the ReviewPayment

--- a/src/screens/HotStorageVault/Settings.tsx
+++ b/src/screens/HotStorageVault/Settings.tsx
@@ -277,9 +277,13 @@ export default function Settings({wallet, to, matchedRate, toStrike}: any) {
         }).start();
     };
 
+    // Picks which address the Vault tab shows. Serves the cold vault too: this
+    // screen is shared, and the selection is keyed by walletID.
     const navigateToAddresses = () =>
         dispatchNavigate('WalletAddresses', {
             walletID: wallet.getID(),
+            isTouchable: true,
+            selectForVaultDisplay: true,
         });
 
     const navigateToXPub = () =>

--- a/src/screens/HotStorageVault/Vault.tsx
+++ b/src/screens/HotStorageVault/Vault.tsx
@@ -28,15 +28,33 @@ const shortenAddress = (address: string) => {
 
 export default function Vault({ wallet, matchedRate, setSelectedTab }: { wallet: any, matchedRate: string, setSelectedTab: (tab: number) => void }) {
     const currency = btc(1);
-    const { vaultTab } = useAuthStore();
+    const { vaultTab, setVaultDisplayAddress } = useAuthStore();
     const balance = !wallet?.hideBalance && formatBalance(Number(wallet?.getBalance()), wallet?.getPreferredBalanceUnit(), true);
     const balanceWithoutSuffix = !wallet?.hideBalance && formatBalanceWithoutSuffix(Number(wallet?.getBalance()), wallet?.getPreferredBalanceUnit(), true);
     const { wallets, saveToDisk, sleep, isElectrumDisabled } = useContext(BlueStorageContext);
-    const [address, setAddress] = useState();
+    const [address, setAddress] = useState<string | undefined>();
     const [refreshing, setRefreshing] = useState(false);
     // const base64QrCodeRef = useRef(''); // disabled: toDataURL broken under Fabric/New Arch
 
     const obtainWalletAddress = async () => {
+        // A pinned address wins over generating a fresh one. Picked from
+        // Settings > Show Addresses, and kept per walletID so hot and cold are
+        // independent. Without this the useFocusEffect below would overwrite
+        // the choice with a next-free address every time the tab regained
+        // focus, which is to say immediately.
+        const pinned = useAuthStore.getState().vaultDisplayAddress?.[wallet?.getID?.()];
+        if (pinned) {
+            setAddress(pinned);
+            // Still subscribe it: the user picked it in order to be paid on it,
+            // and an unsubscribed address gets no incoming-payment push.
+            try {
+                const GroundControl = require('../../../blue_modules/groundControl');
+                await GroundControl.majorTomToGroundControl([pinned], [], []);
+            } catch (notifyErr) {
+                console.warn('[GroundControl] Failed to subscribe pinned address:', notifyErr);
+            }
+            return;
+        }
         let newAddress;
         try {
             if (!isElectrumDisabled) newAddress = await Promise.race([wallet.getAddressAsync(), sleep(1000)]);
@@ -62,13 +80,20 @@ export default function Vault({ wallet, matchedRate, setSelectedTab }: { wallet:
 
     }
 
+    // Subscribing to the pin (not just reading it in the callback) is what makes
+    // the tab update on arrival from the picker: navigation restores this tab
+    // without necessarily re-firing focus.
+    const pinnedAddress = useAuthStore(
+        (st: any) => st.vaultDisplayAddress?.[wallet?.getID?.()],
+    );
+
     useFocusEffect(
         useCallback(() => {
             if (wallet) {
                 obtainWalletAddress();
             }
             // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [wallet]),
+        }, [wallet, pinnedAddress]),
     );
 
     const copyToClipboard = (text: string) => {
@@ -216,6 +241,23 @@ export default function Vault({ wallet, matchedRate, setSelectedTab }: { wallet:
                         </TouchableOpacity> */}
                     </View>
 {/* address shown inside copy button above */}
+                    {pinnedAddress ? (
+                        // Without this there is no way back. The pin survives
+                        // every focus, so a user who picked an old address once
+                        // would keep seeing it forever with nothing on screen
+                        // explaining why it stopped advancing.
+                        <TouchableOpacity
+                            onPress={() => {
+                                setVaultDisplayAddress(wallet?.getID?.(), null);
+                                SimpleToast.show('Back to a fresh address', SimpleToast.SHORT);
+                            }}
+                            style={{ paddingHorizontal: 30, paddingTop: 10 }}
+                        >
+                            <Text style={{ fontSize: 13, color: colors.green, textAlign: 'center' }}>
+                                You chose this address. Tap to go back to a fresh one.
+                            </Text>
+                        </TouchableOpacity>
+                    ) : null}
                     {/* <Text h4 style={styles.infoText}>You can use this Bitcoin Network address of your vault to receive coins</Text> */}
                 </>
                 :

--- a/src/screens/HotStorageVault/index.tsx
+++ b/src/screens/HotStorageVault/index.tsx
@@ -14,7 +14,8 @@ import useAuthStore from "@Cypher/stores/authStore";
 
 
 const HotStorageVault = ({ _, route }: any) => {
-    const { wallet, matchedRate, currency, to = null, toStrike = null } = useRoute().params as { wallet: any, matchedRate: string, currency: string, to: null | string, toStrike: null | string };
+    const routeParams = useRoute().params as { wallet: any, matchedRate: string, currency: string, to: null | string, toStrike: null | string, tapTab?: number };
+    const { wallet, matchedRate, currency, to = null, toStrike = null, tapTab } = routeParams;
     const [selectedTab, setSelectedTab] = useState(0);
     const [utxo, setUtxo] = useState(null);
     const { vaultTab } = useAuthStore();
@@ -24,6 +25,17 @@ const HotStorageVault = ({ _, route }: any) => {
             setSelectedTab(1)
         }
     }, [to, toStrike])
+
+    // Returning from the address picker: show the tab the choice affects, so
+    // the new QR is what the user sees rather than something they must go and
+    // find. Cleared straight after so re-selecting the Settings tab by hand
+    // does not get yanked back here.
+    useEffect(() => {
+        if (typeof tapTab === 'number') {
+            setSelectedTab(tapTab);
+            routeParams.tapTab = undefined;
+        }
+    }, [tapTab, routeParams])
 
     const onChangeSelectedTab = useCallback((id: number) => {
         setSelectedTab(id);

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -197,6 +197,15 @@ export type AuthStateType = {
     arkPendingLnReceives: ArkLightningReceiveView[];
     // Current chain tip height (from esplora). Needed to convert VTXO
     // expiryHeight → blocks-until-expiry for the depletion ring.
+    /**
+     * Address the vault's Vault tab should display, per walletID.
+     *
+     * Empty means "use a fresh next-free address", which is the default and
+     * what the tab did unconditionally before. Keyed by wallet so the hot and
+     * cold vaults are independent, and so a selection cannot follow the user
+     * onto a different wallet.
+     */
+    vaultDisplayAddress: Record<string, string>;
     arkChainTipHeight: number | null;
     // Epoch ms the tip above was read. The tip is PERSISTED, so a cold launch
     // offline rehydrates one that may be days old, and
@@ -338,6 +347,7 @@ export type AuthStateType = {
     setArkScheduledStuckSwapNotifs: (state: Record<string, number>) => void;
     setArkExpiryNotifsScheduleVersion: (state: number) => void;
     setArkPendingLnReceives: (state: ArkLightningReceiveView[]) => void;
+    setVaultDisplayAddress: (walletID: string, address: string | null) => void;
     setArkChainTipHeight: (state: number | null) => void;
     setArkLastSyncedAt: (state: number | null) => void;
     setArkLastBackupAt: (state: number | null) => void;
@@ -566,6 +576,7 @@ const createAuthStore = (
     arkScheduledStuckSwapNotifs: {},
     arkExpiryNotifsScheduleVersion: 0,
     arkPendingLnReceives: [],
+    vaultDisplayAddress: {},
     arkChainTipHeight: null,
     arkChainTipHeightAt: null,
     arkLastSyncedAt: null,
@@ -648,6 +659,14 @@ const createAuthStore = (
     setArkScheduledStuckSwapNotifs: (state: Record<string, number>) => set({ arkScheduledStuckSwapNotifs: state }),
     setArkExpiryNotifsScheduleVersion: (state: number) => set({ arkExpiryNotifsScheduleVersion: state }),
     setArkPendingLnReceives: (state: ArkLightningReceiveView[]) => set({ arkPendingLnReceives: state }),
+    setVaultDisplayAddress: (walletID: string, address: string | null) =>
+        set((state: any) => {
+            const next = { ...(state.vaultDisplayAddress ?? {}) };
+            // A null clears the pin and returns the tab to a fresh address.
+            if (address) next[walletID] = address;
+            else delete next[walletID];
+            return { vaultDisplayAddress: next };
+        }),
     // Stamps the read time with the value, so the two can never drift apart.
     setArkChainTipHeight: (state: number | null) =>
         set({ arkChainTipHeight: state, arkChainTipHeightAt: state == null ? null : Date.now() }),


### PR DESCRIPTION
**Settings → Show Addresses** opened a list whose rows did nothing. It looks identical to the receive picker, where tapping *does* select, so tapping and getting no response reads as a broken screen rather than an informational list. That is exactly how it was reported.

It is now a picker, and the choice lands where it is useful: the selected address becomes the **QR and the address string on the Vault tab**.

Serves the **cold vault** too. That Settings screen is shared, and the selection is keyed by `walletID`, so hot and cold are independent and a pin cannot follow the user onto a different wallet.

## Four things worth knowing

**The pin has to win inside `obtainWalletAddress`, not around it.** That function runs from `useFocusEffect`, so anything layered on top would be overwritten with a next-free address the moment the tab regained focus.

**The Vault tab subscribes to the pinned value** rather than reading it inside the focus callback. Navigation restores the tab without necessarily re-firing focus, so the subscription is what makes the QR update on arrival from the picker.

**A pinned address is still subscribed to GroundControl.** The user picked it in order to be paid on it, and an unsubscribed address gets no incoming-payment push. Easy to drop by accident, since the subscribe call lives in the branch being bypassed.

**There is a way back.** Without one the pin survives every focus, so someone who picked an old address once would keep seeing it forever with nothing on screen explaining why it stopped advancing. The Vault tab now says the address was chosen and offers a tap to return to a fresh one.

## Navigation

Returning from the picker selects the Vault tab via a route param, using the same `CommonActions` merge the buy-deposit picker already uses. That keeps the existing `HotStorageVault` instance and its `wallet` param rather than pushing a second one.

## Deliberately not changed

The **"Vault Addresses"** button on the Vault tab opens the same list and stays read-only. It is a browsing surface, and making it a second way to set the same pin would put the control and its effect on the same screen for no gain.

Flagging rather than assuming: if you want that one selectable too, it is one param.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **57 suites, 629 passed, 1 skipped**

Not device-verified. Worth checking on the phone: pick an address in Settings, confirm the Vault tab QR and string change to it, background and reopen to confirm it sticks, then tap the reset line and confirm it returns to a fresh address.
