### PR TITLE
chore(release): 0.1.8, iOS build 19, and one source of truth for the build number

### DIFF
--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -1172,7 +1172,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWallet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;
@@ -1196,7 +1196,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.7;
+				MARKETING_VERSION = 0.1.8;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1227,7 +1227,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWalletRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;
@@ -1246,7 +1246,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.7;
+				MARKETING_VERSION = 0.1.8;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1404,7 +1404,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = ZJTFQCTLVX;
@@ -1455,7 +1455,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = ZJTFQCTLVX;
@@ -1495,7 +1495,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWallet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;
@@ -1550,7 +1550,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWalletRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -119,7 +119,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypherbox",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypherbox",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypherbox",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Unblocks the first iOS archive of 0.1.8. 65 PRs have landed since v0.1.7-vc35 and none of them has run in a Release build, because Debug sets `SKIP_BUNDLING=1` and never exercises the embedded bundle path.

## Marketing version

0.1.7 to 0.1.8 in `package.json`, the lockfile's two root entries, and the app target's `MARKETING_VERSION`.

The Watch and Stickers targets keep their legacy `1.0` and `6.5.0`. They have shipped that way for every release and this is not the change to start moving them.

## Build number drift, fixed

This is the part worth reading.

The main app target reads `INFOPLIST_FILE = BlueWallet/Info.plist`, which hardcoded `CFBundleVersion` as a **literal 17**, last touched in the 0.1.5 bump. Every other target reads `$(CURRENT_PROJECT_VERSION)`, which had since moved to 18:

| target | CFBundleVersion source | value before |
|---|---|---|
| BlueWallet (app) | literal in Info.plist | **17** |
| Watch, Watch Extension, Stickers, Widgets | `$(CURRENT_PROJECT_VERSION)` | **18** |

So the app and its own extensions were carrying different build numbers, and the pbxproj value that looked authoritative never reached the app.

`Info.plist` now uses `$(CURRENT_PROJECT_VERSION)` like the other four. That same file already used `$(MARKETING_VERSION)` for `CFBundleShortVersionString`, so substitution is known to work in this exact plist. This just stops one field being the exception.

**Build number goes to 19, not 18.** It has to clear both previous values, because which one actually reached TestFlight depends on the target, and an upload at or below an existing build is rejected outright.

## Android untouched

`versionCode 35` / `versionName "0.1.7"` deliberately unchanged. Android is parked until iOS is done, and this bump exists to unblock an iOS archive. It will need its own bump when Android resumes.

## Checks

- `npm ci --dry-run` resolves cleanly against the edited lockfile.
- Lockfile diff is 2 lines, both the root version field. No dependency movement.
- Full suite: 59 suites, 689 passing, unchanged from main.
- Exactly 4 files touched.