### PR TITLE
fix(ark): share chain-source health, so the tip poll stops re-earning a known 429

### DIFF
--- a/src/services/ark/chainTip.ts
+++ b/src/services/ark/chainTip.ts
@@ -1,4 +1,5 @@
 import { ESPLORA_URLS } from './config';
+import { noteEsploraFailure, noteEsploraSuccess, orderedEsploraUrls } from './esploraHealth';
 
 /**
  * Fetch the current chain tip height, rotating across the esplora providers.
@@ -28,7 +29,12 @@ import { ESPLORA_URLS } from './config';
 const TIP_FETCH_TIMEOUT_MS = 8000;
 
 export async function fetchChainTipHeight(): Promise<number | null> {
-    for (const base of ESPLORA_URLS) {
+    // Health-ordered, not raw list order. This is the exit's dominant request
+    // source once #219 made the tip poll the unit of polling, so starting every
+    // one of several hundred polls at a provider that is mid-cooldown spends a
+    // request to be told the same 429 the open path already learned. Ordering
+    // only: every provider is still reachable, just later. See esploraHealth.ts.
+    for (const base of orderedEsploraUrls(ESPLORA_URLS)) {
         try {
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort(), TIP_FETCH_TIMEOUT_MS);
@@ -38,16 +44,33 @@ export async function fetchChainTipHeight(): Promise<number | null> {
             } finally {
                 clearTimeout(timer);
             }
-            if (!res.ok) continue;
+            if (!res.ok) {
+                // A 429 arrives here as a plain non-ok response, so this is the
+                // branch that actually sees rate limiting. Feed the status text
+                // to the classifier rather than a bare "not ok".
+                noteEsploraFailure(base, `${res.status} ${res.statusText ?? ''}`);
+                continue;
+            }
             const text = (await res.text()).trim();
             // A real tip height is a bare integer in the ~800k–10M range. The
             // bot-block page is long HTML/JSON — reject anything non-numeric,
             // too long, or implausibly small so it can't be read as a tip.
-            if (!/^\d{5,8}$/.test(text)) continue;
+            if (!/^\d{5,8}$/.test(text)) {
+                // Junk where an integer belongs: a bot-block or error page,
+                // which in this context is the disguised rate-limit body.
+                noteEsploraFailure(base, text.slice(0, 200));
+                continue;
+            }
             const n = Number(text);
-            if (Number.isFinite(n) && n > 0) return n;
-        } catch {
-            // try the next provider
+            if (Number.isFinite(n) && n > 0) {
+                noteEsploraSuccess(base);
+                return n;
+            }
+        } catch (err) {
+            // Timeout or transport failure. Records as 'unreachable', which
+            // carries the short cooldown, so a blip does not sideline a
+            // provider for the full quota hour.
+            noteEsploraFailure(base, String((err as Error)?.message ?? err));
         }
     }
     return null;

--- a/src/services/ark/esploraHealth.ts
+++ b/src/services/ark/esploraHealth.ts
@@ -1,0 +1,82 @@
+/**
+ * One shared record of which chain sources are currently unhappy.
+ *
+ * WHY THIS IS SHARED AND NOT PER-CALLER
+ *
+ * The cooldown machinery in esploraProviders.ts had exactly one caller. The
+ * open path in restore.ts kept its own module-level map and routed around a
+ * 429 correctly. Every other JS-side chain call walked the raw list from index
+ * 0 every single time, so what the open path learned was thrown away:
+ *
+ *   - chainTip.ts, which during a unilateral exit is the DOMINANT request
+ *     source. #219 turned the drive into a tip poll every 2 to 10 minutes, so
+ *     a ~24h wait is roughly 180 polls, and a two-day exit several hundred.
+ *     Each one started at blockstream.info, including in the hour after
+ *     blockstream had answered 429 and been put on a one-hour cooldown by the
+ *     open path standing right next to it.
+ *   - exitFunding.ts's fee lookups, on the screen the user is staring at while
+ *     trying to fund the exit that cannot proceed without it.
+ *
+ * That is #194's "rotation is reactive and can rotate INTO an already-exhausted
+ * provider", still live after the cooldown logic that was supposed to fix it,
+ * because the logic was never wired to the callers that spend the most.
+ *
+ * Sharing it also makes the learning cross-pollinate: a quota discovered while
+ * opening the wallet is known by the next tip poll, and a tip poll that eats a
+ * 429 steers the next open. One IP, one quota, so one map.
+ *
+ * DELIBERATELY IN MEMORY ONLY
+ *
+ * Resets on app restart, matching the behaviour restore.ts already had and
+ * documented. A cooldown is a guess from a single observation, and persisting
+ * guesses across launches would let one bad minute mis-route a wallet for an
+ * hour after the user tried to fix it by relaunching. The first failure after
+ * launch re-learns it at a cost of one request.
+ *
+ * This module owns MUTABLE state, which is why it is separate from
+ * esploraProviders.ts. That file stays pure and import-free so its rules can be
+ * unit-tested without standing up the SDK.
+ */
+import {
+    classifyEsploraFailure,
+    esploraUrlsByHealth,
+    type EsploraHealth,
+} from './esploraProviders';
+
+const health: EsploraHealth = {};
+
+/** The live map. Exported for the open path, which passes it to the chooser. */
+export function getEsploraHealth(): EsploraHealth {
+    return health;
+}
+
+/**
+ * Record that `url` failed, classifying the cause so the cooldown fits it.
+ *
+ * `detail` is the raw error text. classifyEsploraFailure reads a 429 out of it,
+ * including the disguised form where bark feeds a rate-limit JSON body to a hex
+ * parser and complains about blockhash length.
+ */
+export function noteEsploraFailure(url: string, detail: string, now = Date.now()): void {
+    health[url] = { failedAt: now, kind: classifyEsploraFailure(detail) };
+}
+
+/** Forget a provider's failure, e.g. after it answers successfully again. */
+export function noteEsploraSuccess(url: string): void {
+    delete health[url];
+}
+
+/**
+ * The providers to walk, best first. Never drops one: see esploraUrlsByHealth.
+ *
+ * Callers that walk a list until something answers should use this instead of
+ * ESPLORA_URLS directly.
+ */
+export function orderedEsploraUrls(urls: readonly string[], now = Date.now()): string[] {
+    return esploraUrlsByHealth({ urls, health, now });
+}
+
+/** Test seam. Not used in app code. */
+export function __resetEsploraHealthForTests(): void {
+    for (const k of Object.keys(health)) delete health[k];
+}

--- a/src/services/ark/esploraProviders.ts
+++ b/src/services/ark/esploraProviders.ts
@@ -156,3 +156,68 @@ export function chooseEsploraProvider(args: {
     })[0];
     return { url: soonest as string, coolingDown: true };
 }
+
+/**
+ * The full provider list, reordered so the ones worth trying come first.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM chooseEsploraProvider
+ *
+ * `chooseEsploraProvider` answers "which ONE do I point the wallet at", which
+ * is what the open path needs: bark takes a single esplora address in its
+ * config. But the JS-side callers do not pick one, they WALK the list until
+ * something answers. Handing them a single URL would throw away the fallback
+ * that makes them work at all.
+ *
+ * So this returns every provider, in the order a walker should try them. Same
+ * health rules, different shape.
+ *
+ * NOTHING IS EVER DROPPED
+ *
+ * A cooling-down provider is demoted, never removed. Cooldowns are a guess
+ * built on one observed failure, and a wrong guess must not be able to take a
+ * provider out of service: the walker still reaches it after the healthy ones,
+ * which is strictly better than today's blind order and never worse. With an
+ * empty health map the output is `urls` unchanged, so a fresh launch behaves
+ * exactly as it did before.
+ *
+ * THE ORDER
+ *
+ *  1. Available, and no sibling host of the same operator is cooling down.
+ *     A quota is per IP-and-operator, so a Blockstream 429 makes every
+ *     Blockstream host a bad bet, not just the one that answered.
+ *  2. Available, but an operator sibling is cooling down.
+ *  3. Cooling down, soonest to recover first.
+ *
+ * List order is preserved inside each tier, so the privacy property the list
+ * ordering documents still holds: a healthy wallet talks to the first entry.
+ */
+export function esploraUrlsByHealth(args: {
+    urls: readonly string[];
+    health: EsploraHealth;
+    now: number;
+}): string[] {
+    const { urls, health, now } = args;
+    const isCooling = (u: string) => {
+        const h = health[u];
+        return h != null && now - h.failedAt < cooldownFor(h.kind);
+    };
+    const recoversAt = (u: string) => {
+        const h = health[u];
+        return h ? h.failedAt + cooldownFor(h.kind) : 0;
+    };
+
+    const burnedOperators = new Set(
+        urls.filter(isCooling).map((u) => esploraOperator(u)),
+    );
+
+    const clean: string[] = [];
+    const tainted: string[] = [];
+    const cooling: string[] = [];
+    for (const u of urls) {
+        if (isCooling(u)) cooling.push(u);
+        else if (burnedOperators.has(esploraOperator(u))) tainted.push(u);
+        else clean.push(u);
+    }
+    cooling.sort((a, b) => recoversAt(a) - recoversAt(b));
+    return [...clean, ...tainted, ...cooling];
+}

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -22,6 +22,7 @@ import useAuthStore from '@Cypher/stores/authStore';
 
 import { barkStateTag } from './barkState';
 import { ESPLORA_URLS } from './config';
+import { noteEsploraFailure, noteEsploraSuccess, orderedEsploraUrls } from './esploraHealth';
 import { assertNoActiveArkExit } from './exit';
 import type {
     ExitEconomicPolicy,
@@ -207,10 +208,23 @@ export async function fetchExitFeeRates(): Promise<ExitFeeRateTable> {
     const fromMempool = ratesFromMempoolRecommended(recommended);
     if (fromMempool) return fromMempool;
 
-    for (const base of ESPLORA_URLS) {
+    // Health-ordered: this runs on the screen the user is staring at while
+    // trying to fund an exit that cannot proceed without a rate, so spending
+    // the first attempt on a provider already known to be rate limited is the
+    // worst possible place to pay for blind ordering. See esploraHealth.ts.
+    for (const base of orderedEsploraUrls(ESPLORA_URLS)) {
         const est = await get(`${base}/fee-estimates`);
         const fromEsplora = ratesFromEsploraEstimates(est);
+        if (!est) {
+            // `get` swallows the cause and returns null for both a non-ok
+            // response and a throw, so the classifier cannot tell a 429 from a
+            // dead host here. Record it as unreachable, which takes the SHORT
+            // cooldown: under-penalising a quota costs one wasted request next
+            // time, over-penalising a healthy provider costs an hour.
+            noteEsploraFailure(base, 'fee-estimates unavailable');
+        }
         if (fromEsplora) {
+            noteEsploraSuccess(base);
             if (__DEV__) console.log('[Ark exit-funding] fee rates via esplora', base, fromEsplora);
             return fromEsplora;
         }

--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -6,8 +6,8 @@ import {
     chooseEsploraProvider,
     classifyEsploraFailure,
     ESPLORA_OPEN_ATTEMPTS,
-    type EsploraHealth,
 } from './esploraProviders';
+import { getEsploraHealth, noteEsploraFailure } from './esploraHealth';
 import { ARK_DATADIR } from './datadir';
 import { cacheArkMnemonicForReopen, getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
 
@@ -117,17 +117,13 @@ export async function restoreArkWalletFromDisk(): Promise<ArkRestoreResult> {
  * errors are retried; a genuine seed/datadir mismatch fails fast. Callers
  * (restoreArkWalletFromDisk, reopenArkWalletFromCache) own the openInFlight
  * guard around this.
- */
-/**
- * Which providers have failed recently, and why.
  *
- * Module-level so it outlives a single open loop: the sync loop's self-heal
- * calls this every tick, and without memory each call restarted at the first
- * provider and re-earned the same 429. Resets on app restart, which is fine,
- * the first failure re-learns it.
+ * Provider health is SHARED with every other JS-side chain caller rather than
+ * private to this file. It was module-level here so it outlived a single open
+ * loop, which was right as far as it went, but the tip poll and the exit fee
+ * lookups kept re-earning 429s this map already knew about. One IP means one
+ * quota, so one map. See esploraHealth.ts.
  */
-const esploraHealth: EsploraHealth = {};
-
 async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
     let lastErr: Error | undefined;
     for (let attempt = 1; attempt <= OPEN_ATTEMPTS; attempt++) {
@@ -139,7 +135,7 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
         // for an unreachable host.
         const choice = chooseEsploraProvider({
             urls: ESPLORA_URLS,
-            health: esploraHealth,
+            health: getEsploraHealth(),
             now: Date.now(),
         });
         const esploraUrl = choice.url;
@@ -167,7 +163,7 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
             // Record the failure BEFORE deciding what to do, so the next
             // attempt in this same loop already routes around this provider.
             const kind = classifyEsploraFailure(detail);
-            esploraHealth[esploraUrl] = { failedAt: Date.now(), kind };
+            noteEsploraFailure(esploraUrl, detail);
 
             const transient = /ServerConnection|Connection|timeout|timed out|network|bad response from server|not a blockhash|failed to parse hex|Esplora client/i.test(detail);
             const stopping = !transient || attempt === OPEN_ATTEMPTS;
@@ -190,7 +186,7 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
                     `classified=${kind}; ` +
                     (stopping
                         ? `GIVING UP (${!transient ? 'non-transient error' : 'attempts exhausted'}); ` +
-                          `providers tried: ${Object.keys(esploraHealth).join(', ')}`
+                          `providers tried: ${Object.keys(getEsploraHealth()).join(', ')}`
                         : `retrying in ${OPEN_RETRY_DELAY_MS}ms`),
                 );
             }

--- a/tests/unit/esploraProviders.test.ts
+++ b/tests/unit/esploraProviders.test.ts
@@ -3,6 +3,7 @@ import {
     ESPLORA_OPEN_ATTEMPTS,
     esploraOperator,
     chooseEsploraProvider,
+    esploraUrlsByHealth,
     classifyEsploraFailure,
     ESPLORA_RATE_LIMIT_COOLDOWN_MS,
     type EsploraHealth,
@@ -136,5 +137,91 @@ describe('classifying an esplora failure', () => {
 
     it('treats a connection failure as unreachable, which cools down briefly', () => {
         expect(classifyEsploraFailure('ServerConnection: timed out')).toBe('unreachable');
+    });
+});
+
+describe('walking the list, for callers that try every provider in turn', () => {
+    // chooseEsploraProvider answers "which ONE", which is what bark's config
+    // needs. The JS-side callers (chainTip, exit fee lookups) walk the list
+    // until something answers, so handing them one URL would throw away the
+    // fallback. Same health rules, different shape.
+    const URLS = [
+        'https://blockstream.info/api',
+        'https://mempool.space/api',
+        'https://mempool.emzy.de/api',
+        'https://mempool.va1.mempool.space/api',
+    ];
+    const NOW = 1_700_000_000_000;
+    const order = (health: EsploraHealth, now = NOW) =>
+        esploraUrlsByHealth({ urls: URLS, health, now });
+
+    it('changes nothing at all when no provider has failed', () => {
+        // The safety property that makes this landable without ceremony: a
+        // fresh launch behaves exactly as the blind order did.
+        expect(order({})).toEqual(URLS);
+    });
+
+    it('never drops a provider, only demotes it', () => {
+        // A cooldown is a guess from ONE observation. A wrong guess must not
+        // be able to take a provider out of service.
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW - 60_000, kind: 'rate-limited' },
+            [URLS[1]]: { failedAt: NOW - 10_000, kind: 'unreachable' },
+            [URLS[2]]: { failedAt: NOW - 10_000, kind: 'unreachable' },
+            [URLS[3]]: { failedAt: NOW - 10_000, kind: 'unreachable' },
+        };
+        expect([...order(h)].sort()).toEqual([...URLS].sort());
+    });
+
+    it('demotes a rate-limited provider below the healthy ones', () => {
+        // #194: several hundred tip polls over a two-day exit each started at
+        // blockstream, in the hour after blockstream had already answered 429.
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW - 60_000, kind: 'rate-limited' },
+        };
+        expect(order(h)[0]).not.toBe(URLS[0]);
+        expect(order(h).indexOf(URLS[0])).toBe(URLS.length - 1);
+    });
+
+    it('demotes an operator sibling of a burned provider too', () => {
+        // A quota is per IP-and-operator, so a mempool.space 429 makes the
+        // regional mempool.space node a bad bet as well.
+        const h: EsploraHealth = {
+            [URLS[1]]: { failedAt: NOW - 60_000, kind: 'rate-limited' },
+        };
+        const o = order(h);
+        expect(o[0]).toBe(URLS[0]);
+        // The va1 sibling shares mempool.space, so it ranks below the
+        // independent community mirror despite coming first in list order.
+        expect(o.indexOf(URLS[2])).toBeLessThan(o.indexOf(URLS[3]));
+    });
+
+    it('puts the soonest-to-recover first when everything is cooling', () => {
+        // A stale provider beats no chain source, and the exit drive has no
+        // better option than to try something.
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW, kind: 'rate-limited' },
+            [URLS[1]]: { failedAt: NOW, kind: 'unreachable' },
+            [URLS[2]]: { failedAt: NOW, kind: 'rate-limited' },
+            [URLS[3]]: { failedAt: NOW, kind: 'rate-limited' },
+        };
+        // unreachable carries the short cooldown, so it recovers first.
+        expect(order(h)[0]).toBe(URLS[1]);
+    });
+
+    it('restores a provider once its cooldown has expired', () => {
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW - ESPLORA_RATE_LIMIT_COOLDOWN_MS - 1, kind: 'rate-limited' },
+        };
+        expect(order(h)).toEqual(URLS);
+    });
+
+    it('preserves list order inside a tier', () => {
+        // The privacy property the list ordering documents still holds.
+        const h: EsploraHealth = {
+            [URLS[0]]: { failedAt: NOW - 60_000, kind: 'rate-limited' },
+        };
+        const healthy = order(h).slice(0, 3);
+        expect(healthy).toEqual([URLS[1], URLS[2], URLS[3]]);
     });
 });


### PR DESCRIPTION
Refs #194, fix 2.

## What was actually still broken

The cooldown machinery added for #194 works. It had **exactly one caller**.

`restore.ts` (the wallet open path) kept a private module-level health map, recorded *why* a provider failed, and routed around it: an hour for a quota, five minutes for an unreachable host. Correct.

Everything else walked `ESPLORA_URLS` blind from index 0, every single time:

| caller | when it runs |
|---|---|
| `chainTip.ts` | the exit tip poll |
| `exitFunding.ts` | fee lookups on the exit funding screen |

So what the open path learned was thrown away by the callers that spend the most requests.

## Why it matters most now

#219 made the tip poll the unit of polling during a unilateral exit. That is one poll every 2 to 10 minutes for as long as the exit runs: roughly 180 over a 24h wait, several hundred over a two-day one. **Every one of them started at `blockstream.info`**, including during the hour after blockstream had answered 429 and been put on a cooldown by the open path standing right next to it.

The fee lookups did the same thing, on the screen a user is staring at while trying to fund an exit that cannot proceed without a rate.

This is #194's own words, "rotation is reactive and can rotate INTO an already-exhausted provider", still live after the fix that was supposed to close it, because the fix was never wired to the hot callers.

## The change

Promotes the health map into a shared module, and adds `esploraUrlsByHealth` as a list-shaped counterpart to `chooseEsploraProvider`. Those answer different questions: the open path needs **one** url for bark's config, but these callers **walk** the list until something answers, so handing them a single url would throw away the fallback that makes them work at all.

Order:
1. Available, and no operator sibling is cooling down. A quota is per IP-and-operator, so a Blockstream 429 makes every Blockstream host a bad bet.
2. Available, but an operator sibling is cooling down.
3. Cooling down, soonest to recover first.

List order is preserved inside each tier, so the privacy property the list ordering documents still holds: a healthy wallet talks to the first entry only.

Sharing also makes the learning cross-pollinate. A quota discovered while opening the wallet is known by the next tip poll, and a tip poll that eats a 429 steers the next open. One IP, one quota, one map.

## Why this is safe to land before a live exit

**Ordering only. Nothing is ever dropped.** A cooling-down provider is demoted, not removed, and is still reached after the healthy ones. A cooldown is a guess built on a single observed failure, and a wrong guess must not be able to take a provider out of service. With an empty health map the output is the list unchanged, so a fresh launch behaves exactly as it does today. Worst case is current behaviour.

## Deliberately not in scope

`walletHandle.ts` has its own separate session-pinned rotation for the SDK config, independent of this map. Left alone: it is squarely on the exit path, and unifying two rotation schemes is worth doing on its own rather than days before a live exit.

Also worth stating plainly, since #194 asks for a request budget: **a true per-request budget is not implementable client side.** The bulk of esplora traffic is issued by bark's Rust core inside `syncArkWallet` / `progressExits`, over the native HTTP client. JS never sees those requests and cannot count them. Counting only the handful of JS-side calls would report headroom that does not exist. What removes the cap is fix 4, our own chain source, which is unblocked by credentials and DNS rather than by code.

## Testing

- 7 new unit tests on the ordering rules, including the two invariants that make it safe: unchanged output on an empty map, and no provider ever dropped.
- Full suite: 58 suites, 669 passing, against 58 / 662 on main.
- `tsc` 402, identical to main, and the unique-error-kind diff against main is empty.