### PR TITLE
feat(ark): tell the user once, at the batched claim height, when an exit is ready

### DIFF
--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -5,6 +5,7 @@ import {
     applyExpiredVtxoFilter,
     ARK_ARKOOR_ASSUMED_DAYS,
     AVG_BLOCK_MINUTES,
+    cancelArkExitReadyNotice,
     cancelArkPendingRound,
     cancelVtxoExpiryWarnings,
     cancelVtxoStuckSwapWarnings,
@@ -23,6 +24,8 @@ import {
     fetchArkExitVtxos,
     decideExitClaimBatch,
     decideExitDrivePlan,
+    decideExitReadyNotice,
+    scheduleArkExitReadyNotice,
     type ExitDriveSnapshot,
     isVtxoMidRound,
     fetchClaimableExitVtxos,
@@ -296,6 +299,13 @@ export default function useArkSync(): UseArkSync {
     // poll is what replaced using the full drive as the unit of polling.
     const exitTipPollLastMsRef = useRef(0);
     const exitTipHeightRef = useRef<number | null>(null);
+    // The single "exit is ready to finish" alarm currently armed with the OS,
+    // and the value it should quote. Held in a ref rather than persisted: the
+    // alarm itself survives a kill (it is an OS-level entry under a fixed id),
+    // and the first drive after a cold launch re-derives and re-arms it, which
+    // replaces rather than duplicates. See services/ark/exitReadyNotice.ts.
+    const exitReadyArmedRef = useRef<{ targetHeight: number; fireAtMs: number } | null>(null);
+    const exitReadySatsRef = useRef<number | null>(null);
     // Counter used by the idle-skip heuristic. Increments every cycle that
     // returns balance=0 and vtxos.all.length=0; resets the moment either
     // turns non-zero. We use this to avoid the 2s Bark `syncArkWallet`
@@ -345,6 +355,78 @@ export default function useArkSync(): UseArkSync {
         const _t0 = Date.now();
         const _stamp = (label: string) => __DEV__ && console.log(`[ArkSync] ${label} +${Date.now() - _t0}ms`);
         _stamp('cycle start');
+
+        /**
+         * Keep the single "exit is ready to finish" alarm in step with what the
+         * exit is actually doing.
+         *
+         * Called from BOTH the cheap tip poll and the full drive. That matters:
+         * while waiting, a full drive runs at most every six hours, so an
+         * estimate refined only there would spend most of the wait stale. The
+         * tip poll runs every 2 to 10 minutes and already has the fresh tip.
+         *
+         * The decision itself is pure and lives in services/ark/exitReadyNotice.
+         */
+        const applyExitReadyNotice = (tip: number | null) => {
+            const snap = exitDriveSnapshotRef.current;
+            // No drive has observed a phase yet, so there is nothing to reason
+            // from. The first full drive of the session fills this in.
+            if (!snap) return;
+            const decision = decideExitReadyNotice({
+                claimableCount: snap.claimableCount,
+                awaitingHeights: snap.awaitingHeights,
+                processingCount: snap.processingCount,
+                tipHeight: tip,
+                now: Date.now(),
+                armed: exitReadyArmedRef.current,
+                blockMs: AVG_BLOCK_MINUTES * 60 * 1000,
+            });
+            try {
+                if (decision.action === 'arm' && decision.fireAtMs != null && decision.targetHeight != null) {
+                    scheduleArkExitReadyNotice(
+                        decision.fireAtMs,
+                        exitReadySatsRef.current ?? undefined,
+                    );
+                    exitReadyArmedRef.current = {
+                        targetHeight: decision.targetHeight,
+                        fireAtMs: decision.fireAtMs,
+                    };
+                    _stamp(
+                        `exit ready notice armed (${decision.reason}) for height ` +
+                        `${decision.targetHeight}${decision.provisional ? ' provisional' : ''}, ` +
+                        `about ${Math.round((decision.fireAtMs - Date.now()) / 60000)} min out`,
+                    );
+                } else if (decision.action === 'cancel') {
+                    // Unconditional, not gated on the ref: an alarm queued by a
+                    // previous session survives a kill, and this session starts
+                    // with no memory of it.
+                    if (exitReadyArmedRef.current) {
+                        _stamp(`exit ready notice cancelled (${decision.reason})`);
+                    }
+                    cancelArkExitReadyNotice();
+                    exitReadyArmedRef.current = null;
+                }
+            } catch (noticeErr: any) {
+                console.warn(
+                    '[Ark exit] exit-ready notice scheduling failed:',
+                    noticeErr?.message ?? noticeErr,
+                );
+            }
+        };
+
+        /**
+         * Drop the alarm unconditionally, for the moments where waiting for the
+         * next drive to work it out would be too late: the sweep has just
+         * broadcast, or the exit has just retired. An alarm that fires after
+         * the funds are on chain is worse than no alarm at all.
+         */
+        const retireExitReadyNotice = () => {
+            try {
+                cancelArkExitReadyNotice();
+            } catch { /* cancellation is best-effort, never fatal */ }
+            exitReadyArmedRef.current = null;
+            exitReadySatsRef.current = null;
+        };
         try {
             // ----- Emergency-exit path -----
             //
@@ -449,6 +531,10 @@ export default function useArkSync(): UseArkSync {
                             `exit tip poll: ${tip ?? 'unreadable'}` +
                             (plan.blocksToNext != null ? ` (${plan.blocksToNext} blocks to next)` : ''),
                         );
+                        // Fresh tip, so this is the cheapest and most frequent
+                        // chance to correct the "come back at" estimate. One
+                        // request already paid for.
+                        applyExitReadyNotice(tip ?? exitTipHeightRef.current);
                     } catch (tipErr: any) {
                         console.warn('[Ark exit] tip poll failed:', tipErr?.message ?? tipErr);
                     }
@@ -564,6 +650,23 @@ export default function useArkSync(): UseArkSync {
                         processingCount: unknownScheduleCount,
                     };
 
+                    // What the alarm should quote. Live, not the at-start
+                    // figure: an exit lands in pieces, so once part of it has
+                    // been claimed the at-start total names money that is
+                    // already in the user's on-chain wallet.
+                    const inFlightExitSats = exitVtxosForBatch
+                        .filter((v) => isActiveExit(v))
+                        .reduce((acc, v) => acc + Number(v.amountSats ?? 0), 0);
+                    exitReadySatsRef.current = inFlightExitSats > 0 ? inFlightExitSats : null;
+                    // Re-derive the alarm from what this drive just observed.
+                    // Runs BEFORE the claim below so a target pushed out by a
+                    // late leaf is armed even on a tick that also sweeps.
+                    applyExitReadyNotice(
+                        exitTipHeightRef.current ??
+                        useAuthStore.getState().arkChainTipHeight ??
+                        null,
+                    );
+
                     const batchDecision = decideExitClaimBatch({
                         claimableCount: claimable.length,
                         stillProgressingCount: stillProgressing,
@@ -622,6 +725,13 @@ export default function useArkSync(): UseArkSync {
                                 // opens a fresh window rather than inheriting
                                 // this one's elapsed time.
                                 useAuthStore.getState().setArkExitClaimBatchSince(null);
+                                // The sweep the alarm existed to prompt has
+                                // happened, with the app open. Drop it here and
+                                // not only on the next drive, so it cannot fire
+                                // about funds that are already on chain. If a
+                                // straggler is still ripening the next drive
+                                // arms a fresh one for the new target.
+                                retireExitReadyNotice();
                             } else {
                                 _stamp('exit claim returned no txid, NOT marking drained');
                             }
@@ -753,6 +863,7 @@ export default function useArkSync(): UseArkSync {
                             );
                         } else {
                             console.warn('[Ark exit] no exit ever materialised (nothing active, never drained, grace expired) — clearing exit-in-progress WITHOUT deleting the vault');
+                            retireExitReadyNotice();
                             setArkExitInProgress(false);
                             setArkExitDestinationAddress(null);
                             setArkExitStartedAt(null);
@@ -769,6 +880,7 @@ export default function useArkSync(): UseArkSync {
                         // "Delete Ark vault" flow exists for when the user
                         // actually wants the vault removed.
                         console.log('[Ark exit] complete — funds swept; vault kept');
+                        retireExitReadyNotice();
                         const correlationId = await getArkExitCorrelationId();
                         if (correlationId) {
                             recordEvent({

--- a/src/services/ark/backgroundNotifications.ts
+++ b/src/services/ark/backgroundNotifications.ts
@@ -215,15 +215,28 @@ export function isArkExpiryWarningSource(s: unknown): s is ArkExpiryWarningSourc
 }
 
 /**
+ * The single "your exit is ready to finish" alarm. One per wallet, not one per
+ * capsule: the claim is batched, so it fires at the height the batch is
+ * waiting for. See services/ark/exitReadyNotice.ts for the schedule rule.
+ */
+export const ARK_EXIT_READY_SOURCE = 'ark-exit-ready';
+
+export function isArkExitReadySource(s: unknown): boolean {
+    return s === ARK_EXIT_READY_SOURCE;
+}
+
+/**
  * Every notification source whose tap should deep-link into the Capsules
  * tab: the expiry warnings (refresh is the action), payment-received
- * (see what landed), and refresh-complete (see the fresh capsules; the
- * visit also reconciles any stale locked/pulsing UI state). The tap
- * handler in notificationHandler.ts matches against this.
+ * (see what landed), refresh-complete (see the fresh capsules; the
+ * visit also reconciles any stale locked/pulsing UI state), and exit-ready
+ * (opening the app IS the action, since the claim only runs in foreground).
+ * The tap handler in notificationHandler.ts matches against this.
  */
 export function isArkCapsuleTapSource(s: unknown): boolean {
     return (
         isArkExpiryWarningSource(s) ||
+        isArkExitReadySource(s) ||
         s === 'ark-received' ||
         s === 'ark-refresh-complete'
     );
@@ -385,14 +398,17 @@ const STUCK_SWAP_SCHEDULE: ReadonlyArray<{
  * {@link cancelVtxoExpiryWarnings} so users don't get phantom alerts about
  * funds that already moved.
  */
-function notificationIdFor(vtxoId: string, kind: WarnKind | StuckSwapKind): string {
+function fnv1aNotificationId(tagged: string): string {
     let h = 2166136261;
-    const tagged = `${kind}:${vtxoId}`;
     for (let i = 0; i < tagged.length; i++) {
         h ^= tagged.charCodeAt(i);
         h = Math.imul(h, 16777619);
     }
     return String(h & 0x7fffffff);
+}
+
+function notificationIdFor(vtxoId: string, kind: WarnKind | StuckSwapKind): string {
+    return fnv1aNotificationId(`${kind}:${vtxoId}`);
 }
 
 // Migration: prior to the 2h -> 6h rollout the second warning was tagged
@@ -516,6 +532,57 @@ export function cancelVtxoStuckSwapWarnings(vtxoId: string): void {
         }
     } catch (err) {
         console.warn('[Ark notifications] cancelVtxoStuckSwapWarnings:', err);
+    }
+}
+
+/**
+ * Fixed id for the exit-ready alarm. There is one exit per wallet and one
+ * alarm per exit, so re-arming replaces the entry rather than stacking a
+ * second one, and cancelling needs nothing but this constant.
+ */
+const EXIT_READY_NOTIFICATION_ID = fnv1aNotificationId('ark-exit-ready:wallet');
+
+/**
+ * Arm the single "your exit is ready to finish" alarm for `fireAtMs`.
+ *
+ * Idempotent: the OS replaces an entry with the same id, so the caller can
+ * re-arm freely as the estimate is refined. Cancellation on claim or on the
+ * exit retiring is the caller's job via {@link cancelArkExitReadyNotice},
+ * so an alarm can never announce funds that already landed.
+ *
+ * Gated on the same reminders toggle as every other Ark alarm. That is where
+ * OS notification permission is requested, so scheduling around it would
+ * queue alarms the OS has never agreed to deliver.
+ */
+export function scheduleArkExitReadyNotice(fireAtMs: number, satsAmount?: number): void {
+    if (!useAuthStore.getState().arkBgRefreshEnabled) return;
+    if (!Number.isFinite(fireAtMs) || fireAtMs <= Date.now()) return;
+    ensureInit();
+    const satsKnown = satsAmount != null && Number.isFinite(satsAmount) && satsAmount > 0;
+    PushNotification.localNotificationSchedule({
+        id: EXIT_READY_NOTIFICATION_ID,
+        channelId: CHANNEL_ID,
+        title: 'Your exit is ready to finish',
+        message: satsKnown
+            ? `Open Cypher Box to collect ${Math.round(satsAmount as number).toLocaleString()} sats to your Bitcoin wallet.`
+            : 'Open Cypher Box to collect your funds to your Bitcoin wallet.',
+        date: new Date(fireAtMs),
+        priority: 'high',
+        importance: 'high',
+        playSound: true,
+        soundName: 'default',
+        userInfo: { source: ARK_EXIT_READY_SOURCE },
+        allowWhileIdle: true,
+    });
+}
+
+export function cancelArkExitReadyNotice(): void {
+    try {
+        PushNotification.cancelLocalNotification(EXIT_READY_NOTIFICATION_ID);
+    } catch (err) {
+        // Cancellation should never throw, but the library has been observed
+        // to no-throw-but-warn on stale ids. Swallow.
+        console.warn('[Ark notifications] cancelArkExitReadyNotice:', err);
     }
 }
 

--- a/src/services/ark/exitReadyNotice.ts
+++ b/src/services/ark/exitReadyNotice.ts
@@ -1,0 +1,226 @@
+/**
+ * When should the app tell the user their exit is ready to finish?
+ *
+ * THE PROBLEM
+ *
+ * An exit needs the user to open the app once, at a moment nobody can guess.
+ * On 2026-08-19 a claim landed within one block of ripening purely because
+ * someone happened to be awake and holding the phone. The drive is
+ * foreground-only, so a user who closes the app has no way of knowing when to
+ * come back, and the panel's own copy used to promise the funds swept
+ * themselves.
+ *
+ * ONE NOTIFICATION, AT THE HEIGHT THE BATCH IS ALREADY WAITING FOR
+ *
+ * The tempting design is one alarm per capsule, as each becomes claimable.
+ * That is wrong. `decideExitClaimBatch` deliberately holds the sweep until
+ * every capsule has ripened, so the whole exit lands as one UTXO paying one
+ * transaction overhead instead of N. A per-capsule alarm therefore fires, the
+ * user opens the app, the batch correctly holds, and nothing visible happens.
+ * Then it happens again.
+ *
+ * Measured on the 2026-08-22 mainnet exit, 7 capsules holding 4,990 sats:
+ *
+ *   aa2c257e  800  leaf @963390  claimable @963534
+ *   d4ec1101  700  leaf @963390  claimable @963534
+ *   1f6627c2  698  leaf @963390  claimable @963534
+ *   9211887d  698  leaf @963455  claimable @963599
+ *   a6e24d2f  698  leaf @963455  claimable @963599
+ *   bc672cb8  698  leaf @963455  claimable @963599
+ *   ec46d966  698  leaf @963508  claimable @963652
+ *
+ * The batch fires at 963652. A per-capsule schedule would have fired at
+ * 963534, then 963599, then 963652: two of the three are pure noise. So the
+ * trigger is `max(claimableHeight)` across everything still ripening, which is
+ * the same number `decideExitClaimBatch` reports as `blocksUntilAllReady`.
+ *
+ * THE TARGET IS PROVISIONAL WHILE ANYTHING IS STILL BROADCASTING
+ *
+ * A capsule that has not confirmed its leaf has no `claimableHeight` yet, and
+ * its eventual height can land AFTER the current maximum. In that run
+ * `ec46d966` confirmed last and pushed the batch height from 963599 out to
+ * 963652. So the target has to be re-evaluated as leaves confirm, not computed
+ * once. Every height in the table is leaf-confirm plus exactly 144, which is
+ * three independent confirmations of `vtxoExitDelta = 144`, so once the last
+ * leaf confirms the answer is known a full 24 hours ahead.
+ *
+ * BLOCKS ARE THE TRUTH, THE DATE IS AN ESTIMATE
+ *
+ * The OS schedules alarms against a clock, and the trigger is a block height,
+ * so the height has to be converted. Block intervals are exponentially
+ * distributed, so the wait for N blocks has a standard deviation of sqrt(N)
+ * intervals: at 144 blocks out that is about two hours either side.
+ *
+ * The two failure directions are not symmetric. Late costs a little delay on
+ * funds that have no deadline and nobody racing them, since past its CSV a
+ * claimable exit output is an ordinary UTXO only this wallet can spend. Early
+ * spends the single interruption this feature is allowed, on nothing. So the
+ * estimate is deliberately biased one standard deviation late. See
+ * `blocksToFireIn`.
+ *
+ * It also self-corrects. Every tip poll re-derives the date from the live tip,
+ * and re-arming replaces the alarm rather than adding one, so an estimate that
+ * drifts while the app was closed is fixed the moment it opens again. An alarm
+ * that does fire early prompts exactly the action that repairs it.
+ *
+ * Pure and import-free, matching exitClaimBatch.ts and exitDriveCadence.ts, so
+ * the rule can be tested without standing up the sync loop or the OS layer.
+ */
+
+export type ExitReadyNoticeInput = {
+    /** Capsules ready to sweep right now. */
+    claimableCount: number;
+    /**
+     * `claimableHeight` of each capsule waiting out its CSV, from
+     * `ExitState.AwaitingDelta.inner.claimableHeight`.
+     */
+    awaitingHeights: readonly number[];
+    /** Capsules still broadcasting, so no ripening height yet. */
+    processingCount: number;
+    /** Freshest tip known. null when every provider failed. */
+    tipHeight: number | null;
+    /** Current epoch ms. */
+    now: number;
+    /** What is currently armed with the OS, null when nothing is. */
+    armed: { targetHeight: number; fireAtMs: number } | null;
+    /** ms per block used to turn a height into a date. */
+    blockMs: number;
+};
+
+export type ExitReadyNoticeDecision = {
+    /** Arm (or replace) the alarm, drop it, or leave it exactly as it is. */
+    action: 'arm' | 'cancel' | 'keep';
+    /** Height the batch is waiting for, null when none is known. */
+    targetHeight: number | null;
+    /** Epoch ms to fire at. Only set for 'arm'. */
+    fireAtMs: number | null;
+    /**
+     * True while a straggler is still broadcasting, so `targetHeight` can
+     * still move out. Recorded for the drive log: it is the difference
+     * between an estimate that will be refined and one that is final.
+     */
+    provisional: boolean;
+    /** Why, for the drive log. */
+    reason:
+        | 'no-exit'
+        | 'claim-imminent'
+        | 'no-schedule'
+        | 'tip-unknown'
+        | 'already-ripe'
+        | 'first-arm'
+        | 'target-moved'
+        | 'estimate-moved'
+        | 'unchanged';
+};
+
+/**
+ * How far the date has to move before the alarm is replaced.
+ *
+ * The estimate is re-derived on every tip poll, which is as often as every two
+ * minutes near the end. Re-arming on each of those would churn the OS alarm
+ * for nothing: when blocks arrive on schedule the ABSOLUTE date barely moves,
+ * because one fewer block remaining and ten more minutes elapsed cancel out.
+ * Only a sustained drift, blocks genuinely running fast or slow, accumulates
+ * past this and earns a replacement.
+ */
+export const NOTICE_RESCHEDULE_EPSILON_MS = 15 * 60_000;
+
+/**
+ * Blocks to price the alarm at, given how many actually remain.
+ *
+ * Block arrival is Poisson, so waiting for N blocks has a mean of N intervals
+ * and a standard deviation of sqrt(N) of them. Adding one sigma puts the alarm
+ * late roughly five times out of six instead of early half the time.
+ *
+ * The margin shrinks as the target approaches, which is what makes it cheap:
+ * 12 extra blocks at 144 out, 2 at 4 out, and it is re-derived on every poll,
+ * so a user with the app open near the end gets a nearly exact estimate.
+ */
+export function blocksToFireIn(blocksRemaining: number): number {
+    if (!(blocksRemaining > 0)) return 0;
+    return blocksRemaining + Math.sqrt(blocksRemaining);
+}
+
+export function decideExitReadyNotice(input: ExitReadyNoticeInput): ExitReadyNoticeDecision {
+    const { claimableCount, processingCount, tipHeight, now, armed, blockMs } = input;
+
+    const heights = (input.awaitingHeights ?? []).filter(
+        (h) => typeof h === 'number' && Number.isFinite(h) && h > 0,
+    );
+
+    const nothing = (
+        reason: ExitReadyNoticeDecision['reason'],
+    ): ExitReadyNoticeDecision => ({
+        action: 'cancel',
+        targetHeight: null,
+        fireAtMs: null,
+        provisional: false,
+        reason,
+    });
+
+    // No exit in flight at all, so any alarm left over from a finished one has
+    // to go: it would otherwise announce funds that already landed.
+    if (claimableCount <= 0 && heights.length === 0 && processingCount <= 0) {
+        return nothing('no-exit');
+    }
+
+    // Everything that was going to ripen has. `decideExitClaimBatch` sweeps on
+    // this very tick, with the app open by definition, so there is nothing
+    // left to call the user back for.
+    if (heights.length === 0 && processingCount <= 0) {
+        return nothing('claim-imminent');
+    }
+
+    // Stragglers exist but none has confirmed its leaf, so no ripening height
+    // is known. Promise nothing rather than guess a date; the next drive that
+    // sees a confirmed leaf arms it.
+    if (heights.length === 0) {
+        return nothing('no-schedule');
+    }
+
+    const targetHeight = Math.max(...heights);
+    const provisional = processingCount > 0;
+
+    const keep = (
+        reason: ExitReadyNoticeDecision['reason'],
+    ): ExitReadyNoticeDecision => ({
+        action: 'keep',
+        targetHeight,
+        fireAtMs: armed?.fireAtMs ?? null,
+        provisional,
+        reason,
+    });
+
+    // The tip is unreadable, so there is no honest way to date the alarm.
+    // Leave whatever is armed alone: the last good estimate beats no alarm,
+    // and beats one derived from a number we do not have.
+    if (tipHeight == null || !Number.isFinite(tipHeight)) return keep('tip-unknown');
+
+    const blocksRemaining = targetHeight - Math.floor(tipHeight);
+
+    // The tip has passed the target but bark has not caught up yet, which
+    // means the app is open and driving. Anything armed is due about now
+    // anyway, and re-arming it here would only push it back out.
+    if (blocksRemaining <= 0) return keep('already-ripe');
+
+    const fireAtMs = now + Math.round(blocksToFireIn(blocksRemaining) * blockMs);
+
+    const arm = (
+        reason: ExitReadyNoticeDecision['reason'],
+    ): ExitReadyNoticeDecision => ({
+        action: 'arm',
+        targetHeight,
+        fireAtMs,
+        provisional,
+        reason,
+    });
+
+    if (armed == null) return arm('first-arm');
+    // A late leaf confirming pushes the batch out, which is the case the
+    // provisional target exists for. Always re-arm on it.
+    if (armed.targetHeight !== targetHeight) return arm('target-moved');
+    if (Math.abs(fireAtMs - armed.fireAtMs) >= NOTICE_RESCHEDULE_EPSILON_MS) {
+        return arm('estimate-moved');
+    }
+    return keep('unchanged');
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -219,6 +219,8 @@ export {
     cancelVtxoExpiryWarnings,
     scheduleVtxoStuckSwapWarnings,
     cancelVtxoStuckSwapWarnings,
+    scheduleArkExitReadyNotice,
+    cancelArkExitReadyNotice,
 } from './backgroundNotifications';
 
 export { formatBlocksUntil, formatExitCollectWait } from './expiry';
@@ -269,6 +271,8 @@ export type {
 
 export { decideExitClaimBatch } from './exitClaimBatch';
 export { decideExitDrivePlan } from './exitDriveCadence';
+export { decideExitReadyNotice } from './exitReadyNotice';
+export type { ExitReadyNoticeInput, ExitReadyNoticeDecision } from './exitReadyNotice';
 export type { ExitDriveSnapshot, ExitDrivePhase, ExitDriveAction, ExitDrivePlan } from './exitDriveCadence';
 export type { ExitClaimBatchInput, ExitClaimBatchDecision } from './exitClaimBatch';
 

--- a/tests/unit/exitReadyNotice.test.ts
+++ b/tests/unit/exitReadyNotice.test.ts
@@ -1,0 +1,188 @@
+/**
+ * One alarm, at the height the batched claim is already waiting for.
+ *
+ * The exit drive is foreground-only, so finishing an exit depends on the user
+ * opening the app after the right block. On 2026-08-19 a claim landed within
+ * one block of ripening purely because someone happened to be awake and
+ * holding the phone.
+ *
+ * The heights below are from the 2026-08-22 mainnet exit, 7 capsules holding
+ * 4,990 sats. Leaves confirmed at 963390 (x3), 963455 (x3) and 963508, and
+ * every claimableHeight is leaf-confirm plus exactly 144. A per-capsule
+ * schedule would fire at 963534, 963599 and 963652; only the last of those is
+ * the moment the batch actually sweeps.
+ */
+
+import {
+    decideExitReadyNotice,
+    blocksToFireIn,
+    NOTICE_RESCHEDULE_EPSILON_MS,
+} from '../../src/services/ark/exitReadyNotice';
+
+const MINUTE = 60 * 1000;
+const BLOCK_MS = 10 * MINUTE;
+const T0 = 1_700_000_000_000;
+
+/** The three distinct ripening heights of the measured run. */
+const EARLY = 963534;
+const MID = 963599;
+const LAST = 963652;
+
+const decide = (over: Partial<Parameters<typeof decideExitReadyNotice>[0]> = {}) =>
+    decideExitReadyNotice({
+        claimableCount: 0,
+        awaitingHeights: [EARLY, EARLY, EARLY, MID, MID, MID, LAST],
+        processingCount: 0,
+        tipHeight: 963508,
+        now: T0,
+        armed: null,
+        blockMs: BLOCK_MS,
+        ...over,
+    });
+
+describe('the trigger is the batch height, not each capsule', () => {
+    it('arms for the LAST ripening height across every straggler', () => {
+        const d = decide();
+        expect(d.action).toBe('arm');
+        // Not EARLY, which is where a per-capsule schedule would have fired
+        // twice for nothing while decideExitClaimBatch correctly held.
+        expect(d.targetHeight).toBe(LAST);
+    });
+
+    it('ignores capsules that have already ripened', () => {
+        // Three are claimable, three still awaiting. The already-claimable ones
+        // cannot extend the wait, so the target is the last of the stragglers.
+        const d = decide({ claimableCount: 3, awaitingHeights: [MID, MID, MID] });
+        expect(d.action).toBe('arm');
+        expect(d.targetHeight).toBe(MID);
+    });
+
+    it('discards junk heights rather than treating them as a target', () => {
+        const d = decide({ awaitingHeights: [0, -1, Number.NaN, MID] });
+        expect(d.targetHeight).toBe(MID);
+    });
+});
+
+describe('the target is provisional while a leaf is still confirming', () => {
+    it('flags provisional when anything is still broadcasting', () => {
+        const d = decide({ awaitingHeights: [EARLY, MID], processingCount: 1 });
+        expect(d.action).toBe('arm');
+        expect(d.provisional).toBe(true);
+    });
+
+    it('re-arms when a late leaf pushes the batch out', () => {
+        // ec46d966 confirmed last in the measured run and moved the batch from
+        // 963599 to 963652. An alarm computed once would have been 53 blocks
+        // early, about nine hours.
+        const armed = { targetHeight: MID, fireAtMs: T0 + 91 * BLOCK_MS };
+        const d = decide({ armed, awaitingHeights: [MID, LAST] });
+        expect(d.action).toBe('arm');
+        expect(d.reason).toBe('target-moved');
+        expect(d.targetHeight).toBe(LAST);
+    });
+
+    it('arms nothing while no straggler has a height yet', () => {
+        // Every capsule still Processing: there is no schedule to promise.
+        const d = decide({ awaitingHeights: [], processingCount: 4 });
+        expect(d.action).toBe('cancel');
+        expect(d.reason).toBe('no-schedule');
+        expect(d.targetHeight).toBeNull();
+    });
+});
+
+describe('when there is nothing to call the user back for', () => {
+    it('cancels once the exit is over', () => {
+        const d = decide({ claimableCount: 0, awaitingHeights: [], processingCount: 0 });
+        expect(d.action).toBe('cancel');
+        expect(d.reason).toBe('no-exit');
+    });
+
+    it('cancels when the sweep fires on this very tick', () => {
+        // claimable with no stragglers is exactly decideExitClaimBatch's
+        // all-ready case, which claims now, with the app open by definition.
+        const d = decide({ claimableCount: 3, awaitingHeights: [], processingCount: 0 });
+        expect(d.action).toBe('cancel');
+        expect(d.reason).toBe('claim-imminent');
+    });
+});
+
+describe('the date is an estimate, and it is biased late', () => {
+    it('prices the wait one standard deviation past the mean', () => {
+        // Block arrival is Poisson: N blocks has a standard deviation of
+        // sqrt(N) intervals. 144 out is 12 extra blocks, about two hours.
+        expect(blocksToFireIn(144)).toBeCloseTo(156, 6);
+        expect(blocksToFireIn(4)).toBeCloseTo(6, 6);
+        expect(blocksToFireIn(0)).toBe(0);
+        expect(blocksToFireIn(-5)).toBe(0);
+    });
+
+    it('never fires before the target could physically arrive', () => {
+        const d = decide();
+        const blocks = LAST - 963508; // 144
+        expect(d.fireAtMs).not.toBeNull();
+        expect((d.fireAtMs as number) - T0).toBeGreaterThan(blocks * BLOCK_MS);
+    });
+
+    it('shrinks the margin as the target approaches', () => {
+        const far = decide({ tipHeight: LAST - 144 });
+        const near = decide({ tipHeight: LAST - 4 });
+        const farMargin = (far.fireAtMs as number) - T0 - 144 * BLOCK_MS;
+        const nearMargin = (near.fireAtMs as number) - T0 - 4 * BLOCK_MS;
+        expect(nearMargin).toBeLessThan(farMargin);
+    });
+});
+
+describe('re-arming only when the estimate has actually moved', () => {
+    it('leaves the alarm alone when blocks arrive on schedule', () => {
+        // One block later and ten minutes on: the absolute date is unchanged,
+        // so nothing should be re-armed.
+        const first = decide({ tipHeight: 963508 });
+        const later = decide({
+            tipHeight: 963509,
+            now: T0 + BLOCK_MS,
+            armed: { targetHeight: LAST, fireAtMs: first.fireAtMs as number },
+        });
+        expect(later.action).toBe('keep');
+        expect(later.reason).toBe('unchanged');
+    });
+
+    it('re-arms when the chain has run sustainedly fast', () => {
+        const first = decide({ tipHeight: 963508 });
+        // Ten blocks in the time one was budgeted for: the date moves ~90 min
+        // earlier, well past the epsilon.
+        const later = decide({
+            tipHeight: 963518,
+            now: T0 + BLOCK_MS,
+            armed: { targetHeight: LAST, fireAtMs: first.fireAtMs as number },
+        });
+        expect(later.action).toBe('arm');
+        expect(later.reason).toBe('estimate-moved');
+        expect((first.fireAtMs as number) - (later.fireAtMs as number))
+            .toBeGreaterThanOrEqual(NOTICE_RESCHEDULE_EPSILON_MS);
+    });
+
+    it('arms on the first evaluation of a session', () => {
+        expect(decide({ armed: null }).reason).toBe('first-arm');
+    });
+});
+
+describe('refusing to invent a date', () => {
+    it('keeps the last good estimate when every chain source failed', () => {
+        const armed = { targetHeight: LAST, fireAtMs: T0 + 144 * BLOCK_MS };
+        const d = decide({ tipHeight: null, armed });
+        expect(d.action).toBe('keep');
+        expect(d.reason).toBe('tip-unknown');
+        // Crucially not a cancel: no tip is not evidence the exit is over.
+        expect(d.fireAtMs).toBe(armed.fireAtMs);
+    });
+
+    it('does not push the alarm back out once the tip has crossed', () => {
+        // bark has not reported the capsules claimable yet, but the app is
+        // plainly open and driving. Re-arming here would delay an alarm that
+        // is due about now.
+        const armed = { targetHeight: LAST, fireAtMs: T0 + 5 * MINUTE };
+        const d = decide({ tipHeight: LAST + 1, armed });
+        expect(d.action).toBe('keep');
+        expect(d.reason).toBe('already-ripe');
+    });
+});


### PR DESCRIPTION
Closes #199.

## The problem

A unilateral exit needs the user to open the app once, at a moment nobody can guess. The drive is foreground-only, so a user who closes the app has no way of knowing when to come back. On 2026-08-19 a claim landed within one block of ripening only because someone happened to be awake and holding the phone.

## One alarm, at the height the batch is already waiting for

The tempting design is one alarm per capsule as each ripens. That is wrong: `decideExitClaimBatch` deliberately holds the sweep until every capsule has ripened, so the whole exit lands as one UTXO paying one transaction overhead instead of N. A per-capsule alarm fires, the user opens the app, the batch correctly holds, and nothing visible happens. Then it happens again.

Measured on the 2026-08-22 mainnet exit, 7 capsules holding 4,990 sats:

```
aa2c257e  800  leaf @963390  claimable @963534
d4ec1101  700  leaf @963390  claimable @963534
1f6627c2  698  leaf @963390  claimable @963534
9211887d  698  leaf @963455  claimable @963599
a6e24d2f  698  leaf @963455  claimable @963599
bc672cb8  698  leaf @963455  claimable @963599
ec46d966  698  leaf @963508  claimable @963652
```

The batch fires at 963652. A per-capsule schedule would have fired at 963534, then 963599, then 963652: two of the three are pure noise. So the trigger is `max(claimableHeight)` across everything still ripening.

## The target is provisional while anything is still broadcasting

A capsule whose leaf has not confirmed has no `claimableHeight` yet, and its eventual height can land after the current maximum. In that run `ec46d966` confirmed last and pushed the batch height from 963599 out to 963652. So the target is re-derived as leaves confirm rather than computed once. Re-arming replaces the alarm under a fixed id.

## Blocks are the truth, the date is an estimate

Block intervals are exponentially distributed, so the wait for N blocks has a standard deviation of sqrt(N) intervals: at 144 blocks out, about two hours either side.

The two failure directions are not symmetric. Late costs a little delay on funds that have no deadline and nobody racing them, since past its CSV a claimable exit output is an ordinary UTXO only this wallet can spend. Early spends the single interruption this feature is allowed, on nothing. So the estimate is deliberately biased one standard deviation late, and it self-corrects from the live tip on every poll.

## Where it runs

Refreshed from the cheap tip poll as well as the full drive. While waiting, a full drive runs at most every six hours, so an estimate refined only there would spend most of the wait stale. The tip poll runs every 2 to 10 minutes and already has the fresh tip, so this costs no extra requests.

Cancelled the moment the sweep broadcasts or the exit retires, so it can never announce funds that have already landed. Gated on the same reminders toggle as every other Ark alarm, which is where OS notification permission is requested.

## Testing

- 16 new unit tests covering the batch trigger, the provisional target, the late bias, re-arm suppression, and refusal to invent a date when every chain source fails.
- Full suite: 58 suites, 654 passing, against 57 / 638 on main.
- `tsc` adds no new error kind. It adds one more instance each of two pre-existing `@types/react-native-push-notification` errors that main already carries on the existing `scheduleVtxoExpiryWarnings` path.
- The decision rule is pure and import-free, matching `exitClaimBatch.ts`, so it is tested without standing up the sync loop or the OS layer.

Not yet exercised against a live exit. That is what the next mainnet exit run is for.