### PR TITLE
perf(ark): poll the tip to decide, and drive the exit only when it moves

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -22,7 +22,7 @@ import {
     fetchChainTipHeight,
     fetchArkExitVtxos,
     decideExitClaimBatch,
-    decideExitDriveCadence,
+    decideExitDrivePlan,
     type ExitDriveSnapshot,
     isVtxoMidRound,
     fetchClaimableExitVtxos,
@@ -292,6 +292,10 @@ export default function useArkSync(): UseArkSync {
     // What the LAST drive saw. Lets the next one pick a cadence without
     // spending a request to find out what phase the exit is in.
     const exitDriveSnapshotRef = useRef<ExitDriveSnapshot | null>(null);
+    // Last wall-clock ms a cheap tip poll ran, and the tip it returned. The
+    // poll is what replaced using the full drive as the unit of polling.
+    const exitTipPollLastMsRef = useRef(0);
+    const exitTipHeightRef = useRef<number | null>(null);
     // Counter used by the idle-skip heuristic. Increments every cycle that
     // returns balance=0 and vtxos.all.length=0; resets the moment either
     // turns non-zero. We use this to avoid the 2s Bark `syncArkWallet`
@@ -406,17 +410,51 @@ export default function useArkSync(): UseArkSync {
                 // cuts the esplora load 4x. Skipped ticks do nothing at all
                 // (normal sync stays skipped while an exit is running).
                 const nowMs = Date.now();
-                const cadence = decideExitDriveCadence({
+                const plan = decideExitDrivePlan({
                     last: exitDriveSnapshotRef.current,
+                    tipHeight: exitTipHeightRef.current,
                     now: nowMs,
-                    lastRunAt: exitDriveLastRunMsRef.current,
+                    lastFullRunAt: exitDriveLastRunMsRef.current,
+                    lastTipPollAt: exitTipPollLastMsRef.current,
                 });
-                if (!cadence.run) {
+
+                if (plan.action === 'skip') {
                     _stamp(
-                        `exit drive skipped (${cadence.phase}, every ${Math.round(cadence.waitMs / 1000)}s)`,
+                        `exit drive skipped (${plan.phase}/${plan.reason}, every ` +
+                        `${Math.round(plan.waitMs / 1000)}s` +
+                        (plan.blocksToNext != null ? `, ${plan.blocksToNext} blocks to next` : '') +
+                        ')',
                     );
                     return;
                 }
+
+                if (plan.action === 'tip') {
+                    // ONE request, against ~20 for a full drive. This is the
+                    // whole change: asking "has anything happened" no longer
+                    // costs the same as doing the work.
+                    exitTipPollLastMsRef.current = nowMs;
+                    try {
+                        const tip = await fetchChainTipHeight();
+                        if (tip != null) {
+                            exitTipHeightRef.current = tip;
+                            // Closes #204 as a side effect: the store's tip was
+                            // frozen for the whole of an exit because the normal
+                            // sync path returns before refreshing it, which is
+                            // what left the VTXO capsule expiry displays stale
+                            // and over-optimistic. This is the only place it
+                            // advances mid-exit.
+                            setArkChainTipHeight(tip);
+                        }
+                        _stamp(
+                            `exit tip poll: ${tip ?? 'unreadable'}` +
+                            (plan.blocksToNext != null ? ` (${plan.blocksToNext} blocks to next)` : ''),
+                        );
+                    } catch (tipErr: any) {
+                        console.warn('[Ark exit] tip poll failed:', tipErr?.message ?? tipErr);
+                    }
+                    return;
+                }
+
                 exitDriveLastRunMsRef.current = nowMs;
                 try {
                     // Sync the wallet FIRST. The normal sync path below is
@@ -522,7 +560,7 @@ export default function useArkSync(): UseArkSync {
                     // entry), so anything paced off one computes a constant.
                     exitDriveSnapshotRef.current = {
                         claimableCount: claimable.length,
-                        awaitingCount: pendingClaimableHeights.length,
+                        awaitingHeights: pendingClaimableHeights,
                         processingCount: unknownScheduleCount,
                     };
 

--- a/src/services/ark/exitDriveCadence.ts
+++ b/src/services/ark/exitDriveCadence.ts
@@ -1,132 +1,178 @@
 /**
- * How often the exit drive should actually run.
+ * What the exit drive should do on this tick.
  *
  * THE PROBLEM
  *
  * The drive polls hard for an event whose block height it already knows. Once
  * every leaf is confirmed and sitting in AwaitingDelta, `claimableHeight` is
  * populated and fixed, and for the next vtxoExitDelta blocks (~24h) there is
- * exactly one question worth asking: has the tip passed it. The drive instead
- * ran a full syncArkWallet + progressExits + syncExits + listClaimableExits +
- * allVtxos + balance every 120 seconds for that entire window, and
- * `progressExits` had nothing to progress during any of it.
+ * exactly one question worth asking: has the tip passed it.
  *
- * Measured on the 2026-08-22 mainnet exit: 44 hours total, of which roughly 40
- * were spent in AwaitingDelta with nothing to broadcast. At 120s that is ~1,200
- * full drives to observe two block heights arriving. Blockstream's
- * unauthenticated cap is 700 requests/hour/IP, and it is per IP, so a user
- * behind CGNAT shares it with strangers. On 2026-08-24 that cap was hit and the
- * wallet would not open at all. See #194.
+ * Answering it used to cost a full syncArkWallet + progressExits + syncExits +
+ * listClaimableExits + allVtxos + balance, roughly 20 requests, because the full
+ * drive WAS the unit of polling. Measured on the 2026-08-22 mainnet exit: 44
+ * hours, roughly 40 of them waiting. Blockstream's unauthenticated cap is 700
+ * requests/hour/IP and it is shared behind CGNAT.
  *
- * THE FIX, AND WHY IT IS A FLAT INTERVAL RATHER THAN A GRADUATED ONE
+ * THE FIX
  *
- * Back the waiting phase off to a single long interval. Three phases with
- * genuinely different needs previously shared one timer:
+ * Separate "has anything changed" from "do the work". Checking the tip is one
+ * request. The full drive runs only when the answer is yes.
  *
- *   broadcasting  urgent, racing expiry, keep the fast cadence
- *   waiting       ~95% of wall clock, nothing to do until the tip moves
- *   claimable     one drainExits, fire promptly
+ *   broadcasting  full drive, fast. Each tree level needs the app to relay the
+ *                 next, so this is the phase that genuinely needs attention.
+ *   waiting       tip poll only, paced by blocks remaining. A full drive when
+ *                 the tip crosses the soonest claimableHeight, or on the floor
+ *                 below.
+ *   claimable     full drive, fast. The claim is the point.
  *
- * The obvious refinement is to taper: back off hard while ripening is hours
- * away and tighten as it approaches. That needs a chain tip, and DURING AN EXIT
- * THERE IS NO FREE ONE.
+ * WHY THIS NEEDED A LIVE TIP FIRST
  *
- *   - `arkChainTipHeight` in the store is frozen for the duration of an exit,
- *     because the sync loop returns before refreshing it (#204).
- *   - `ExitState.inner.tipHeight` on the exit records is ALSO frozen. bark
- *     stamps it once when the state is entered and never rewrites it: the
- *     AwaitingDelta arm returns its state unchanged while `tip <
- *     claimable_height`, and bark only persists a state that differs from the
- *     stored one. Verified against bark 0.6.1 and confirmed on device, where
- *     one capsule read 963510 across four captures spanning 21 hours while the
- *     chain advanced to 963795. Only the Claimable transition restamps it.
+ * An earlier attempt tapered the full drive by blocks remaining and could not
+ * work, because no live tip existed during an exit: `arkChainTipHeight` is
+ * frozen (#204) and `ExitState.inner.tipHeight` is stamped once on entry and
+ * never advances. Both give a constant blocks-remaining. Polling the tip
+ * ourselves is what makes the taper real, and writing it to the store is what
+ * closes #204 as a side effect.
  *
- * A taper driven off either value computes a CONSTANT blocks-remaining of about
- * vtxoExitDelta and therefore never tapers, so it would be dead code wearing
- * the label of a live optimisation. This module does not pretend otherwise.
+ * REQUEST BUDGET, over a ~24h (144 block) wait
  *
- * The cost of the flat interval is that a claim can fire up to one interval
- * after its capsule ripens. That is safe: past its CSV an exit output is an
- * ordinary UTXO only this wallet can spend, with no deadline and nobody to race.
+ *   before, 120s flat        ~720 full drives      ~14,400 requests
+ *   30 min flat (shipped)     ~48 full drives         ~960 requests
+ *   this                     ~180 tip polls + 4        ~260 requests
  *
- * The real fix is to stop using the full drive as the unit of polling: check the
- * tip with one `/blocks/tip/height` request on a tight cadence, and run the full
- * drive only when the tip has crossed a `claimableHeight`. That is ~1 request
- * per check instead of ~20, stays responsive at ripening, and unfreezes #204 as
- * a side effect. It is a larger change than this one and wants verification
- * against a live multi-day exit, so it is tracked as #219.
- *
- * WHY DECIDING NEEDS NO REQUESTS
- *
- * The decision reads a snapshot the PREVIOUS drive already fetched. Every field
- * comes from calls the drive makes anyway for its claim-batching decision, so
- * the cost of deciding is zero.
+ * and it is responsive at the end rather than up to 30 minutes late, because
+ * the poll tightens to 2 minutes as ripening approaches.
  *
  * Pure and import-free, matching exitClaimBatch.ts and changeRefresh.ts.
  */
 
-/** State observed on the last drive. Costs nothing: the drive already had it. */
+/** State observed on the last FULL drive. Costs nothing: it already had it. */
 export type ExitDriveSnapshot = {
     /** Capsules ready to sweep now. */
     claimableCount: number;
-    /** Capsules confirmed and waiting out the CSV, with a known ripening height. */
-    awaitingCount: number;
+    /** `claimableHeight` of each capsule waiting out its CSV. */
+    awaitingHeights: readonly number[];
     /** Capsules still broadcasting, so no ripening height yet. */
     processingCount: number;
 };
 
 export type ExitDrivePhase = 'broadcasting' | 'claimable' | 'waiting' | 'unknown';
 
-/** Fast cadence, unchanged from the original flat throttle. */
-export const EXIT_DRIVE_FAST_MS = 120_000;
-/** Every capsule is waiting out its CSV. Nothing to do until the chain moves. */
-export const EXIT_DRIVE_WAITING_MS = 30 * 60_000;
+/** Everything except a tip poll. */
+export type ExitDriveAction = 'full' | 'tip' | 'skip';
 
-export type ExitDriveDecision = {
-    run: boolean;
+/** Full-drive cadence for the phases that need one every tick. */
+export const EXIT_DRIVE_FAST_MS = 120_000;
+
+/** Tip-poll cadence, by blocks until the soonest ripening. One request each. */
+export const TIP_POLL_NEAR_MS = 120_000;
+export const TIP_POLL_MID_MS = 5 * 60_000;
+export const TIP_POLL_FAR_MS = 10 * 60_000;
+
+/**
+ * A full drive at least this often while waiting, whatever the tip says.
+ *
+ * bark's AwaitingDelta arm calls `check_confirmed` on every progressExits and
+ * drops back to Processing if the exit transaction has vanished in a reorg.
+ * Polling only the tip gives that up, so this is the floor that bounds how long
+ * a reorg can go unnoticed.
+ *
+ * Six hours rather than one is a deliberate trade. An hourly floor costs ~480
+ * requests over a 24h wait and would dominate the budget this change exists to
+ * cut. The exposure it buys back is bounded and mild: a missed reorg delays the
+ * exit until the next full drive, it does not lose funds, and the transaction
+ * is buried deeper with every hour that passes.
+ */
+export const FULL_DRIVE_FLOOR_MS = 6 * 60 * 60_000;
+
+export type ExitDrivePlan = {
+    action: ExitDriveAction;
     phase: ExitDrivePhase;
-    /** Interval this phase warrants, for the log and the next comparison. */
+    /** Interval this phase warrants, for the log. */
     waitMs: number;
+    /** Blocks until the SOONEST ripening, when it can be computed. */
+    blocksToNext: number | null;
+    /** Why, for the drive log. */
+    reason: string;
 };
 
-export function decideExitDriveCadence(args: {
+export function decideExitDrivePlan(args: {
     last: ExitDriveSnapshot | null;
+    /** Freshest tip known, from the poll. null when it could not be read. */
+    tipHeight: number | null;
     now: number;
-    lastRunAt: number;
-}): ExitDriveDecision {
-    const { last, now, lastRunAt } = args;
-    const elapsed = now - lastRunAt;
-    const fast = (phase: ExitDrivePhase): ExitDriveDecision => ({
-        run: elapsed >= EXIT_DRIVE_FAST_MS,
+    lastFullRunAt: number;
+    lastTipPollAt: number;
+}): ExitDrivePlan {
+    const { last, tipHeight, now, lastFullRunAt, lastTipPollAt } = args;
+    const sinceFull = now - lastFullRunAt;
+    const sinceTip = now - lastTipPollAt;
+
+    const full = (phase: ExitDrivePhase, reason: string): ExitDrivePlan => ({
+        action: sinceFull >= EXIT_DRIVE_FAST_MS ? 'full' : 'skip',
         phase,
         waitMs: EXIT_DRIVE_FAST_MS,
+        blocksToNext: null,
+        reason,
     });
 
     // No snapshot yet (first drive of a session, or a cold launch mid-exit).
     // Run: we cannot reason about a phase we have never observed.
     if (last == null) {
-        return { run: true, phase: 'unknown', waitMs: EXIT_DRIVE_FAST_MS };
+        return { action: 'full', phase: 'unknown', waitMs: EXIT_DRIVE_FAST_MS, blocksToNext: null, reason: 'no-snapshot' };
     }
 
-    // Anything still broadcasting is racing expiry and needs the app's
-    // attention every tick, because each tree level needs the app to relay the
-    // next. This is the phase the old flat throttle was actually tuned for, and
-    // it keeps that cadence. Checked FIRST: a straggler still needs relaying
-    // even when other capsules have already ripened.
-    if (last.processingCount > 0) return fast('broadcasting');
+    // Anything still broadcasting needs the app every tick, because each tree
+    // level must be relayed before the next can go. Checked FIRST: a straggler
+    // still needs relaying even when other capsules have already ripened.
+    if (last.processingCount > 0) return full('broadcasting', 'still-broadcasting');
 
-    // Something is ready to sweep. Fire promptly: the claim is the whole point
-    // and waiting on it strands recovered value.
-    if (last.claimableCount > 0) return fast('claimable');
+    // Something is ready to sweep. The claim is the whole point.
+    if (last.claimableCount > 0) return full('claimable', 'claim-ready');
 
-    // Everything is confirmed and waiting out its CSV. Nothing this app can do
-    // changes anything until the chain advances past a claimableHeight.
-    if (last.awaitingCount > 0) {
-        return { run: elapsed >= EXIT_DRIVE_WAITING_MS, phase: 'waiting', waitMs: EXIT_DRIVE_WAITING_MS };
+    const heights = last.awaitingHeights.filter((h) => Number.isFinite(h) && h > 0);
+    if (heights.length === 0) {
+        // Active exit, but no capsule in any phase we recognise. Erring toward
+        // more requests is wrong for THIS issue and right for not stalling an
+        // exit: a stalled exit costs the user far more than a quota.
+        return full('unknown', 'no-known-schedule');
     }
 
-    // An exit is flagged active but the snapshot shows no capsule in any known
-    // phase. Erring toward more requests is wrong for THIS issue and right for
-    // not stalling an exit: a stalled exit costs the user far more than a quota.
-    return fast('unknown');
+    // Reorg floor. Placed inside the waiting branch because it is the only
+    // phase that would otherwise go hours without calling progressExits.
+    if (sinceFull >= FULL_DRIVE_FLOOR_MS) {
+        return { action: 'full', phase: 'waiting', waitMs: EXIT_DRIVE_FAST_MS, blocksToNext: null, reason: 'reorg-floor' };
+    }
+
+    const soonest = Math.min(...heights);
+
+    // No usable tip: the poll failed, or has not run yet. Do not guess a
+    // cadence from a number we do not have.
+    if (tipHeight == null || !Number.isFinite(tipHeight)) {
+        return {
+            action: sinceTip >= TIP_POLL_NEAR_MS ? 'tip' : 'skip',
+            phase: 'waiting',
+            waitMs: TIP_POLL_NEAR_MS,
+            blocksToNext: null,
+            reason: 'tip-unknown',
+        };
+    }
+
+    // Something ripened. This is the whole reason the poll exists.
+    if (tipHeight >= soonest) {
+        return { action: 'full', phase: 'waiting', waitMs: EXIT_DRIVE_FAST_MS, blocksToNext: 0, reason: 'tip-crossed' };
+    }
+
+    const blocksToNext = soonest - tipHeight;
+    const waitMs =
+        blocksToNext > 20 ? TIP_POLL_FAR_MS : blocksToNext >= 6 ? TIP_POLL_MID_MS : TIP_POLL_NEAR_MS;
+
+    return {
+        action: sinceTip >= waitMs ? 'tip' : 'skip',
+        phase: 'waiting',
+        waitMs,
+        blocksToNext,
+        reason: 'awaiting-ripening',
+    };
 }

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -268,8 +268,8 @@ export type {
 } from './exitFundingCoinos';
 
 export { decideExitClaimBatch } from './exitClaimBatch';
-export { decideExitDriveCadence } from './exitDriveCadence';
-export type { ExitDriveSnapshot, ExitDrivePhase } from './exitDriveCadence';
+export { decideExitDrivePlan } from './exitDriveCadence';
+export type { ExitDriveSnapshot, ExitDrivePhase, ExitDriveAction, ExitDrivePlan } from './exitDriveCadence';
 export type { ExitClaimBatchInput, ExitClaimBatchDecision } from './exitClaimBatch';
 
 export { resolveExitReserveTarget } from './exitReserveTarget';

--- a/tests/unit/exitDriveCadence.test.ts
+++ b/tests/unit/exitDriveCadence.test.ts
@@ -1,98 +1,174 @@
 /**
- * Backing off the exit drive when it has nothing to do.
+ * Separating "has anything changed" from "do the work".
  *
- * The 2026-08-22 mainnet exit ran 44 hours, roughly 40 of them in AwaitingDelta
- * with nothing to broadcast, at a flat 120s cadence. Blockstream's cap is 700
- * requests/hour/IP and it is shared behind CGNAT. On 2026-08-24 it was hit and
- * the wallet would not open at all.
- *
- * The waiting interval is deliberately FLAT rather than tapering toward
- * ripening: no live chain tip is available during an exit without spending a
- * request, so a taper would compute a constant and never fire. See the module
- * docblock.
+ * The 2026-08-22 mainnet exit ran 44 hours, roughly 40 of them waiting on a
+ * block height it already knew, at ~20 requests per check because the full
+ * drive WAS the unit of polling. Blockstream's cap is 700 requests/hour/IP and
+ * it is shared behind CGNAT.
  */
 
 import {
-    decideExitDriveCadence,
+    decideExitDrivePlan,
     EXIT_DRIVE_FAST_MS,
-    EXIT_DRIVE_WAITING_MS,
+    TIP_POLL_NEAR_MS,
+    TIP_POLL_MID_MS,
+    TIP_POLL_FAR_MS,
+    FULL_DRIVE_FLOOR_MS,
     type ExitDriveSnapshot,
 } from '../../src/services/ark/exitDriveCadence';
 
 const NOW = 1_700_000_000_000;
+const TIP = 963_500;
+
 const snap = (o: Partial<ExitDriveSnapshot> = {}): ExitDriveSnapshot => ({
     claimableCount: 0,
-    awaitingCount: 0,
+    awaitingHeights: [],
     processingCount: 0,
     ...o,
 });
-const decide = (last: ExitDriveSnapshot | null, sinceMs: number) =>
-    decideExitDriveCadence({ last, now: NOW, lastRunAt: NOW - sinceMs });
 
-describe('phases that must stay fast', () => {
-    it('keeps the fast cadence while anything is still broadcasting', () => {
-        // Racing expiry, and each tree level needs the app to relay the next.
-        const d = decide(snap({ processingCount: 1, awaitingCount: 3 }), 0);
-        expect(d.phase).toBe('broadcasting');
-        expect(d.waitMs).toBe(EXIT_DRIVE_FAST_MS);
+/** Default the clocks to "long ago" so a decision is never blocked by them. */
+const plan = (
+    last: ExitDriveSnapshot | null,
+    tipHeight: number | null,
+    opts: { sinceFull?: number; sinceTip?: number } = {},
+) =>
+    decideExitDrivePlan({
+        last,
+        tipHeight,
+        now: NOW,
+        lastFullRunAt: NOW - (opts.sinceFull ?? EXIT_DRIVE_FAST_MS),
+        lastTipPollAt: NOW - (opts.sinceTip ?? TIP_POLL_FAR_MS),
     });
 
-    it('fires promptly once something is claimable', () => {
-        const d = decide(snap({ claimableCount: 1 }), EXIT_DRIVE_FAST_MS);
-        expect(d.phase).toBe('claimable');
-        expect(d.run).toBe(true);
+describe('phases that still need the full drive', () => {
+    it('drives fully while anything is broadcasting', () => {
+        // Each tree level must be relayed before the next can go, so this is
+        // the phase that genuinely needs the app.
+        const p = plan(snap({ processingCount: 1, awaitingHeights: [963_600] }), TIP);
+        expect(p.action).toBe('full');
+        expect(p.phase).toBe('broadcasting');
     });
 
-    it('holds the claimable phase to its own interval, not longer', () => {
-        expect(decide(snap({ claimableCount: 1 }), EXIT_DRIVE_FAST_MS - 1).run).toBe(false);
+    it('lets broadcasting outrank a capsule that has already ripened', () => {
+        const p = plan(snap({ processingCount: 1, claimableCount: 3 }), TIP);
+        expect(p.phase).toBe('broadcasting');
+        expect(p.action).toBe('full');
     });
 
-    it('broadcasting outranks claimable, since a straggler still needs relaying', () => {
-        expect(decide(snap({ processingCount: 1, claimableCount: 3 }), 0).phase)
-            .toBe('broadcasting');
-    });
-});
-
-describe('backing off while every capsule waits out its CSV', () => {
-    it('waits half an hour when every capsule is confirmed and waiting', () => {
-        const d = decide(snap({ awaitingCount: 3 }), 0);
-        expect(d.phase).toBe('waiting');
-        expect(d.waitMs).toBe(EXIT_DRIVE_WAITING_MS);
-        expect(d.run).toBe(false);
+    it('drives fully when something is claimable', () => {
+        expect(plan(snap({ claimableCount: 1 }), TIP).action).toBe('full');
     });
 
-    it('still runs once the backed-off interval has elapsed', () => {
-        const waiting = snap({ awaitingCount: 3 });
-        expect(decide(waiting, EXIT_DRIVE_WAITING_MS - 1).run).toBe(false);
-        expect(decide(waiting, EXIT_DRIVE_WAITING_MS).run).toBe(true);
+    it('drives fully with no snapshot, rather than guessing a phase', () => {
+        const p = plan(null, TIP);
+        expect(p.action).toBe('full');
+        expect(p.reason).toBe('no-snapshot');
     });
 
-    it('does not back off on a single waiting capsule any differently', () => {
-        // Count is not a cadence input: one capsule mid-CSV is as idle as five.
-        expect(decide(snap({ awaitingCount: 1 }), 0).waitMs).toBe(EXIT_DRIVE_WAITING_MS);
+    it('drives fully when an active exit shows no recognisable schedule', () => {
+        expect(plan(snap(), TIP).reason).toBe('no-known-schedule');
     });
 });
 
-describe('what it refuses to back off on', () => {
-    it('runs when there is no snapshot yet, rather than guessing a phase', () => {
-        const d = decide(null, 0);
-        expect(d.run).toBe(true);
-        expect(d.phase).toBe('unknown');
+describe('the waiting phase polls the tip instead of driving', () => {
+    const waiting = snap({ awaitingHeights: [963_600] });
+
+    it('asks for a tip poll, not a full drive', () => {
+        const p = plan(waiting, TIP);
+        expect(p.action).toBe('tip');
+        expect(p.phase).toBe('waiting');
+        expect(p.blocksToNext).toBe(100);
     });
 
-    it('keeps the fast cadence when no capsule is in any known phase', () => {
-        // Erring toward more requests is wrong for this issue and right for not
-        // stalling an exit. A stalled exit costs the user far more than a quota.
-        const d = decide(snap(), 0);
-        expect(d.phase).toBe('unknown');
-        expect(d.waitMs).toBe(EXIT_DRIVE_FAST_MS);
+    it('paces the poll by blocks remaining, which a live tip finally allows', () => {
+        expect(plan(waiting, 963_500).waitMs).toBe(TIP_POLL_FAR_MS);   // 100 blocks
+        expect(plan(waiting, 963_585).waitMs).toBe(TIP_POLL_MID_MS);   // 15
+        expect(plan(waiting, 963_597).waitMs).toBe(TIP_POLL_NEAR_MS);  // 3
     });
 
-    it('returns to the fast cadence as soon as a waiting capsule ripens', () => {
-        // The transition that ends the backed-off phase: the drive that
-        // observes a claimable capsule writes a snapshot the next one reads.
-        expect(decide(snap({ awaitingCount: 3 }), 0).waitMs).toBe(EXIT_DRIVE_WAITING_MS);
-        expect(decide(snap({ awaitingCount: 2, claimableCount: 1 }), 0).waitMs)
-            .toBe(EXIT_DRIVE_FAST_MS);
+    it('paces off the SOONEST height, since that is the next thing that can change', () => {
+        const many = snap({ awaitingHeights: [963_652, 963_505, 963_599] });
+        expect(plan(many, TIP).blocksToNext).toBe(5);
+        expect(plan(many, TIP).waitMs).toBe(TIP_POLL_NEAR_MS);
+    });
+
+    it('skips entirely between polls', () => {
+        expect(plan(waiting, TIP, { sinceTip: TIP_POLL_FAR_MS - 1 }).action).toBe('skip');
+        expect(plan(waiting, TIP, { sinceTip: TIP_POLL_FAR_MS }).action).toBe('tip');
+    });
+});
+
+describe('what promotes a poll back to a full drive', () => {
+    const waiting = snap({ awaitingHeights: [963_600] });
+
+    it('the tip crossing the soonest ripening height', () => {
+        const p = plan(waiting, 963_600);
+        expect(p.action).toBe('full');
+        expect(p.reason).toBe('tip-crossed');
+    });
+
+    it('a tip past the height, not merely equal to it', () => {
+        expect(plan(waiting, 963_999).action).toBe('full');
+    });
+
+    it('the reorg floor, however quiet the chain has been', () => {
+        // bark drops a reorged exit back to Processing on progressExits, which
+        // a tip-only poll never calls. This bounds how long that goes unseen.
+        const p = plan(waiting, TIP, { sinceFull: FULL_DRIVE_FLOOR_MS });
+        expect(p.action).toBe('full');
+        expect(p.reason).toBe('reorg-floor');
+    });
+
+    it('but not one minute before the floor', () => {
+        expect(plan(waiting, TIP, { sinceFull: FULL_DRIVE_FLOOR_MS - 60_000 }).action).toBe('tip');
+    });
+});
+
+describe('what it refuses to do', () => {
+    const waiting = snap({ awaitingHeights: [963_600] });
+
+    it('does not guess a cadence from a tip it does not have', () => {
+        const p = plan(waiting, null);
+        expect(p.reason).toBe('tip-unknown');
+        expect(p.blocksToNext).toBeNull();
+        // Falls back to the TIGHTEST poll rather than the loosest: an unreadable
+        // tip is a reason to look again sooner, not later.
+        expect(p.waitMs).toBe(TIP_POLL_NEAR_MS);
+    });
+
+    it('never starves the full drive when the tip is permanently unreadable', () => {
+        // Offline for hours: the floor still forces a real drive.
+        const p = plan(waiting, null, { sinceFull: FULL_DRIVE_FLOOR_MS });
+        expect(p.action).toBe('full');
+        expect(p.reason).toBe('reorg-floor');
+    });
+
+    it('does not fire a full drive more often than the fast cadence', () => {
+        expect(plan(snap({ claimableCount: 1 }), TIP, { sinceFull: EXIT_DRIVE_FAST_MS - 1 }).action)
+            .toBe('skip');
+    });
+
+    it('ignores malformed heights rather than pacing off them', () => {
+        const junk = snap({ awaitingHeights: [0, -1, NaN, 963_600] });
+        expect(plan(junk, TIP).blocksToNext).toBe(100);
+    });
+});
+
+describe('the request budget this exists to cut', () => {
+    it('spends one poll where the old design spent a full drive', () => {
+        // A 24h wait is ~144 blocks. Far out the poll is 10 minutes, so the
+        // waiting phase costs ~1 request per poll instead of ~20 per drive.
+        const p = plan(snap({ awaitingHeights: [963_500 + 144] }), TIP);
+        expect(p.action).toBe('tip');
+        expect(p.waitMs).toBe(TIP_POLL_FAR_MS);
+    });
+
+    it('tightens to two minutes at the end, so the claim is not 30 minutes late', () => {
+        // The shipped flat-30-minute version could not do this: with no live
+        // tip, blocks-remaining was a constant and never tapered.
+        const p = plan(snap({ awaitingHeights: [963_502] }), TIP);
+        expect(p.waitMs).toBe(TIP_POLL_NEAR_MS);
+        expect(p.blocksToNext).toBe(2);
     });
 });


### PR DESCRIPTION
Closes #219. Closes #204.

## The problem

The drive polled hard for an event whose block height it already knew. Once every leaf sits in `AwaitingDelta`, `claimableHeight` is fixed, and for the next ~24h there is exactly one question worth asking: **has the tip passed it.**

Answering it cost a full `syncArkWallet` + `progressExits` + `syncExits` + `listClaimableExits` + `allVtxos` + `balance`, roughly 20 requests, because **the full drive was the unit of polling**.

Now the question and the work are separate. Checking the tip is one request. The full drive runs only when the answer is yes.

## Budget, over a ~24h (144 block) wait

| | drives | requests |
|---|---|---|
| 120s flat (original) | ~720 full | ~14,400 |
| 30 min flat (shipped in #218) | ~48 full | ~960 |
| **this** | ~180 tip polls + 4 full | **~260** |

And it is **responsive at the end** rather than up to 30 minutes late, because the poll tightens to 2 minutes as ripening approaches.

## Why the taper only works now

#218 tried to pace the **full drive** by blocks remaining and could not work, because **no live tip existed during an exit**. `arkChainTipHeight` is frozen (#204) and `ExitState.inner.tipHeight` is stamped once on entry and never advances, so both yield a constant blocks-remaining. That is why #218 shipped as a flat interval.

Polling the tip ourselves is what makes the taper real. Writing that tip to the store is what **closes #204**: this is now the only place the store's tip advances mid-exit, which is what unfreezes the VTXO capsule expiry displays.

## Safety, in the order it is checked

**Broadcasting still gets a full drive every tick**, checked first and before any ripening logic, because each tree level must be relayed before the next can go. A straggler needs relaying even when other capsules have already ripened.

**Claimable still gets a full drive.** The claim is the point.

**A reorg floor** forces a full drive every 6 hours while waiting. bark's `AwaitingDelta` arm calls `check_confirmed` on every `progressExits` and drops a reorged exit back to `Processing`; a tip-only poll never calls it.

Six hours rather than one is deliberate. Hourly would cost ~480 requests over a 24h wait and dominate the budget this change exists to cut, while the exposure it buys back is bounded and mild: a missed reorg **delays** the exit until the next full drive, it does not lose funds, and the transaction buries deeper every hour.

**An unreadable tip falls back to the tightest poll, not the loosest**, and the floor still guarantees a real drive. Being offline cannot starve the exit.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **57 suites, 638 passed, 1 skipped**
- 19 tests on this module: each promotion back to a full drive (tip crossed, reorg floor, broadcasting, claimable, no snapshot), the taper at 100/15/3 blocks, pacing off the soonest of several heights, a permanently unreadable tip, and malformed heights

**Not device-verified, and cannot be.** Confirming this needs another multi-day exit. The drive log now names the phase, the reason and the blocks remaining on every tick, so the pacing is observable when one next runs.

Given that, worth deciding whether this ships in the next release or waits for a live exit to validate it. It is new machinery in the loop that has twice retired an exit early, which is the argument for waiting; the counter-argument is that the phase it changes is the one where nothing happens by definition, and every safety-relevant phase keeps the cadence it already had.


