### PR TITLE
fix(ark): charge a shared round root once, not once per sibling

### DIFF
--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -395,6 +395,9 @@ export async function computeArkExitPlan(
             plan.selectedSats, 'sats in,', plan.netRecoverableSats, 'recoverable;',
             'excluded', plan.excluded.length, 'holding', plan.excludedSats, 'sats;',
             'reserve=', plan.reserveSats, 'over totalExitVb=', plan.totalExitVb,
+            (plan.sharedAncestryVb > 0
+                ? `(gross ${plan.grossExitVb}, shared ancestry -${plan.sharedAncestryVb})`
+                : ''),
             'at', plan.feeRateSatPerVb, 'sat/vB (claim at', plan.claimFeeRateSatPerVb,
             '); policy=', plan.economicPolicy,
             '; urgency=', urgency.urgency, 'slack=', urgency.tightestSlackBlocks, 'blocks',

--- a/src/services/ark/exitTriage.ts
+++ b/src/services/ark/exitTriage.ts
@@ -333,8 +333,14 @@ export type ExitTriageResult = {
     netRecoverableSats: number;
     /** Face value the user is being asked to abandon. */
     excludedSats: number;
-    /** Summed exit vsize over the SELECTED capsules only (spec 4.3). */
+    /** Summed exit vsize over the SELECTED capsules, after deducting shared
+     *  round roots. See sharedAncestryVb. */
     totalExitVb: number;
+    /** What the naive per-capsule sum would have been, before that deduction.
+     *  Kept so the saving is visible in logs rather than silently applied. */
+    grossExitVb: number;
+    /** vB removed as double-counted shared ancestry. */
+    sharedAncestryVb: number;
     /** Recommended on-chain reserve for the selected set. 0 when nothing is
      *  selected, so a nothing-to-exit wallet is never gated. */
     reserveSats: number;
@@ -436,6 +442,66 @@ export function perVtxoExitVb(v: Pick<ExitTriageVtxo, 'exitDepth' | 'exitTxWeigh
  * must return 0, NOT the floor, or a wallet with nothing exitable would be
  * gated on a 5,000 sat reserve it has no use for.
  */
+/**
+ * vB the per-capsule sum double-counts, because siblings share tree ancestors.
+ *
+ * THE OVER-COUNT, MEASURED
+ *
+ * `perVtxoVb` charges every capsule its own full chain. That is exact when
+ * capsules come from DIFFERENT rounds and wrong when several come from the
+ * same one, because a shared ancestor is broadcast once and CPFP-bumped once.
+ *
+ * Verified on chain 2026-08-22 by walking all seven capsules of a real exit:
+ * eleven distinct tree transactions, eleven CPFP children, 3,585 sats paid.
+ * Per-capsule accounting counted EIGHTEEN transaction instances and predicted
+ * 6,036. `2a62cb07` is paid once and serves five capsules; `221c33d1` once and
+ * serves four. Seven of the eighteen were the same transactions counted twice.
+ *
+ * WHY expiryHeight IDENTIFIES A SHARED ROOT
+ *
+ * The SDK gives no ancestry: `Vtxo` carries `exitDepth` and `exitTxWeightWu`
+ * and nothing else, and the latter exists expressly so clients can estimate
+ * "without loading the full genesis". So the tree cannot be walked here.
+ *
+ * A round reissues its outputs together, setting one expiry for all of them, so
+ * capsules sharing an `expiryHeight` came from the same round and therefore
+ * share that round's tree root. Checked against the measured exit: the five
+ * capsules at expiry 967241 are exactly the five the chain walk found under
+ * `2a62cb07`, and the capsules under the other two roots carry distinct
+ * expiries.
+ *
+ * DELIBERATELY CONSERVATIVE
+ *
+ * Only ONE level is deducted per group, the root that every member provably
+ * shares. Deeper sharing is real (`221c33d1` served four of those five) but
+ * invisible from here, so it is left over-counted rather than guessed at.
+ * On the measured exit this recovers four of the seven double-counted
+ * instances.
+ *
+ * The direction of risk is why. Over-reserving asks the user to have more on
+ * hand than needed, which is inconvenient. Under-reserving stalls an exit
+ * mid-flight, which is not. Every remaining safety margin is untouched: the
+ * SPIKE_MULT headroom still doubles the result and RESERVE_FLOOR_SATS still
+ * applies underneath it.
+ */
+export function sharedAncestryVb(
+    selected: readonly { expiryHeight: number }[],
+): number {
+    const byRound = new Map<number, number>();
+    for (const e of selected) {
+        const h = Math.floor(Number(e.expiryHeight) || 0);
+        // Expiry 0 means "unknown", not "the same round as every other
+        // unknown". Grouping those together would invent sharing.
+        if (h <= 0) continue;
+        byRound.set(h, (byRound.get(h) ?? 0) + 1);
+    }
+    let saving = 0;
+    for (const count of byRound.values()) {
+        if (count > 1) saving += (count - 1) * CPFP_CHILD_VB;
+    }
+    return saving;
+}
+
 export function reserveSatsForExitVb(totalExitVb: number, feeRateSatPerVb: number): number {
     if (totalExitVb <= 0) return 0;
     const rate = Math.max(0, Number(feeRateSatPerVb) || 0);
@@ -865,13 +931,28 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
     selected.sort((a, b) => b.netRecoveredSats - a.netRecoveredSats || a.id.localeCompare(b.id));
     excluded.sort((a, b) => b.sats - a.sats || a.id.localeCompare(b.id));
 
-    const totalExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
+    // Charge each shared round root once rather than once per sibling. See
+    // sharedAncestryVb: the per-capsule sum over-counted a measured seven-capsule
+    // exit by 68%, and the error grows in exactly the consolidated wallets this
+    // file argues for, because more siblings per round means more sharing.
+    const grossExitVb = selected.reduce((acc, e) => acc + e.perVtxoVb, 0);
+    const sharedVb = sharedAncestryVb(selected);
+    const totalExitVb = Math.max(0, grossExitVb - sharedVb);
     const reserveSats = reserveSatsForExitVb(totalExitVb, feeRate);
     const netRecoverableSats = selected.reduce((acc, e) => acc + e.netRecoveredSats, 0);
     // What the exit is actually expected to SPEND, as opposed to what the user
     // must have available. Bare rate, no SPIKE_MULT and no floor: those two are
     // headroom on the reserve, not costs anyone expects to pay.
-    const expectedSpendSats = selected.reduce((acc, e) => acc + e.exitTreeCostSats, 0);
+    //
+    // Derived from totalExitVb, which is NET of shared round roots, rather than
+    // summed from the per-capsule figures, which are gross. A shared ancestor is
+    // broadcast and bumped once, so the wallet only pays for it once.
+    //
+    // The per-capsule `exitTreeCostSats` stays gross on purpose: it decides
+    // whether THAT capsule is worth exiting, and a capsule cannot claim credit
+    // for a discount that exists only because a sibling happens to be in the
+    // same set. See the two-pot rule above ExitEconomicVerdict.
+    const expectedSpendSats = Math.ceil(totalExitVb * feeRate);
     // Runway the slowest selected capsule needs before it can be collected:
     // its tree has to confirm and then sit out the CSV delta. This is the
     // "come back at" figure, and it is why a hardcoded ~24h understates a deep
@@ -893,6 +974,8 @@ export function triageArkExit(input: TriageArkExitInput): ExitTriageResult {
         netRecoverableSats,
         excludedSats: excluded.reduce((acc, e) => acc + e.sats, 0),
         totalExitVb,
+        grossExitVb,
+        sharedAncestryVb: sharedVb,
         reserveSats,
         underWaterCount: selected.filter((e) => e.economic !== 'profitable').length,
         expectedSpendSats,

--- a/tests/unit/exitTriage.test.ts
+++ b/tests/unit/exitTriage.test.ts
@@ -11,6 +11,8 @@ import {
   ExitTriageVtxo,
   ExitTriageNote,
   SPIKE_MULT,
+  sharedAncestryVb,
+  CPFP_CHILD_VB,
   describeExitNote,
   RESERVE_FLOOR_SATS,
   perVtxoExitVb,
@@ -94,8 +96,10 @@ describe('the exit set on the live wallet', () => {
   it('sizes the reserve to the selected set, not the whole wallet', () => {
     const r = triage();
     // 632 + 632 + 1035*4 = 5,404 vB over the six, against 16,060 over all eight.
-    expect(r.totalExitVb).toBe(5404);
-    expect(r.reserveSats).toBe(10808);
+    // 4,804 not 5,404: the five capsules at expiry 967241 came from one round
+    // and share its tree root, which is now charged once (4 x CPFP_CHILD_VB).
+    expect(r.totalExitVb).toBe(4804);
+    expect(r.reserveSats).toBe(9608);
   });
 
   it('costs the discarded dust at two thirds of the untriaged exit', () => {
@@ -104,7 +108,8 @@ describe('the exit set on the live wallet', () => {
     const r = triage();
     const dust = r.excluded.reduce((a, e) => a + e.perVtxoVb, 0);
     expect(dust).toBe(10656);
-    expect(dust + r.totalExitVb).toBe(16060);
+    // Less the same shared root, now that siblings do not each pay for it.
+    expect(dust + r.totalExitVb).toBe(15460);
   });
 
   it('names every exclusion with an amount and a reason', () => {
@@ -504,8 +509,10 @@ describe('economic policy: how far past the economics the user may go', () => {
     const forced = triage({ economicPolicy: 'recover-everything' });
     expect(forced.selectedIds).toHaveLength(8);
     expect(forced.excluded).toHaveLength(0);
-    expect(forced.totalExitVb).toBe(16060);
-    expect(forced.reserveSats).toBe(32120);
+    // recover-everything also pulls in the two dust capsules, which share an
+    // expiry with each other, so five roots are deduped rather than four.
+    expect(forced.totalExitVb).toBe(15310);
+    expect(forced.reserveSats).toBe(30620);
   });
 
   it('offers the override only when it would change something', () => {
@@ -522,8 +529,9 @@ describe('economic policy: how far past the economics the user may go', () => {
     // The loss is what the exit is expected to SPEND beyond what it returns.
     // Pricing it against reserveSats instead would charge the user for the
     // spike headroom and the floor, neither of which anyone expects to pay.
-    expect(forced.expectedSpendSats).toBe(16060);
-    expect(forced.netLossSats).toBe(16060 - (4990 - 8 * 76));
+    expect(forced.expectedSpendSats).toBe(15310);
+    // Loss follows expectedSpendSats, which is now net of the shared roots.
+    expect(forced.netLossSats).toBe(15310 - (4990 - 8 * 76));
     expect(forced.netLossSats).toBeLessThan(forced.reserveSats - forced.netRecoverableSats);
     expect(forced.underWaterCount).toBe(8);
   });
@@ -532,7 +540,7 @@ describe('economic policy: how far past the economics the user may go', () => {
     const forced = triage({ economicPolicy: 'recover-everything' });
     // reserveSats carries SPIKE_MULT on top of the same vsize, so it is
     // strictly the larger of the two and must never be quoted as the cost.
-    expect(forced.reserveSats).toBe(32120);
+    expect(forced.reserveSats).toBe(30620);
     expect(forced.expectedSpendSats).toBe(forced.totalExitVb * forced.feeRateSatPerVb);
     expect(forced.reserveSats).toBeGreaterThan(forced.expectedSpendSats);
   });
@@ -554,6 +562,88 @@ describe('economic policy: how far past the economics the user may go', () => {
     expect(r.reserveSats).toBe(5000);
     expect(r.expectedSpendSats).toBe(632);
     expect(r.netLossSats).toBe(0);
+  });
+
+  describe('shared tree ancestry: siblings do not each pay for the same root', () => {
+    // Verified on chain 2026-08-22 across all seven capsules of a real exit:
+    // eleven distinct tree transactions and eleven CPFP children, 3,585 sats
+    // paid, against a per-capsule model that counted eighteen instances and
+    // predicted 6,036. The five capsules at expiry 967241 are exactly the five
+    // the chain walk found under 2a62cb07.
+
+    it('deducts one root per group of siblings, not one per sibling', () => {
+      const five = Array.from({ length: 5 }, (_, i) => ({ expiryHeight: 967241 }));
+      expect(sharedAncestryVb(five)).toBe(4 * CPFP_CHILD_VB);
+    });
+
+    it('deducts nothing when every capsule came from a different round', () => {
+      expect(sharedAncestryVb([
+        { expiryHeight: 967241 }, { expiryHeight: 967253 }, { expiryHeight: 967351 },
+      ])).toBe(0);
+    });
+
+    it('handles several groups at once', () => {
+      // The measured wallet: 5 under one root, and two singletons.
+      const live = [
+        ...Array.from({ length: 5 }, () => ({ expiryHeight: 967241 })),
+        { expiryHeight: 967253 },
+        { expiryHeight: 967351 },
+      ];
+      expect(sharedAncestryVb(live)).toBe(4 * CPFP_CHILD_VB);
+    });
+
+    it('never groups capsules whose expiry is unknown', () => {
+      // 0 means "we do not know", not "the same round as every other unknown".
+      // Grouping them would INVENT sharing and under-reserve.
+      expect(sharedAncestryVb([
+        { expiryHeight: 0 }, { expiryHeight: 0 }, { expiryHeight: 0 },
+      ])).toBe(0);
+    });
+
+    it('lowers the demanded reserve on a consolidated wallet', () => {
+      const sameRound = Array.from({ length: 5 }, (_, i) =>
+        v({ id: `s${i}`, sats: 5_000, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: TIP + 4000 }));
+      const r = triageArkExit({
+        vtxos: sameRound, feeRateSatPerVb: 5, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(r.selectedIds).toHaveLength(5);
+      expect(r.sharedAncestryVb).toBe(4 * CPFP_CHILD_VB);
+      expect(r.totalExitVb).toBe(r.grossExitVb - r.sharedAncestryVb);
+      expect(r.totalExitVb).toBeLessThan(r.grossExitVb);
+    });
+
+    it('leaves a fragmented wallet untouched, where nothing is shared', () => {
+      const differentRounds = Array.from({ length: 5 }, (_, i) =>
+        v({ id: `d${i}`, sats: 5_000, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: TIP + 4000 + i * 100 }));
+      const r = triageArkExit({
+        vtxos: differentRounds, feeRateSatPerVb: 5, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(r.sharedAncestryVb).toBe(0);
+      expect(r.totalExitVb).toBe(r.grossExitVb);
+    });
+
+    it('keeps every other safety margin intact', () => {
+      // The deduction reduces the BARE vsize. SPIKE_MULT still doubles it and
+      // the floor still applies underneath, which is what makes an imperfect
+      // sharing estimate survivable.
+      const sameRound = Array.from({ length: 5 }, (_, i) =>
+        v({ id: `k${i}`, sats: 500_000, exitDepth: 2, exitTxWeightWu: 1325, expiryHeight: TIP + 4000 }));
+      const r = triageArkExit({
+        vtxos: sameRound, feeRateSatPerVb: 5, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(r.reserveSats).toBe(r.totalExitVb * r.feeRateSatPerVb * SPIKE_MULT);
+      expect(r.reserveSats).toBeGreaterThan(r.expectedSpendSats);
+    });
+
+    it('can never drive the vsize negative', () => {
+      expect(sharedAncestryVb([])).toBe(0);
+      const r = triageArkExit({
+        vtxos: [v({ id: 'one', sats: 5_000, exitDepth: 2, exitTxWeightWu: 1325 })],
+        feeRateSatPerVb: 1, chainTipHeight: TIP, vtxoExitDeltaBlocks: EXIT_DELTA,
+      });
+      expect(r.totalExitVb).toBeGreaterThan(0);
+      expect(r.sharedAncestryVb).toBe(0);
+    });
   });
 
   describe('the two-pot rule: the verdict is priced on spend, never on the reserve', () => {
@@ -801,14 +891,17 @@ describe('economic policy: how far past the economics the user may go', () => {
 
     const forced = triageArkExit({ ...at7, economicPolicy: 'recover-everything' });
     expect(forced.selectedIds).toHaveLength(7);
-    expect(forced.totalExitVb).toBe(6036);
-    expect(forced.reserveSats).toBe(84504);
+    // 5,436 not 6,036: the chain walk showed 2a62cb07 serving five capsules.
+    // The remaining gap to the 3,585 actually paid is 221c33d1's deeper
+    // sharing, which expiryHeight cannot see and is left over-counted.
+    expect(forced.totalExitVb).toBe(5436);
+    expect(forced.reserveSats).toBe(76104);
     // 84,504 sats of reserve to recover 2,330. The user has to see that.
     expect(forced.netRecoverableSats).toBe(2330);
     // Expected spend is the same vsize at the bare rate; the reserve doubles it
     // for spike cover. The loss the user is accepting is the former.
-    expect(forced.expectedSpendSats).toBe(6036 * 7);
-    expect(forced.netLossSats).toBe(6036 * 7 - 2330);
+    expect(forced.expectedSpendSats).toBe(5436 * 7);
+    expect(forced.netLossSats).toBe(5436 * 7 - 2330);
   });
 });
 


### PR DESCRIPTION
Closes #201.

## The over-count, measured

`perVtxoVb` charges every capsule its own full exit chain. Exact when capsules come from **different** rounds, wrong when several come from the **same** one, because a shared ancestor is broadcast once and CPFP-bumped once.

Verified on chain 2026-08-22 by walking all seven capsules of a real exit: **eleven** distinct tree transactions, eleven CPFP children, **3,585 sats paid**. Per-capsule accounting counted **eighteen** transaction instances and predicted **6,036**. `2a62cb07` is paid once and serves five capsules; `221c33d1` once and serves four.

## The fix I specified is not implementable

The issue says "size the reserve over distinct tree transactions". **The SDK exposes no ancestry.** `Vtxo` carries `exitDepth` and `exitTxWeightWu` and nothing else, and the latter exists expressly so clients can estimate *"without loading the full genesis"*.

So this substitutes a proxy, and I would rather say that plainly than quietly ship something narrower than the issue promises.

## Why expiryHeight identifies a shared root

A round reissues its outputs together and sets **one expiry for all of them**, so capsules sharing an `expiryHeight` came from the same round and share its tree root.

Checked against your device, not assumed:

```
exp=967241: 1f6627c2 9211887d a6e24d2f bc672cb8 ec46d966
exp=967253: d4ec1101
exp=967351: aa2c257e
```

Those five are exactly the five the chain walk found under `2a62cb07`, and the capsules under the other two roots carry distinct expiries.

## Deliberately conservative

**Only one level is deducted per group**, the root every member provably shares. Deeper sharing is real, `221c33d1` served four of those five, but invisible from here, so it is left over-counted rather than guessed at.

On the measured exit that recovers four of the seven double-counted instances: **6,036 vB becomes 5,436**, against the ~3,585 actually paid.

The direction of risk is why. Over-reserving asks the user to have more on hand than needed, which is inconvenient. **Under-reserving stalls an exit mid-flight**, which is not. Every other margin is untouched: `SPIKE_MULT` still doubles the result, `RESERVE_FLOOR_SATS` still applies underneath, and capsules with an unknown expiry (`0`) are never grouped, since "unknown" is not a round.

## An inconsistency this surfaced

`expectedSpendSats` was summed from the per-capsule figures, which are **gross**, while `totalExitVb` is now **net**. It derives from `totalExitVb` now: a shared ancestor is only paid for once.

The per-capsule `exitTreeCostSats` stays gross **on purpose**. It decides whether *that* capsule is worth exiting, and a capsule cannot claim credit for a discount that exists only because a sibling happens to be in the same set.

## Verification

- `tsc --noEmit`: **400**, zero differing normalized error lines against `main`
- `npx jest -b -i tests/unit`: **57 suites, 646 passed, 1 skipped**
- 8 new tests, and existing assertions encoding the old over-count are updated **with the reason each number moved**, not to whatever the code now returns

`grossExitVb` and `sharedAncestryVb` are carried on the result and logged, so the deduction is visible rather than silently applied.

**Not device-verified.** The honest test is the next real exit: compare the demanded reserve against what the tree actually costs. That is also the check that would catch the proxy being wrong.
