### PR TITLE
chore(release): Android versionCode 36, versionName 0.1.8

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,8 +99,8 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 35
-        versionName "0.1.7"
+        versionCode 36
+        versionName "0.1.8"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         missingDimensionStrategy 'react-native-camera', 'general' //add this line


### PR DESCRIPTION
Brings Android in line with the 0.1.8 bump that already landed for iOS and `package.json` in #238.

```
versionCode  35 -> 36
versionName  0.1.7 -> 0.1.8
```

All three now agree: `package.json` 0.1.8, iOS `MARKETING_VERSION` 0.1.8 (build 19), Android 0.1.8 / 36.

## Why 36

Play rejects a reused `versionCode`, and **35 is spent**: it shipped as `v0.1.7-vc35`, the current latest GitHub release. Checked every release tag; the highest code in use is 35, so 36 is the next free value.

One caveat I cannot check from here: if anything was ever pushed to a Play **internal or closed test track** with a code above 35, that would not appear in the repo's tags or releases. Worth a glance at the Play Console before uploading.

## Scope

Config only. Signing and upload are unchanged by this and remain a release-user step.

Unit tests, `tsc` and the reproducible build are unaffected: this touches no JS and no toolchain pin, only two literals in `defaultConfig`.

## Unrelated finding, deliberately not fixed here

`scripts/build-release-apk.sh` is **referenced by nothing**: not `package.json`, `RELEASE.md`, `BUILD.md`, any workflow, or the Makefile. It contains:

```sh
TIMESTAMP=$(date +%s)
sed -i '' "s/versionCode [0-9]*/versionCode $TIMESTAMP/g" app/build.gradle
```

That sets `versionCode` to a Unix timestamp, currently around **1.79 billion**. Play requires monotonically increasing codes, so running that script once would strand the sequential scheme permanently: every future code below the timestamp would be rejected, and the ceiling is 2,100,000,000.

It also does `grep -v "Password" keystore.properties`, printing the rest of that file to stdout.

Raising it rather than fixing it, since deleting a script is a separate decision from a version bump. Worth removing or gutting.