### PR TITLE
docs(readme): read the release badge from GitHub instead of hardcoding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚡ Cypher Box - A Fun Way to Play Bitcoin
 
-[![Release](https://img.shields.io/badge/release-v0.1.7-f7931a)](https://github.com/CypherBoxLLC/Cypher-Box/releases)
+[![Release](https://img.shields.io/github/v/release/CypherBoxLLC/Cypher-Box?color=f7931a&label=release)](https://github.com/CypherBoxLLC/Cypher-Box/releases)
 [![Reproducible build](https://github.com/CypherBoxLLC/Cypher-Box/actions/workflows/build-verify.yml/badge.svg)](https://github.com/CypherBoxLLC/Cypher-Box/actions/workflows/build-verify.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Platform](https://img.shields.io/badge/platform-iOS%20%7C%20Android-lightgrey)](https://github.com/CypherBoxLLC/Cypher-Box/releases)


### PR DESCRIPTION
The release badge was a literal string:

```
https://img.shields.io/badge/release-v0.1.7-f7931a
```

So it had to be hand-edited on every release, and it was already a version behind: `v0.1.8-vc36` shipped while the README still advertised 0.1.7.

Now:

```
https://img.shields.io/github/v/release/CypherBoxLLC/Cypher-Box?color=f7931a&label=release
```

Shields resolves that from the GitHub API, so it tracks whatever the latest release actually is and cannot go stale again. Verified live, it currently renders `release: v0.1.8-vc36`. Colour is unchanged.

The other three badges were already dynamic or version-independent, and this was the only hardcoded version string in the file.