### PR TITLE
fix(ark): say which phase the exit is in, so a stall does not look like progress

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -47,6 +47,8 @@ import {
   estimateArkOnchainRecover,
   recoverArkOnchainBoard,
   fetchArkExitVtxos,
+  summariseExitPhase,
+  AVG_BLOCK_MINUTES,
   fetchPendingExitsTotalSats,
   formatBlocksUntil,
   formatExitCollectWait,
@@ -70,7 +72,7 @@ import {
   writeArkBackupToTempFile,
   buildExitFundingSources,
 } from "@Cypher/services/ark";
-import type { ExitEconomicPolicy, ExitFeeConvertEstimate, ExitTriageResult } from "@Cypher/services/ark";
+import type { ExitEconomicPolicy, ExitFeeConvertEstimate, ExitTriageResult, ExitPhaseSummary } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
 import Share from "react-native-share";
 import { BlueStorageContext } from "../../../../blue_modules/storage-context";
@@ -972,6 +974,10 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const [externalAddrInput, setExternalAddrInput] = useState('');
   const [exitStarting, setExitStarting] = useState(false);
   const [pendingExitSats, setPendingExitSats] = useState<number | null>(null);
+  // Which phase the exit is in, derived from the SAME poll that produces the
+  // sats total. The panel used to print one sentence for the entire two-day
+  // run, so a stalled exit and a working one looked identical.
+  const [exitPhase, setExitPhase] = useState<ExitPhaseSummary | null>(null);
 
   // --- Exit-fee funding gate ---
   //
@@ -1035,6 +1041,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   useEffect(() => {
     if (!arkExitInProgress) {
       setPendingExitSats(null);
+      setExitPhase(null);
       return;
     }
     let cancelled = false;
@@ -1055,10 +1062,45 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
           fetchArkExitVtxos(),
           fetchPendingExitsTotalSats(),
         ]);
-        const activeSats = vtxos
-          .filter((v) => isActiveExit(v))
-          .reduce((acc, v) => acc + Number(v.amountSats), 0);
-        if (!cancelled) setPendingExitSats(Math.max(activeSats, pendingTotal));
+        const active = vtxos.filter((v) => isActiveExit(v));
+        const activeSats = active.reduce((acc, v) => acc + Number(v.amountSats), 0);
+
+        // Phase, off the SAME records. Free: `vtxos` is already in hand and
+        // this adds no request, which matters because chain-source budget is
+        // the exit's scarcest resource.
+        //
+        // A capsule is claimable, or waiting out its CSV with an exact
+        // ripening height, or still broadcasting with no height yet. That last
+        // group is the one the app is load-bearing for, and the one whose
+        // eventual height can push the finish line out.
+        const claimable = active.filter((v) => v.isClaimable);
+        const awaitingHeights: number[] = [];
+        let processingCount = 0;
+        for (const v of active) {
+          if (v.isClaimable) continue;
+          const h = Number(
+            (v.state as { inner?: { claimableHeight?: number } })?.inner?.claimableHeight ?? 0,
+          );
+          if (Number.isFinite(h) && h > 0) awaitingHeights.push(h);
+          else processingCount += 1;
+        }
+        // Live tip: the exit drive polls it itself and writes it here, which is
+        // what made a real countdown possible (the store's tip used to freeze
+        // for the whole exit, and bark's is stamped once on entry).
+        const tipHeight = useAuthStore.getState().arkChainTipHeight ?? null;
+
+        if (!cancelled) {
+          setPendingExitSats(Math.max(activeSats, pendingTotal));
+          setExitPhase(
+            summariseExitPhase({
+              claimableCount: claimable.length,
+              awaitingHeights,
+              processingCount,
+              tipHeight,
+              blockMinutes: AVG_BLOCK_MINUTES,
+            }),
+          );
+        }
       } catch {
         // Best-effort; the status panel falls back to "—" sats.
       }
@@ -2264,11 +2306,28 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   pendingExitSats ??
                   arkBalanceDetail?.pendingExitSats ??
                   arkExitStartedSats;
+                // The AMOUNT only. What is happening to it is the phase line
+                // below, which used to be baked into this sentence and so never
+                // changed for the whole run.
                 return shownSats == null || shownSats <= 0
-                  ? 'Broadcasting exit transactions…'
-                  : `${shownSats.toLocaleString()} sats pending exit. Broadcasting, then a ~24h timelock. Reopen the app after that to collect; it does not progress while closed.`;
+                  ? 'Exit in flight.'
+                  : `${shownSats.toLocaleString()} sats pending exit.`;
               })()}
             </Text>
+
+            {/* PHASE. The fix for a panel that read identically whether the
+                exit was progressing or wedged. Falls back to the previous
+                static sentence until the first poll returns, so a cold launch
+                with the vault still locked is never blank. */}
+            <Text style={{ fontSize: 13, color: '#DDD', marginBottom: 6 }}>
+              {exitPhase?.headline
+                ?? 'Broadcasting, then a timelock. Reopen the app after that to collect; it does not progress while closed.'}
+            </Text>
+            {exitPhase?.detail && (
+              <Text style={{ fontSize: 12, color: '#AAA', marginBottom: 6 }}>
+                {exitPhase.detail}
+              </Text>
+            )}
             {arkExitDestinationAddress && (
               <Text style={{ fontSize: 12, color: '#888' }} numberOfLines={1}>
                 → {arkExitDestinationAddress}

--- a/src/services/ark/exitPhaseSummary.ts
+++ b/src/services/ark/exitPhaseSummary.ts
@@ -1,0 +1,206 @@
+/**
+ * Which phase a unilateral exit is in, and what to tell the user about it.
+ *
+ * THE PROBLEM
+ *
+ * The panel showed one sentence for the entire run: "N sats pending exit.
+ * Broadcasting, then a ~24h timelock. Reopen the app after that to collect."
+ * The amount was honest and decremented as claims landed, but the sentence
+ * never changed, so a STALLED exit and a WORKING one looked identical for two
+ * days. On a path the user takes when they believe the server is hostile, the
+ * only question they have is "is this progressing", and the screen could not
+ * answer it.
+ *
+ * COSTS NOTHING NEW
+ *
+ * Every input here is already fetched. The panel polls `fetchArkExitVtxos()`
+ * every 10s and threw away everything except the sats total, and the chain tip
+ * has been live in the store since the exit drive started polling it itself
+ * (#204/#219). So this is presentation over data already in hand: no extra
+ * esplora requests, which matters because request budget is the exit's
+ * scarcest resource.
+ *
+ * THE THREE PHASES, AND WHY THEY READ DIFFERENTLY
+ *
+ *   publishing  Some capsule is still Processing. The app is needed to
+ *               broadcast the next tree level, and a level cannot be built
+ *               until its parent output exists. This is the phase that needs
+ *               the user REPEATEDLY, so its copy asks them to stay.
+ *   waiting     Every capsule is out of the app's hands and sitting out the
+ *               CSV. The chain does this work whether the app is open or not,
+ *               so its copy releases the user.
+ *   ready       Something is claimable. The sweep fires from the open app.
+ *
+ * BLOCKS ARE THE TRUTH, TIME IS THE ESTIMATE
+ *
+ * `claimableHeight` is exact and fixed from the moment a leaf confirms. The
+ * conversion to a duration is not: block intervals are exponentially
+ * distributed, so a seconds-level countdown stalls visibly and then jumps,
+ * including backwards, which reads as a broken timer rather than an honest
+ * estimate. So the block count leads, the duration follows as an approximation,
+ * and there are no seconds anywhere. See ARK_UNILATERAL_EXIT_TRIAGE_SPEC 7.2.
+ *
+ * NEVER IMPLIES IT FINISHES BY ITSELF
+ *
+ * The drive is foreground-only. Every phase's copy has to survive the user
+ * closing the app, so none of it promises completion. The countdown ends at
+ * "ready to collect", never at "done".
+ *
+ * Pure and import-free, matching exitClaimBatch.ts, exitDriveCadence.ts and
+ * exitReadyNotice.ts, so the wording and the thresholds are testable without
+ * standing up the SDK or the sync loop.
+ */
+
+export type ExitPhase = 'publishing' | 'waiting' | 'ready' | 'settling';
+
+export type ExitPhaseInput = {
+    /** Capsules ready to sweep right now (`isClaimable`). */
+    claimableCount: number;
+    /**
+     * `claimableHeight` for each capsule sitting out its CSV, from
+     * `ExitState.AwaitingDelta.inner.claimableHeight`.
+     */
+    awaitingHeights: readonly number[];
+    /** Capsules still broadcasting, so no ripening height exists yet. */
+    processingCount: number;
+    /** Freshest tip known, or null when no chain source answered. */
+    tipHeight: number | null;
+    /** Minutes per block used to turn a height into a duration. */
+    blockMinutes: number;
+};
+
+export type ExitPhaseSummary = {
+    phase: ExitPhase;
+    /** One line naming what is happening now. */
+    headline: string;
+    /** Secondary line, or null when there is nothing honest to add. */
+    detail: string | null;
+    /** Blocks until everything is collectable. null when not yet knowable. */
+    blocksRemaining: number | null;
+    /** The height everything is collectable at. null when not yet knowable. */
+    targetHeight: number | null;
+};
+
+/**
+ * Blocks as a rough duration.
+ *
+ * Deliberately coarse and deliberately vague in its wording. Minutes below two
+ * hours, whole hours above, and never a unit finer than a minute. "about" is
+ * load-bearing: it is the difference between an estimate the user forgives for
+ * drifting and a timer they treat as broken.
+ */
+export function approxDuration(blocks: number, blockMinutes: number): string {
+    const mins = Math.max(0, Math.round(blocks * blockMinutes));
+    if (mins < 1) return 'under a minute';
+    if (mins < 120) return `about ${mins} min`;
+    const hours = Math.round(mins / 60);
+    if (hours < 48) return `about ${hours} hours`;
+    return `about ${Math.round(hours / 24)} days`;
+}
+
+function plural(n: number, one: string, many: string): string {
+    return n === 1 ? one : many;
+}
+
+export function summariseExitPhase(input: ExitPhaseInput): ExitPhaseSummary {
+    const claimable = Math.max(0, Math.floor(input.claimableCount || 0));
+    const processing = Math.max(0, Math.floor(input.processingCount || 0));
+    const heights = (input.awaitingHeights ?? [])
+        .map((h) => Math.floor(Number(h) || 0))
+        .filter((h) => h > 0);
+    const tip = input.tipHeight != null && Number.isFinite(input.tipHeight)
+        ? Math.floor(input.tipHeight)
+        : null;
+
+    // Everything is collectable once the LAST one ripens, which is also what
+    // the claim batches on: one sweep, one transaction overhead, rather than
+    // one per capsule. So the figure the user is shown is the same figure the
+    // app is actually waiting for.
+    const targetHeight = heights.length > 0 ? Math.max(...heights) : null;
+    const blocksRemaining =
+        targetHeight != null && tip != null ? Math.max(0, targetHeight - tip) : null;
+
+    // Ready outranks everything: something can be collected NOW, and that is
+    // true whatever else is still in flight behind it.
+    if (claimable > 0) {
+        const alsoWaiting = heights.length + processing;
+        return {
+            phase: 'ready',
+            headline: `Ready to collect. ${claimable} ${plural(claimable, 'capsule is', 'capsules are')} past the timelock.`,
+            detail: alsoWaiting > 0
+                // Says why nothing may appear to happen yet. The batch holds
+                // for the stragglers so the whole exit lands as one payment.
+                ? `Collecting together with ${alsoWaiting} still finishing, so it arrives as one payment. Keep the app open.`
+                : 'Keep the app open while it sends.',
+            blocksRemaining,
+            targetHeight,
+        };
+    }
+
+    // Publishing outranks waiting: if ANY capsule still needs a broadcast, the
+    // app is load-bearing and the copy must not tell the user to leave.
+    if (processing > 0) {
+        return {
+            phase: 'publishing',
+            headline: `Publishing exit transactions for ${processing} ${plural(processing, 'capsule', 'capsules')}.`,
+            detail: heights.length > 0
+                ? `${heights.length} already published and waiting out the timelock. Keep the app open, each step needs it.`
+                : 'Keep the app open, each step needs it.',
+            // A capsule with no ripening height yet can push the finish line
+            // out once its leaf confirms, so any figure here would be a floor
+            // presented as an answer. Withheld rather than guessed.
+            blocksRemaining: null,
+            targetHeight: null,
+        };
+    }
+
+    if (heights.length > 0) {
+        const n = heights.length;
+        const published = `${n} ${plural(n, 'capsule is', 'capsules are')} published and waiting out the timelock.`;
+        if (blocksRemaining == null) {
+            return {
+                phase: 'waiting',
+                headline: published,
+                // No tip means no chain source answered. Saying nothing about
+                // timing is better than inventing one, and the remedy belongs
+                // here because the user can act on it.
+                detail: 'Cannot reach a chain source to check the countdown. Try cellular if you are on wifi.',
+                blocksRemaining: null,
+                targetHeight,
+            };
+        }
+        if (blocksRemaining === 0) {
+            return {
+                phase: 'waiting',
+                headline: published,
+                detail: 'The timelock has passed. Collecting on the next check.',
+                blocksRemaining: 0,
+                targetHeight,
+            };
+        }
+        return {
+            phase: 'waiting',
+            headline: published,
+            // Blocks first because they are certain, duration second because
+            // it is not. Closes on what the app will do rather than implying
+            // the funds arrive on their own.
+            detail:
+                `${blocksRemaining} ${plural(blocksRemaining, 'block', 'blocks')} to go, ${approxDuration(blocksRemaining, input.blockMinutes)}. ` +
+                'You can close the app. We will tell you when it is ready to collect.',
+            blocksRemaining,
+            targetHeight,
+        };
+    }
+
+    // Nothing claimable, nothing waiting, nothing processing. Either the drive
+    // has not read state yet this session, or the last capsules were just
+    // swept and the flag has not cleared. Both are momentary, so this says
+    // "checking" rather than asserting either one.
+    return {
+        phase: 'settling',
+        headline: 'Checking the exit status.',
+        detail: null,
+        blocksRemaining: null,
+        targetHeight: null,
+    };
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -58,6 +58,8 @@ export type {
 } from './history';
 
 export { fetchChainTipHeight, blocksToDays, AVG_BLOCK_MINUTES } from './chainTip';
+export { summariseExitPhase, approxDuration } from './exitPhaseSummary';
+export type { ExitPhase, ExitPhaseInput, ExitPhaseSummary } from './exitPhaseSummary';
 
 export { syncArkWallet } from './sync';
 

--- a/tests/unit/exitPhaseSummary.test.ts
+++ b/tests/unit/exitPhaseSummary.test.ts
@@ -1,0 +1,165 @@
+import {
+  summariseExitPhase,
+  approxDuration,
+  type ExitPhaseInput,
+} from '../../src/services/ark/exitPhaseSummary';
+
+const TIP = 963_500;
+const base: ExitPhaseInput = {
+  claimableCount: 0,
+  awaitingHeights: [],
+  processingCount: 0,
+  tipHeight: TIP,
+  blockMinutes: 10,
+};
+const at = (o: Partial<ExitPhaseInput>) => summariseExitPhase({ ...base, ...o });
+
+describe('which phase the exit is in', () => {
+  // The defect: one sentence for the entire two-day run, so a stalled exit and
+  // a working one looked identical.
+
+  it('publishing while any capsule still needs a broadcast', () => {
+    const r = at({ processingCount: 2 });
+    expect(r.phase).toBe('publishing');
+    expect(r.headline).toContain('2 capsules');
+  });
+
+  it('waiting once every capsule is out of the app\'s hands', () => {
+    const r = at({ awaitingHeights: [963_600, 963_652] });
+    expect(r.phase).toBe('waiting');
+  });
+
+  it('ready as soon as anything is collectable', () => {
+    const r = at({ claimableCount: 1 });
+    expect(r.phase).toBe('ready');
+  });
+
+  it('ranks ready above everything still in flight behind it', () => {
+    // Something can be collected NOW, which is true whatever else is pending.
+    expect(at({ claimableCount: 1, processingCount: 3, awaitingHeights: [963_600] }).phase)
+      .toBe('ready');
+  });
+
+  it('ranks publishing above waiting, because the app is load-bearing there', () => {
+    // If ANY capsule still needs a broadcast, the copy must not release the
+    // user. Getting this order wrong tells someone to close the app during the
+    // one phase that stops without them.
+    const r = at({ processingCount: 1, awaitingHeights: [963_600, 963_652] });
+    expect(r.phase).toBe('publishing');
+    expect(`${r.headline} ${r.detail}`).toContain('Keep the app open');
+  });
+
+  it('says it is checking rather than guessing when it knows nothing yet', () => {
+    expect(at({}).phase).toBe('settling');
+  });
+});
+
+describe('the countdown: blocks are the truth, time is the estimate', () => {
+  it('counts to the LAST capsule, which is what the claim batches on', () => {
+    // The sweep holds for the stragglers so the exit lands as one payment, so
+    // the figure shown must be the figure actually being waited for.
+    const r = at({ awaitingHeights: [963_534, 963_599, 963_652] });
+    expect(r.targetHeight).toBe(963_652);
+    expect(r.blocksRemaining).toBe(152);
+  });
+
+  it('leads with blocks and follows with an approximation', () => {
+    const r = at({ awaitingHeights: [TIP + 6] });
+    expect(r.detail).toContain('6 blocks to go');
+    expect(r.detail).toContain('about 60 min');
+  });
+
+  it('never shows seconds, at any distance', () => {
+    // Block intervals are exponential: a seconds countdown stalls and then
+    // jumps, including backwards, and reads as a broken timer.
+    for (const blocks of [1, 6, 20, 144, 1000]) {
+      expect(approxDuration(blocks, 10)).not.toMatch(/\bsec|\d+:\d\d/);
+    }
+  });
+
+  it('hedges every duration it prints', () => {
+    for (const blocks of [1, 6, 144, 4032]) {
+      expect(approxDuration(blocks, 10)).toMatch(/about|under/);
+    }
+  });
+
+  it('coarsens as the distance grows', () => {
+    expect(approxDuration(6, 10)).toBe('about 60 min');
+    expect(approxDuration(144, 10)).toBe('about 24 hours');
+    expect(approxDuration(4032, 10)).toBe('about 28 days');
+  });
+
+  it('never counts below zero once the tip has crossed', () => {
+    const r = at({ awaitingHeights: [TIP - 20] });
+    expect(r.blocksRemaining).toBe(0);
+    expect(r.detail).toContain('timelock has passed');
+  });
+
+  it('withholds a figure while anything is still broadcasting', () => {
+    // A capsule with no ripening height yet can push the finish line out when
+    // its leaf confirms, so any number here would be a floor shown as an
+    // answer. Observed live: a late leaf moved the batch from 963599 to 963652.
+    const r = at({ processingCount: 1, awaitingHeights: [963_600] });
+    expect(r.blocksRemaining).toBeNull();
+    expect(r.targetHeight).toBeNull();
+  });
+
+  it('names the remedy instead of the internal state when no tip is known', () => {
+    const r = at({ awaitingHeights: [963_652], tipHeight: null });
+    expect(r.blocksRemaining).toBeNull();
+    expect(r.detail).toContain('cellular');
+  });
+
+  it('ignores a missing or zero ripening height rather than counting from it', () => {
+    const r = at({ awaitingHeights: [0, 963_652, Number.NaN] });
+    expect(r.targetHeight).toBe(963_652);
+  });
+});
+
+describe('copy contract', () => {
+  const all = [
+    at({ processingCount: 2 }),
+    at({ processingCount: 1, awaitingHeights: [963_600] }),
+    at({ awaitingHeights: [963_652] }),
+    at({ awaitingHeights: [963_652], tipHeight: null }),
+    at({ awaitingHeights: [TIP - 5] }),
+    at({ claimableCount: 2 }),
+    at({ claimableCount: 1, processingCount: 2 }),
+    at({}),
+  ];
+
+  it('never promises the exit finishes by itself', () => {
+    // The drive is foreground-only. The countdown ends at "ready to collect",
+    // never at "done". This is the sentence class that made #196 a bug.
+    for (const r of all) {
+      const text = `${r.headline} ${r.detail ?? ''}`.toLowerCase();
+      expect(text).not.toMatch(/automatic|by itself|on its own|sweeps? automatically/);
+    }
+  });
+
+  it('releases the user only once the chain is doing the work', () => {
+    // Safe to leave ONLY when every capsule is waiting out its CSV.
+    expect(at({ awaitingHeights: [963_652] }).detail).toContain('close the app');
+    for (const r of [at({ processingCount: 1 }), at({ claimableCount: 1 })]) {
+      expect(`${r.headline} ${r.detail ?? ''}`).not.toContain('close the app');
+    }
+  });
+
+  it('uses no em dashes anywhere', () => {
+    for (const r of all) {
+      expect(r.headline).not.toContain('—');
+      expect(r.detail ?? '').not.toContain('—');
+    }
+  });
+
+  it('always gives the user a headline', () => {
+    for (const r of all) expect(r.headline.length).toBeGreaterThan(0);
+  });
+
+  it('agrees with itself on singular and plural', () => {
+    expect(at({ processingCount: 1 }).headline).toContain('1 capsule.');
+    expect(at({ processingCount: 3 }).headline).toContain('3 capsules');
+    expect(at({ awaitingHeights: [TIP + 1] }).detail).toContain('1 block to go');
+    expect(at({ awaitingHeights: [TIP + 2] }).detail).toContain('2 blocks to go');
+  });
+});


### PR DESCRIPTION
## The problem

The exit panel showed one sentence for the entire run:

> `N sats pending exit. Broadcasting, then a ~24h timelock. Reopen the app after that to collect; it does not progress while closed.`

The amount was honest and decremented as claims landed. The sentence never changed. So for two days **a stalled exit and a working one were indistinguishable**, on the path a user takes precisely when they believe the server is hostile.

## The change

The amount stays where it was. What is happening to it becomes a phase, derived from the per-capsule exit records.

| phase | when | what the copy does |
|---|---|---|
| publishing | some capsule still `Processing` | asks the user to stay, because the app must broadcast the next tree level |
| waiting | every capsule sitting out its CSV | releases the user and gives a real countdown, because the chain does this work with or without the app |
| ready | something `isClaimable` | says the sweep fires from the open app |

Ranking matters. `ready` outranks everything, because something can be collected now whatever else is behind it. `publishing` outranks `waiting`, because if any capsule still needs a broadcast the app is load-bearing and the copy must not tell the user to leave. Both orderings are pinned by tests.

## Costs no requests

Both inputs were already in hand. The panel already polled `getExitVtxos()` every 10s and threw away everything except the sats total, and the chain tip has been live in the store since the drive started polling it itself (#204 / #219). That matters because chain-source budget is the exit's scarcest resource, which is the whole subject of #194.

## Blocks are the truth, time is the estimate

- Block count leads, duration follows as an approximation, and **there are no seconds anywhere**. Block intervals are exponentially distributed, so a seconds countdown stalls visibly and then jumps, including backwards, which reads as a broken timer rather than an honest estimate.
- The count targets the **last** capsule to ripen, which is the same height the claim batches on, so the number shown is the number actually being waited for.
- While anything is still broadcasting, **no figure is shown at all**. A late leaf can push the finish line out, as one did live when it moved a batch from 963599 to 963652. A floor presented as an answer is worse than no answer.
- No tip means no chain source answered, so it names the remedy (try cellular) rather than the internal state.

## Copy contract, enforced by tests

- No phase promises the exit completes on its own. The countdown ends at "ready to collect", never at "done". That sentence class is what made #196 a bug.
- Only the waiting phase tells the user they can close the app.
- No seconds, no em dashes, always a headline, singular and plural agree.

The wording is a first pass and is meant to be rewritten to taste. The constraints above are the part that matters, and they are the part that is tested.

## Testing

- 20 new unit tests. Decision logic is pure and import-free, matching `exitClaimBatch.ts` and `exitDriveCadence.ts`, so wording and thresholds are testable without the SDK or the sync loop.
- Full suite: 59 suites, 689 passing, against 58 / 669 on main.
- `tsc` 402, identical to main, and the unique-error-kind diff against main is empty.
- Falls back to the previous static sentence until the first poll returns, so a cold launch with the vault still locked is never blank.

Not yet seen against a live exit. Refs #200, #196.