### PR TITLE
build(android): target SDK 36 (Android 16) for Google Play compliance

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
 # Building Cypher Box
 
-Cypher Box is a React Native (RN 0.76, New Architecture) Bitcoin wallet. This
+Cypher Box is a React Native (RN 0.77.3, New Architecture) Bitcoin wallet. This
 document covers the Android and iOS builds, and the **reproducible** Android
 build path that lets anyone verify a Play Store release rebuilds from source
 (security-plan §11.1, walletscrutiny goal §13).
@@ -16,20 +16,21 @@ publish the source commit SHA only.
 | Component | Version | Source of truth |
 |---|---|---|
 | JDK | Temurin 17 (LTS) | `android/*` compiled with 17 |
-| Gradle | 8.10.2 | `android/gradle/wrapper/gradle-wrapper.properties` |
-| Android Gradle Plugin | 8.6.0 | resolved via the RN gradle plugin |
-| Kotlin | 1.9.25 | `android/build.gradle` (`ext.kotlinVersion`) |
-| compileSdk / targetSdk | 35 / 34 | `android/build.gradle` |
+| Gradle | 8.11.1 | `android/gradle/wrapper/gradle-wrapper.properties` |
+| Android Gradle Plugin | 8.10.1 | `android/build.gradle` (pinned; overrides RN plugin's 8.7.2) |
+| Kotlin | 2.0.21 | `android/build.gradle` (`ext.kotlinVersion`) |
+| compileSdk / targetSdk | 36 / 36 | `android/build.gradle` |
 | minSdk | 24 | `android/build.gradle` |
-| build-tools | 35.0.0 | `android/build.gradle` |
-| NDK | 26.1.10909125 | `android/build.gradle` (`ext.ndkVersion`) |
-| CMake | 3.22.1 | RN 0.76 default |
+| build-tools | 36.0.0 | `android/build.gradle` |
+| NDK | 27.1.12297006 | `android/build.gradle` (`ext.ndkVersion`) |
+| CMake | 3.22.1 | RN 0.77 default |
 | Node | 22.22.3 (LTS) | dev pin `node@22` (see `CLAUDE.md`) |
 
 > The security plan §11.1 names build-tools 34.0.0 and Node 18.x. Two
-> intentional deviations: the project compiles against **SDK 35**, and **Node
-> 18 is EOL (2025-04)** while RN 0.76's hermes post-build tooling is validated
-> on `node@22` in this repo. The pinned versions above are the real ones.
+> intentional deviations: the project compiles against **SDK 36** (Android 16,
+> the Google Play targetSdk requirement), and **Node 18 is EOL (2025-04)** while
+> RN 0.77's hermes post-build tooling is validated on `node@22` in this repo.
+> The pinned versions above are the real ones.
 
 ---
 
@@ -47,7 +48,7 @@ publish the source commit SHA only.
 
 ## 3. Android - standard build
 
-Always run codegen first (RN 0.76 has a cold-build `build.ninja` race):
+Always run codegen first (RN 0.77 has a cold-build `build.ninja` race):
 
 ```sh
 export ANDROID_HOME="$HOME/Library/Android/sdk"
@@ -103,11 +104,11 @@ make repro-verify    # build twice, assert the two SHA-256s match
 ## 5. node_modules source fixes (`scripts/fix-compile-sdk.sh`)
 
 This branch needs a handful of small source fixes in third-party packages to
-build on RN 0.76 / Gradle 8. They are applied deterministically at
+build on RN 0.77 / Gradle 8. They are applied deterministically at
 `postinstall` time by `scripts/fix-compile-sdk.sh` (idempotent seds), so they
 survive `npm ci` and run identically in the container:
 
-1. **compileSdkVersion** bumped to 35 in any lib still pinning < 30 (AGP 8).
+1. **compileSdkVersion** bumped to 36 in any lib still pinning < 30 (AGP 8).
 2. **react-native-widget-center** - `classifier = '...'` -> `archiveClassifier.set('...')` (the `classifier` Jar property was removed in Gradle 8).
 3. **rn-ldk** - `RnLdk_kotlinVersion` 1.3.50 -> 1.6.0, and `promise.reject(e.message)` -> `promise.reject(e)` (String? vs String on RN 0.76).
 4. **react-native-nitro-modules** - `ReactModuleInfo(...)` named args -> positional, so it binds to RN 0.76's constructor (the named form only exists on RN >= 0.77). This keeps the `react-native-mmkv` / `nitro-modules` pair on their locked versions.
@@ -229,10 +230,10 @@ these still need closing:
 
 ## 8. iOS (not reproducible)
 
-- Min deployment target iOS 15.1 (RN 0.76).
+- Min deployment target iOS 15.1 (RN 0.77).
 - Pin Xcode's Node to `node@22` in `ios/.xcode.env.local` (gitignored):
   `echo 'export NODE_BINARY=/opt/homebrew/opt/node@22/bin/node' > ios/.xcode.env.local`
-  (RN 0.76's hermes script crashes on Node 25/26).
+  (RN 0.77's hermes script crashes on Node 25/26).
 - `cd ios && pod install`, then archive in Xcode. Apple re-signs on upload, so
   we publish the source commit SHA only.
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,17 +8,23 @@
 #
 # Pinned toolchain (must match android/build.gradle + gradle-wrapper.properties):
 #   JDK ........ Temurin 17 (LTS)         android/* is compiled with 17
-#   Gradle ..... 8.10.2 (via ./gradlew)   android/gradle/wrapper/*.properties
-#   SDK ........ platforms;android-35, build-tools;35.0.0   android/build.gradle
-#   NDK ........ 26.1.10909125            android/build.gradle ext.ndkVersion
-#   CMake ...... 3.22.1                   RN 0.76 default
+#   Gradle ..... 8.11.1 (via ./gradlew)   android/gradle/wrapper/*.properties
+#   SDK ........ platforms;android-36, build-tools;36.0.0   android/build.gradle
+#   NDK ........ 27.1.12297006            android/build.gradle ext.ndkVersion
+#   CMake ...... 3.22.1                   RN 0.77 default
 #   Node ....... 22.22.3 (LTS)            matches the dev pin (CLAUDE.md node@22)
-#   AGP ........ 8.6.0                    resolved via the RN gradle plugin
-#   Kotlin ..... 1.9.25                   android/build.gradle
+#   AGP ........ 8.10.1                   pinned in android/build.gradle (overrides RN plugin's 8.7.2)
+#   Kotlin ..... 2.0.21                   android/build.gradle
+#
+# AGP, Gradle and Kotlin are fetched by Gradle at build time from the pins above;
+# only the SDK platform, build-tools and NDK are baked into this image. A few
+# third-party RN libs pin their own older compileSdk (33/34/35); AGP auto-downloads
+# those platforms at build time (checksummed, so still deterministic).
 #
 # DEVIATIONS from the literal §11.1 prompt, intentional (see BUILD.md):
-#   * build-tools 35.0.0, not 34.0.0 - the project compiles against SDK 35.
-#   * Node 22.22.3, not 18.x - Node 18 reached EOL (2025-04); RN 0.76's hermes
+#   * build-tools 36.0.0, not 34.0.0 - the project compiles against SDK 36
+#     (Android 16, the Google Play targetSdk requirement).
+#   * Node 22.22.3, not 18.x - Node 18 reached EOL (2025-04); RN 0.77's hermes
 #     post-build tooling is validated on node@22 in this repo (CLAUDE.md).
 #
 # HARDENING STATUS:
@@ -85,9 +91,9 @@ ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tool
 RUN yes | sdkmanager --licenses >/dev/null \
     && sdkmanager --install \
        "platform-tools" \
-       "platforms;android-35" \
-       "build-tools;35.0.0" \
-       "ndk;26.1.10909125" \
+       "platforms;android-36" \
+       "build-tools;36.0.0" \
+       "ndk;27.1.12297006" \
        "cmake;3.22.1" >/dev/null \
     && echo "sdk.dir=${ANDROID_HOME}" # informational
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,9 +4,9 @@ buildscript {
     ext {
         minSdkVersion = 24
         supportLibVersion = "28.0.0"
-        buildToolsVersion = "35.0.0"
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        buildToolsVersion = "36.0.0"
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         googlePlayServicesVersion = "16.+"
         googlePlayServicesIidVersion = "16.0.1"
         firebaseVersion = "17.3.4"
@@ -22,7 +22,13 @@ buildscript {
         maven { url 'https://www.jitpack.io' }
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        // AGP pinned explicitly for compileSdk/targetSdk 36 (Android 16). React
+        // Native 0.77.3's gradle plugin only provides AGP 8.7.2, whose max tested
+        // API is 35; 8.10.x is the first AGP whose max tested API is 36, so no
+        // android.suppressUnsupportedCompileSdk flag is needed. 8.10.x requires
+        // Gradle 8.11.1 (see gradle/wrapper/gradle-wrapper.properties). The RN 0.77
+        // plugin lineage runs fine on this AGP (RN 0.81 ships AGP 8.11.0 on it).
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("com.bugsnag:bugsnag-android-gradle-plugin:5.8.2")
         classpath 'com.google.gms:google-services:4.4.0'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -41,7 +41,6 @@ newArchEnabled=true
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
 android.resources.ignoreVersionConflict=true
-android.suppressUnsupportedCompileSdk=35
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Wed Jan 31 18:53:13 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scripts/fix-compile-sdk.sh
+++ b/scripts/fix-compile-sdk.sh
@@ -19,8 +19,8 @@ find node_modules/*/android/build.gradle node_modules/@*/*/android/build.gradle 
     ver=$(grep -o "compileSdkVersion [0-9]*" "$f" | head -1 | awk '{print $2}')
     if [ -n "$ver" ] && [ "$ver" -lt 30 ]; then
       mod=$(echo "$f" | sed 's|node_modules/||' | sed 's|/android/build.gradle||')
-      sedi "s/compileSdkVersion $ver/compileSdkVersion 35/" "$f"
-      echo "  Fixed $mod: $ver -> 35"
+      sedi "s/compileSdkVersion $ver/compileSdkVersion 36/" "$f"
+      echo "  Fixed $mod: $ver -> 36"
     fi
   fi
 done
@@ -28,7 +28,7 @@ done
 # Fix Gradle 8 incompatibility: the `classifier` property was removed from the
 # Jar task in Gradle 8. react-native-widget-center's androidJavadocJar /
 # androidSourcesJar tasks still set `classifier = '...'`, which fails at
-# configuration time on this branch (Gradle 8.10.2 / RN 0.76). Rewrite to
+# configuration time on this branch (Gradle 8.11.1 / RN 0.77). Rewrite to
 # archiveClassifier.set('...'). Idempotent: the grep guard skips the file once
 # it has already been rewritten, so re-running postinstall is a no-op.
 # NOTE: patch-package is intentionally NOT used here. patches/ holds an inert

--- a/walletscrutiny/build.sh
+++ b/walletscrutiny/build.sh
@@ -133,7 +133,7 @@ echo "==> [3/4] deriving universal APK via bundletool ${BT_VER}"
   cd /out
   curl -fsSLo bundletool.jar https://github.com/google/bundletool/releases/download/${BT_VER}/bundletool-all-${BT_VER}.jar
   echo '${BT_SHA}  bundletool.jar' | sha256sum -c -
-  AAPT2=\$(ls \"\$ANDROID_HOME\"/build-tools/35.0.0/aapt2)
+  AAPT2=\$(ls \"\$ANDROID_HOME\"/build-tools/36.0.0/aapt2)
   java -jar bundletool.jar build-apks --bundle=app-release.aab --output=built.apks \
     --mode=universal --aapt2=\"\$AAPT2\"
   unzip -o -p built.apks universal.apk > built-universal.apk


### PR DESCRIPTION
Play stops accepting updates from **Aug 31 2026** for apps whose target API is more than a year behind the latest Android release. Ours is 35, so this is a hard deadline rather than housekeeping.

## The change

| | before | after |
|---|---|---|
| compileSdk / targetSdk | 35 | **36** |
| buildTools | 35.0.0 | **36.0.0** |
| AGP | unpinned, RN plugin's 8.7.2 | **8.10.1** |
| Gradle | 8.10.2 | **8.11.1** |

AGP is pinned explicitly because React Native 0.77.3's gradle plugin supplies 8.7.2, whose max tested API is 35. AGP 8.10.x is the first whose max tested API is 36, which is why `android.suppressUnsupportedCompileSdk` is **removed** rather than bumped to 36: with a properly matched AGP there is nothing left to suppress. AGP 8.10.x in turn requires Gradle 8.11.1.

The RN 0.77 plugin lineage runs fine on this AGP; RN 0.81 ships AGP 8.11.0 on it.

Gradle 8.11.1 lands in its own wrapper cache. **8.10.2 stays on disk** for branches that still need it.

## Why four files carry the same version numbers

`Dockerfile.build`, `walletscrutiny/build.sh` (its hardcoded `aapt2` path) and `scripts/fix-compile-sdk.sh` all pin the SDK and build-tools alongside `android/build.gradle`. The reproducible build asserts an **identical SHA-256 across two container runs**, so a version that disagrees between the image and the gradle config breaks determinism rather than just looking untidy. They are updated together here.

This is also why build-tools stays at exactly `36.0.0` rather than moving to a newer point release: the image bakes that version and walletscrutiny resolves `aapt2` from that exact path.

## Reconciled against current main

This was originally authored on 2026-08-11 and main has moved a long way since. On re-applying:

- the **NDK bump to 27.1.12297006 has landed independently**, so only the Dockerfile's comment needed updating, not the gradle value
- the Gradle and RN versions named in the `fix-compile-sdk.sh` header are corrected to match what this commit actually sets, since leaving them would have left a comment contradicting the config beside it

The cherry-pick applied without conflicts.

## Verification

Local verification is limited by design: `compileSdk 36` resolves to a `platforms/android-36` SDK directory, and building it on a dev machine proves nothing about the container that actually ships. **CI is the verifier here** since it builds in the pinned image and runs the determinism check.

Worth watching on this PR specifically: the reproducible-build job passing means the new AGP, Gradle and SDK combination configures, compiles and stays byte-identical across two runs. That is the real signal.

## Not included

The Android `versionCode` is still 35 and `versionName` still 0.1.7. Play rejects a reused versionCode, so a release-prep bump is still required before any upload, along with signing. Deliberately kept out of a build-config change.

Also untested here: **Android 16 runtime behaviour**. targetSdk 36 turns on behaviour changes such as enforced edge-to-edge, and those only surface when running on an Android 16 device. The test hardware on hand is a Galaxy A14 on Android 15, so this PR proves the app builds and stays deterministic at targetSdk 36, not that it looks right on Android 16. That wants an Android 16 device or emulator and should not block the compliance deadline.