### PR TITLE
fix(android): inset the bottom edge, so Android 16 does not put buttons under the nav bar

### DIFF
--- a/src/component-library/ScreenLayout/index.tsx
+++ b/src/component-library/ScreenLayout/index.tsx
@@ -4,12 +4,41 @@ import {
   View,
   ScrollView,
   StyleSheet,
+  Platform,
   RefreshControlProps,
   TouchableOpacity,
   StatusBar,
   StatusBarStyle,
   Image,
 } from 'react-native';
+
+/**
+ * Which sides get an inset when a screen does not name its own.
+ *
+ * Android 16 (targetSdk 36) ENFORCES edge-to-edge and removed the
+ * windowOptOutEdgeToEdgeEnforcement escape hatch, so the app draws behind the
+ * system bars whether it asks to or not. Without a bottom inset, the last
+ * element on a screen sits under the navigation bar or the gesture pill, which
+ * is worst for the buttons that tend to live there: partly covered, and in the
+ * gesture strip where swipes get intercepted before the button sees them.
+ *
+ * 81 of the screens in this app render through ScreenLayout and none of them
+ * pass their own `edges`, so this default is the only thing standing between
+ * them and that.
+ *
+ * ANDROID ONLY, deliberately. On iOS a bottom inset also pads for the home
+ * indicator, which would shift the layout of every one of those screens. iOS
+ * has no edge-to-edge enforcement to answer for, so it keeps the existing
+ * three sides and stays visually unchanged.
+ *
+ * Safe on older Android: react-native-safe-area-context reports a bottom inset
+ * of 0 when the app is not drawing behind the navigation bar, so this is inert
+ * below Android 16 and correct on it.
+ */
+const DEFAULT_EDGES: ReadonlyArray<'top' | 'bottom' | 'left' | 'right'> =
+  Platform.OS === 'android'
+    ? ['right', 'left', 'top', 'bottom']
+    : ['right', 'left', 'top'];
 
 // *** Third Party Import
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -169,7 +198,7 @@ function ScreenLayout({
   return (
     <View style={styles.inner}>
       <SafeAreaView
-        edges={edges ? edges : ['right', 'left', 'top']}
+        edges={edges ? edges : DEFAULT_EDGES}
         style={StyleSheet.flatten([styles.inner, style])}>
         <StatusBar backgroundColor={colors.primary} barStyle={barStyle} />
         {renderContent()}


### PR DESCRIPTION
Follow-up to #239. targetSdk 36 is now on main, so this is the behaviour change that lands with it.

## What breaks without this

Android 16 **enforces** edge-to-edge and removed the `windowOptOutEdgeToEdgeEnforcement` escape hatch. The app draws behind the system bars whether it asks to or not.

`ScreenLayout` insets right, left and top:

```js
edges={edges ? edges : ['right', 'left', 'top']}
```

No bottom. So the last element on a screen ends up under the navigation bar or the gesture pill. That is worst for the buttons that tend to live at the bottom of a screen: partly covered, and sitting in the gesture strip where a swipe gets intercepted before the button sees it.

## Why this default matters so much

Measured on main:

| | |
|---|---|
| screen components | 112 |
| rendering through `ScreenLayout` | **81** |
| passing their own `edges` | **0** |
| handling a bottom inset anywhere else in `src/` | 1 (`ActivityDropdown`) |

Since no screen overrides it, this one default is the only thing standing between 81 screens and that outcome.

## Android only, deliberately

On iOS a bottom inset also pads for the home indicator, so applying it unconditionally would shift the layout of all 81 screens, on a build that has already been archived at 0.1.8 build 19. iOS has no edge-to-edge enforcement to answer for, so it keeps the existing three sides and is byte-identical.

Inert on older Android too: `react-native-safe-area-context` reports a bottom inset of 0 when the app is not drawing behind the navigation bar, so nothing changes below Android 16.

## Verification, and its limit

- `tsc` 402, identical to main, and the unique-error-kind diff against main is **empty**
- full suite 59 suites / 689 passing, unchanged
- no em dashes, no new hosts

**Not visually verified.** That needs an Android 16 device or emulator and the hardware on hand is a Galaxy A14 on Android 15. This closes a known unhandled inset; it does not prove the result looks right. Worth an emulator pass when one is available, but shipping with the inset handled is strictly better than shipping without it.