### PR TITLE
fix(ark): show broadcast progress, so a slow exit phase is not read as a stalled one

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1076,13 +1076,33 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
         const claimable = active.filter((v) => v.isClaimable);
         const awaitingHeights: number[] = [];
         let processingCount = 0;
+        // Per-TRANSACTION progress inside the broadcasting phase. Capsule counts
+        // alone leave the panel printing the same sentence for an hour while
+        // levels are actually confirming underneath, which reads as a stall.
+        // AwaitingCpfpBroadcast means its child has not gone out yet; the two
+        // Awaiting*Confirmation states mean it has and we are waiting on a block.
+        let txAwaitingBroadcast = 0;
+        let txAwaitingConfirmation = 0;
         for (const v of active) {
           if (v.isClaimable) continue;
           const h = Number(
             (v.state as { inner?: { claimableHeight?: number } })?.inner?.claimableHeight ?? 0,
           );
-          if (Number.isFinite(h) && h > 0) awaitingHeights.push(h);
-          else processingCount += 1;
+          if (Number.isFinite(h) && h > 0) {
+            awaitingHeights.push(h);
+            continue;
+          }
+          processingCount += 1;
+          const txs =
+            (v.state as { inner?: { transactions?: { status?: { tag?: string } }[] } })
+              ?.inner?.transactions ?? [];
+          for (const tx of txs) {
+            const tag = tx?.status?.tag;
+            if (tag === 'AwaitingCpfpBroadcast') txAwaitingBroadcast += 1;
+            else if (tag === 'AwaitingConfirmation' || tag === 'AwaitingInputConfirmation') {
+              txAwaitingConfirmation += 1;
+            }
+          }
         }
         // Live tip: the exit drive polls it itself and writes it here, which is
         // what made a real countdown possible (the store's tip used to freeze
@@ -1096,6 +1116,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
               claimableCount: claimable.length,
               awaitingHeights,
               processingCount,
+              txAwaitingBroadcast,
+              txAwaitingConfirmation,
               tipHeight,
               blockMinutes: AVG_BLOCK_MINUTES,
             }),

--- a/src/services/ark/exitPhaseSummary.ts
+++ b/src/services/ark/exitPhaseSummary.ts
@@ -63,6 +63,16 @@ export type ExitPhaseInput = {
     awaitingHeights: readonly number[];
     /** Capsules still broadcasting, so no ripening height exists yet. */
     processingCount: number;
+    /**
+     * Exit-tree transactions on still-broadcasting capsules whose CPFP child
+     * has NOT been published yet (`AwaitingCpfpBroadcast`).
+     */
+    txAwaitingBroadcast?: number;
+    /**
+     * Exit-tree transactions already published and waiting on a block
+     * (`AwaitingConfirmation` / `AwaitingInputConfirmation`).
+     */
+    txAwaitingConfirmation?: number;
     /** Freshest tip known, or null when no chain source answered. */
     tipHeight: number | null;
     /** Minutes per block used to turn a height into a duration. */
@@ -140,12 +150,39 @@ export function summariseExitPhase(input: ExitPhaseInput): ExitPhaseSummary {
     // Publishing outranks waiting: if ANY capsule still needs a broadcast, the
     // app is load-bearing and the copy must not tell the user to leave.
     if (processing > 0) {
+        // SUB-PROGRESS, and why it earns its place.
+        //
+        // Phase alone is not enough here. Broadcasting is the slowest phase and
+        // the one that needs the user present, and every tree level has to
+        // CONFIRM before the next can be relayed (Bitcoin Core's TRUC policy:
+        // one unconfirmed parent, one child, and the CPFP anchor takes that
+        // slot). So the phase legitimately sits unchanged for an hour while
+        // real work happens underneath.
+        //
+        // Observed live 2026-08-28: three capsules went from
+        // AwaitingCpfpBroadcast, to a confirmed shared parent, to one published
+        // and awaiting a block, and the panel printed the same sentence
+        // throughout. From the user's side that is indistinguishable from a
+        // wedged exit, which is the exact confusion this panel exists to remove.
+        //
+        // So count transactions, not just capsules. Published means the CPFP
+        // child is out: waiting on a block, or already confirmed.
+        const pending = Math.max(0, Math.floor(input.txAwaitingBroadcast ?? 0));
+        const inFlight = Math.max(0, Math.floor(input.txAwaitingConfirmation ?? 0));
+        const totalTx = pending + inFlight;
+        // "N of M" where M is only the steps visible right now. A tree reveals
+        // more levels as they confirm, so this is deliberately not a total and
+        // not a percentage.
+        const progress = totalTx > 0
+            ? `${inFlight} of ${totalTx} published, waiting on a confirmation. `
+            : '';
+        const alsoWaiting = heights.length > 0
+            ? `${heights.length} ${plural(heights.length, 'capsule is', 'capsules are')} already through and waiting out the timelock. `
+            : '';
         return {
             phase: 'publishing',
             headline: `Publishing exit transactions for ${processing} ${plural(processing, 'capsule', 'capsules')}.`,
-            detail: heights.length > 0
-                ? `${heights.length} already published and waiting out the timelock. Keep the app open, each step needs it.`
-                : 'Keep the app open, each step needs it.',
+            detail: `${progress}${alsoWaiting}Each step needs a confirmation before the next can go, so this is slow. Keep the app open.`,
             // A capsule with no ripening height yet can push the finish line
             // out once its leaf confirms, so any figure here would be a floor
             // presented as an answer. Withheld rather than guessed.

--- a/tests/unit/exitPhaseSummary.test.ts
+++ b/tests/unit/exitPhaseSummary.test.ts
@@ -163,3 +163,56 @@ describe('copy contract', () => {
     expect(at({ awaitingHeights: [TIP + 2] }).detail).toContain('2 blocks to go');
   });
 });
+
+describe('broadcast sub-progress, so a slow phase is not mistaken for a stalled one', () => {
+  // Live 2026-08-28: three capsules went AwaitingCpfpBroadcast -> confirmed
+  // shared parent -> one published and awaiting a block, over an hour, and the
+  // panel printed the same sentence the whole time. Every level has to confirm
+  // before the next can be relayed, so the phase legitimately does not move.
+
+  it('reports how many transactions are published', () => {
+    const r = at({ processingCount: 3, txAwaitingBroadcast: 2, txAwaitingConfirmation: 1 });
+    expect(r.phase).toBe('publishing');
+    expect(r.detail).toContain('1 of 3 published');
+  });
+
+  it('moves as each one goes out, which is the whole point', () => {
+    const a = at({ processingCount: 3, txAwaitingBroadcast: 3, txAwaitingConfirmation: 0 });
+    const b = at({ processingCount: 3, txAwaitingBroadcast: 1, txAwaitingConfirmation: 2 });
+    expect(a.detail).toContain('0 of 3 published');
+    expect(b.detail).toContain('2 of 3 published');
+    expect(a.detail).not.toBe(b.detail);
+  });
+
+  it('still explains the slowness, so the user knows it is expected', () => {
+    const r = at({ processingCount: 2, txAwaitingBroadcast: 1, txAwaitingConfirmation: 1 });
+    expect(r.detail).toContain('confirmation before the next');
+    expect(r.detail).toContain('Keep the app open');
+  });
+
+  it('mentions capsules already through to the timelock', () => {
+    const r = at({ processingCount: 3, txAwaitingBroadcast: 2, txAwaitingConfirmation: 1, awaitingHeights: [963_652] });
+    expect(r.detail).toContain('1 capsule is already through');
+  });
+
+  it('omits the count rather than printing 0 of 0 when the SDK gave nothing', () => {
+    // Older records, or a tick that returned no transaction list.
+    const r = at({ processingCount: 2 });
+    expect(r.detail).not.toContain('of 0');
+    expect(r.detail).toContain('Keep the app open');
+  });
+
+  it('never claims more published than exist', () => {
+    for (const [b, c] of [[0, 0], [5, 0], [0, 5], [2, 3]]) {
+      const r = at({ processingCount: 1, txAwaitingBroadcast: b, txAwaitingConfirmation: c });
+      const m = r.detail?.match(/(\d+) of (\d+) published/);
+      if (m) expect(Number(m[1])).toBeLessThanOrEqual(Number(m[2]));
+    }
+  });
+
+  it('keeps the copy contract: no em dash, no promise it finishes alone', () => {
+    const r = at({ processingCount: 3, txAwaitingBroadcast: 2, txAwaitingConfirmation: 1 });
+    expect(r.detail).not.toContain('\u2014');
+    expect(`${r.headline} ${r.detail}`.toLowerCase()).not.toMatch(/automatic|by itself|on its own/);
+  });
+});


### PR DESCRIPTION
Follow-up to #237, from using it on a live exit.

## The gap

#237 gave the panel a phase. Broadcasting got one sentence that never changes, and that is the phase where it matters most: it is the slowest, it is the one that needs the user present, and **every tree level has to confirm before the next can be relayed**. That is Bitcoin Core's TRUC policy, one unconfirmed parent and one child, with the CPFP anchor occupying that slot.

So the phase legitimately sits still for a long time while real work happens underneath.

**Observed live on 2026-08-28.** Three capsules moved through three distinct states over roughly an hour:

```
AwaitingCpfpBroadcast  ->  shared parent Confirmed  ->  one published, awaiting a block
```

The panel printed `Publishing exit transactions for 3 capsules. Keep the app open.` the entire time. From the user's side that is indistinguishable from a wedged exit, which is exactly the confusion the phase panel was built to remove.

## The change

Count transactions, not just capsules:

```
0 of 3 published, waiting on a confirmation.  Each step needs a confirmation
before the next can go, so this is slow. Keep the app open.

2 of 3 published, waiting on a confirmation.  1 capsule is already through and
waiting out the timelock. ...
```

Published means the CPFP child is out: `AwaitingConfirmation` or `AwaitingInputConfirmation`. Not yet published is `AwaitingCpfpBroadcast`.

Saying **why** it is slow matters as much as the number. A user who knows each step waits on a block reads a still screen as expected rather than broken.

## Deliberate limits

**"N of M" is not a total and not a percentage.** M is only the steps visible right now, and a tree reveals more levels as they confirm. Calling it a total would be a second, quieter lie.

**When the SDK returns no transaction list the count is omitted**, rather than rendering `0 of 0`.

**Costs nothing.** `progressExits` already returns per-transaction status on every tick and the panel already polls it. Those counts were simply being discarded.

## Testing

- 7 new unit tests, 27 in the file: the live three-capsule case, the count advancing as transactions go out, the absent-data case, an invariant that published never exceeds total, and the existing copy contract (no em dash, never promises it finishes by itself).
- Full suite: 59 suites, 696 passing, against 59 / 690 on main.
- `tsc` 402, identical to main, empty error-kind diff.

Not yet seen on a live exit, since the exit that motivated it is mid-flight and the device is on the pre-0.1.8 build.