### PR TITLE
fix(vault): make the Vault Addresses button select, and stop wiping the vault's params

### DIFF
--- a/screen/wallets/addresses.js
+++ b/screen/wallets/addresses.js
@@ -117,6 +117,7 @@ const WalletAddresses = () => {
   const { colors } = useTheme();
 
   const { setOptions, navigate } = useNavigation();
+  const navigation = useNavigation();
 
   const [search, setSearch] = React.useState('');
 
@@ -196,7 +197,13 @@ const WalletAddresses = () => {
     // second one.
     if (selectForVaultDisplay) {
       setVaultDisplayAddress(walletID, item.address);
-      dispatchNavigate('HotStorageVault', { tapTab: 0 });
+      // goBack, NOT dispatchNavigate. CommonActions.navigate REPLACES params
+      // unless merge:true is set (StackRouter, v6.1.9), so navigating to
+      // HotStorageVault by name would wipe its `wallet` param and render the
+      // vault with nothing. goBack returns to the exact screen instance that
+      // pushed this list, params intact, which for the Vault Addresses button
+      // is already the tab the chosen address appears on.
+      navigation.goBack();
       return;
     }
     // BUY-flow deposit picker: navigate back to the ReviewPayment

--- a/src/screens/HotStorageVault/Vault.tsx
+++ b/src/screens/HotStorageVault/Vault.tsx
@@ -101,9 +101,18 @@ export default function Vault({ wallet, matchedRate, setSelectedTab }: { wallet:
         SimpleToast.show('Copied to clipboard', SimpleToast.SHORT);
     };
 
+    // The "Vault Addresses" button on this tab. Same picker as
+    // Settings > Show Addresses: tapping a row pins it as the address shown
+    // here. Left read-only in the first pass on the theory that a browsing
+    // surface and the thing it changes should not sit on one screen. That was
+    // wrong in practice, because this is the button people actually reach for
+    // when they want a different receive address, and an inert list next to the
+    // QR it would change reads as broken rather than informational.
     const addressHandler = () => {
         dispatchNavigate('WalletAddresses', {
             walletID: wallet.getID(),
+            isTouchable: true,
+            selectForVaultDisplay: true,
         });
     }
 

--- a/src/screens/HotStorageVault/index.tsx
+++ b/src/screens/HotStorageVault/index.tsx
@@ -14,8 +14,7 @@ import useAuthStore from "@Cypher/stores/authStore";
 
 
 const HotStorageVault = ({ _, route }: any) => {
-    const routeParams = useRoute().params as { wallet: any, matchedRate: string, currency: string, to: null | string, toStrike: null | string, tapTab?: number };
-    const { wallet, matchedRate, currency, to = null, toStrike = null, tapTab } = routeParams;
+    const { wallet, matchedRate, currency, to = null, toStrike = null } = useRoute().params as { wallet: any, matchedRate: string, currency: string, to: null | string, toStrike: null | string };
     const [selectedTab, setSelectedTab] = useState(0);
     const [utxo, setUtxo] = useState(null);
     const { vaultTab } = useAuthStore();
@@ -26,16 +25,6 @@ const HotStorageVault = ({ _, route }: any) => {
         }
     }, [to, toStrike])
 
-    // Returning from the address picker: show the tab the choice affects, so
-    // the new QR is what the user sees rather than something they must go and
-    // find. Cleared straight after so re-selecting the Settings tab by hand
-    // does not get yanked back here.
-    useEffect(() => {
-        if (typeof tapTab === 'number') {
-            setSelectedTab(tapTab);
-            routeParams.tapTab = undefined;
-        }
-    }, [tapTab, routeParams])
 
     const onChangeSelectedTab = useCallback((id: number) => {
         setSelectedTab(id);


### PR DESCRIPTION
Two fixes to the address picker from #231, both found by it not working on device.

## 1. The button people actually use was still inert

The **"Vault Addresses"** button on the Vault tab, sitting directly above the QR it would change, still opened the list read-only. I had left it that way deliberately, on the theory that a browsing surface and the thing it changes should not share a screen, and wired only Settings → Show Addresses.

That was wrong. This is the button someone reaches for when they want a different receive address, and an inert list next to the QR reads as broken rather than informational. It now opens the same picker.

## 2. Returning from the picker wiped the vault's route params

This one would have broken the Settings path too, silently.

The picker finished with `dispatchNavigate('HotStorageVault', { tapTab: 0 })`. **`CommonActions.navigate` REPLACES params unless `merge: true` is passed**, which `dispatchNavigate` does not expose. So that call would have replaced `{ wallet, matchedRate, currency, ... }` with `{ tapTab: 0 }` and rendered the vault with no wallet.

The comment already in `addresses.js` asserts the opposite, that it "merges params into the existing instance". **It is wrong, and I took it at face value instead of checking the router.** Verified in `StackRouter.js` (@react-navigation/native 6.1.9): the merge branch is gated on `action.payload.merge`, and the else branch assigns `action.payload.params` outright.

Replaced with `navigation.goBack()`, which returns to the exact screen instance that pushed the list with its params untouched. For the Vault Addresses button that is also the *right* destination, not merely the safe one, since it is already the tab the chosen address appears on.

The `tapTab` route param added for the old approach is removed rather than left as a parameter nothing sets.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **57 suites, 629 passed, 1 skipped**

Still not device-verified, which is why this is a second PR rather than a first. After merging: tap **Vault Addresses**, pick a row, and the QR plus address string on that same tab should change to it. Then background and reopen to confirm it sticks, and tap the reset line to confirm it returns to a fresh address.

Worth noting the pre-existing comment above the buy-deposit branch makes the same false claim about merging. That flow passes params to `ReviewPayment` and appears to work, so either it tolerates replacement or it has a latent version of this bug. Not touched here, but it is worth a look.
