### PR TITLE
fix(vault): mix dice entropy with the CSPRNG, and reject degenerate rolls

### DIFF
--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -231,13 +231,45 @@ const Entropy = () => {
     },
   });
 
-  const push = v => v && dispatch({ type: 'push', value: v.value, bits: v.bits });
-  const pop = () => dispatch({ type: 'pop' });
+  // The raw face sequence, kept alongside the bit counter. The counter cannot
+  // see degeneracy: `getEntropy(face, 6)` maps a face to the same value every
+  // time, so N taps of one button push N*2 zero bits and the counter reports
+  // them as full entropy.
+  const [faces, setFaces] = useState([]);
+  const push = v => {
+    if (!v) return;
+    setFaces(f => [...f, `${v.value}:${v.bits}`]);
+    dispatch({ type: 'push', value: v.value, bits: v.bits });
+  };
+  const pop = () => {
+    setFaces(f => f.slice(0, -1));
+    dispatch({ type: 'pop' });
+  };
   const save = () => {
     if (minBits && entropy.bits < minBits) {
       Alert.alert(
         loc.entropy.title,
         `Not enough entropy yet: ${entropy.bits} of ${minBits} bits. Keep rolling until the counter reaches ${minBits}.`,
+      );
+      return;
+    }
+    // Refuse input that plainly carries no entropy, however many bits it
+    // pushed. This is a usability guard, not the security boundary: the seed
+    // is hashed with the device CSPRNG regardless, so a degenerate sequence is
+    // no longer dangerous. It is here so someone who believes they contributed
+    // 128 bits actually did, rather than being quietly carried by the RNG.
+    //
+    // Deliberately crude. It catches the cases a real die cannot produce and a
+    // bored finger easily can, and does not try to judge randomness beyond
+    // that: rejecting a legitimate but unlucky roll would be worse than
+    // accepting a lazy one that the mix already protects.
+    const distinct = new Set(faces).size;
+    if (faces.length >= 8 && distinct <= 2) {
+      Alert.alert(
+        loc.entropy.title,
+        distinct <= 1
+          ? 'Every entry is the same value, so this carries no randomness. Roll a real die and enter what it lands on.'
+          : 'These entries repeat only two values, so this carries very little randomness. Roll a real die and enter what it lands on.',
       );
       return;
     }

--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -280,6 +280,23 @@ const Entropy = () => {
 
   const hex = entropyToHex(entropy);
   const limitDisplay = limit || ENTROPY_LIMIT;
+
+  // Wording and the expected number of throws, per tab. The counter above
+  // measures BITS PUSHED, which is exactly the thing that misled people here
+  // before: it cannot tell a real roll from a repeated tap. So the screen has
+  // to say in words what the number cannot.
+  //
+  // AVG_BITS_PER_THROW is the real yield of `getEntropy`, not log2(sides).
+  // A d6 maps faces 1-4 to 2 bits and faces 5-6 to 1 bit, averaging 10/6, and
+  // a d20 maps 16 values to 4 bits and 4 values to 2 bits, averaging 3.6. The
+  // encoding is lossy but sound: the bits it does emit are uniform, so 128 of
+  // them from real throws really are 128 bits.
+  const isCoin = tab === 0;
+  const sourceNoun = isCoin ? 'coin' : 'die';
+  const landedNoun = isCoin ? 'side' : 'face';
+  const throwsNoun = isCoin ? 'flips' : 'rolls';
+  const AVG_BITS_PER_THROW = [1, 10 / 6, 3.6];
+  const typicalThrows = Math.ceil(limitDisplay / AVG_BITS_PER_THROW[tab]);
   let bits = Math.min(entropy.bits, limitDisplay).toString();
   bits = ' '.repeat(bits.length < 3 ? 3 - bits.length : 0) + bits;
 
@@ -315,7 +332,18 @@ const Entropy = () => {
       {tab === 1 && <Dice sides={6} push={push} />}
       {tab === 2 && <Dice sides={20} push={push} />}
 
-      {instruction ? <Text style={[styles.instructionText, stylesHook.entropyText]}>{instruction}</Text> : null}
+      <View style={styles.guidance}>
+        {instruction ? <Text style={[styles.instructionText, stylesHook.entropyText]}>{instruction}</Text> : null}
+        <Text style={[styles.guidanceHow, stylesHook.entropyText]}>
+          {`${isCoin ? 'Flip' : 'Roll'} a real ${sourceNoun} and tap the ${landedNoun} it lands on. About ${typicalThrows} ${throwsNoun} fills the counter.`}
+        </Text>
+        <Text style={styles.guidanceWarning}>
+          {`Tapping the same ${landedNoun} over and over, or any pattern you make up, adds no randomness. The counter cannot tell the difference, but your key can.`}
+        </Text>
+        <Text style={[styles.guidanceCalm, stylesHook.entropyText]}>
+          Your phone always mixes in its own randomness, so doing this can only make your key stronger, never weaker.
+        </Text>
+      </View>
 
       <Buttons pop={pop} save={save} colors={colors} />
     </SafeArea>
@@ -340,12 +368,33 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontFamily: 'Courier',
   },
+  guidance: {
+    marginHorizontal: 20,
+    marginBottom: 90,
+  },
   instructionText: {
     fontSize: 13,
     textAlign: 'center',
-    marginHorizontal: 20,
-    marginBottom: 90,
     opacity: 0.7,
+  },
+  guidanceHow: {
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 4,
+    opacity: 0.9,
+  },
+  guidanceWarning: {
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 10,
+    fontWeight: '600',
+    color: '#E0A030',
+  },
+  guidanceCalm: {
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: 10,
+    opacity: 0.6,
   },
   coinRoot: {
     flex: 1,

--- a/src/screens/SavingVaultIntro/index.tsx
+++ b/src/screens/SavingVaultIntro/index.tsx
@@ -7,6 +7,8 @@ import { Button, Input, ScreenLayout, Text } from "@Cypher/component-library";
 import { dispatchNavigate } from "@Cypher/helpers";
 import { colors } from "@Cypher/style-guide";
 import { HDSegwitBech32Wallet } from "../../../class";
+import { randomBytes } from "../../../class/rng";
+import crypto from 'crypto';
 import loc from '../../../loc';
 import { initialState, walletReducer } from "../../../screen/wallets/add";
 import { BlueStorageContext } from '../../../blue_modules/storage-context';
@@ -186,12 +188,37 @@ export default function SavingVaultIntro() {
       const w = new HDSegwitBech32Wallet();
       w.setLabel(label || loc.wallets.details_title);
       if (diceEntropy && diceEntropy.length >= 16) {
-        // 12-word seed from the user's own dice rolls: first 16 bytes ->
-        // bip39.entropyToMnemonic — the same library call generate() uses,
-        // minus the device RNG. Deliberately NOT generateFromEntropy(): the
-        // fork's version pads/concats to 32 bytes and would emit a 24-word
-        // seed, breaking this app's fixed-12-word recovery flow.
-        w.setSecret(bip39.entropyToMnemonic(diceEntropy.slice(0, 16).toString('hex')));
+        // 12-word seed from the user's dice rolls MIXED WITH THE DEVICE CSPRNG.
+        //
+        // The mix is not optional. The entropy screen counts BITS PUSHED, not
+        // entropy, and `getEntropy(face, 6)` returns the same value for the
+        // same face every time. So 64 taps of one button satisfied the 128-bit
+        // gate with 128 zero bits, and this line produced, verbatim:
+        //
+        //   abandon abandon abandon ... abandon about
+        //
+        // the all-zeros BIP39 test vector, which is swept within seconds of
+        // being funded. Tapping one face is also the FASTEST way to fill the
+        // counter, so this was reachable by impatience alone.
+        //
+        // Upstream never had that hole: generateFromEntropy concatenates
+        // randomBytes(32 - user.length), so all-zero dice still yielded a seed
+        // with 128 real bits. We dropped it by accident, not by design, because
+        // that concat forces 32 bytes and would emit a 24-word seed against
+        // this app's fixed-12-word recovery flow.
+        //
+        // Hashing gets both: 16 bytes out, 12 words, two sources. It also
+        // preserves the reason for rolling in the first place, since an
+        // attacker who fully controls the RNG still cannot predict the result
+        // without the dice. Safe if EITHER source is sound, rather than only if
+        // the dice are.
+        const rngBytes = await randomBytes(16);
+        const mixed = crypto
+          .createHash('sha256')
+          .update(Buffer.concat([diceEntropy.slice(0, 16), rngBytes]))
+          .digest()
+          .slice(0, 16);
+        w.setSecret(bip39.entropyToMnemonic(mixed.toString('hex')));
       } else {
         await w.generate();   // BIP39 mnemonic — ~5ms on device
       }

--- a/src/screens/SavingVaultIntro/index.tsx
+++ b/src/screens/SavingVaultIntro/index.tsx
@@ -327,7 +327,7 @@ export default function SavingVaultIntro() {
                     {diceEntropy ? (
                         <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 14 }}>
                             <Text bold style={{ color: colors.green, fontSize: 13, flex: 1 }}>
-                                ✓ 128 bits entropy generated via dice rolls
+                                ✓ Dice rolls added, mixed with your phone's randomness
                             </Text>
                             <TouchableOpacity
                                 onPress={() => setDiceEntropy(null)}
@@ -343,7 +343,6 @@ export default function SavingVaultIntro() {
                                 dispatchNavigate('ProvideEntropy', {
                                     minBits: 128,
                                     limit: 128,
-                                    instruction: 'Roll the dice 100 times and select which face it lands to build more entropy for your seedphrase',
                                     onGenerated: (buf: Buffer) => {
                                         if (buf && buf.length >= 16) setDiceEntropy(buf);
                                     },

--- a/tests/unit/diceEntropyMix.test.ts
+++ b/tests/unit/diceEntropyMix.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Dice entropy must never produce a predictable seed.
+ *
+ * The regression this pins: the entropy screen counts BITS PUSHED, not entropy,
+ * and `getEntropy(face, 6)` maps a face to the same value every time. So 64
+ * taps of one button satisfied the 128-bit gate with 128 zero bits, and feeding
+ * those straight to `entropyToMnemonic` produced the all-zeros BIP39 test
+ * vector, which is swept within seconds of being funded.
+ *
+ * Tapping one face is also the fastest way to fill the counter, so it was
+ * reachable by impatience alone.
+ */
+
+import crypto from 'crypto';
+import { eReducer, getEntropy, convertToBuffer } from '../../screen/wallets/provideEntropy';
+const bip39 = require('bip39');
+
+/** Replay d6 faces (1..6) through the real reducer. */
+const roll = (faces: number[]) => {
+    let state: any;
+    for (const face of faces) {
+        const e = getEntropy(face - 1, 6);
+        if (e) state = eReducer(state, { type: 'push', ...e });
+    }
+    return state;
+};
+
+/** The OLD behaviour: user bytes straight to a mnemonic. */
+const seedWithoutMix = (dice: Buffer) =>
+    bip39.entropyToMnemonic(dice.slice(0, 16).toString('hex'));
+
+/** The behaviour now shipped in SavingVaultIntro: hash dice WITH the CSPRNG. */
+const seedWithMix = (dice: Buffer, rng: Buffer) =>
+    bip39.entropyToMnemonic(
+        crypto.createHash('sha256').update(Buffer.concat([dice.slice(0, 16), rng])).digest()
+            .slice(0, 16).toString('hex'),
+    );
+
+const ALL_ZEROS = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+describe('the degenerate input that reached the 128-bit gate', () => {
+    const lazy = convertToBuffer(roll(Array(64).fill(1)));
+
+    it('really did satisfy the counter with zero entropy', () => {
+        expect(roll(Array(64).fill(1)).bits).toBeGreaterThanOrEqual(128);
+        expect(lazy.slice(0, 16).equals(Buffer.alloc(16))).toBe(true);
+    });
+
+    it('produced the swept all-zeros mnemonic without the mix', () => {
+        expect(seedWithoutMix(lazy)).toBe(ALL_ZEROS);
+    });
+
+    it('does NOT produce it with the mix', () => {
+        const out = seedWithMix(lazy, crypto.randomBytes(16));
+        expect(out).not.toBe(ALL_ZEROS);
+        expect(bip39.validateMnemonic(out)).toBe(true);
+        expect(out.split(' ')).toHaveLength(12);
+    });
+
+    it('gives a different seed every time even from identical dice', () => {
+        // The whole point: worthless dice are carried by the RNG.
+        const seeds = new Set(
+            Array.from({ length: 25 }, () => seedWithMix(lazy, crypto.randomBytes(16))),
+        );
+        expect(seeds.size).toBe(25);
+    });
+});
+
+describe('the mix does not weaken good dice', () => {
+    const good = crypto.randomBytes(16);
+
+    it('still yields a valid 12-word mnemonic', () => {
+        const out = seedWithMix(good, crypto.randomBytes(16));
+        expect(bip39.validateMnemonic(out)).toBe(true);
+        expect(out.split(' ')).toHaveLength(12);
+    });
+
+    it('stays unpredictable to an attacker who controls the RNG entirely', () => {
+        // The reason for rolling in the first place. With the RNG pinned to a
+        // known value, distinct dice must still give distinct seeds.
+        const pinned = Buffer.alloc(16, 0xff);
+        const seeds = new Set(
+            Array.from({ length: 25 }, () => seedWithMix(crypto.randomBytes(16), pinned)),
+        );
+        expect(seeds.size).toBe(25);
+    });
+
+    it('changes the seed when a single dice bit changes', () => {
+        const rng = crypto.randomBytes(16);
+        const flipped = Buffer.from(good);
+        flipped[0] ^= 0x01;
+        expect(seedWithMix(good, rng)).not.toBe(seedWithMix(flipped, rng));
+    });
+});


### PR DESCRIPTION
Sixty-four taps of the same die face produced this seed, verbatim:

```
abandon abandon abandon abandon abandon abandon
abandon abandon abandon abandon abandon about
```

That is the all-zeros BIP39 test vector. Funds sent to it are swept within seconds. The 128-bit counter was satisfied and Save was allowed.

## Cause

The entropy screen counts **bits pushed, not entropy**. `getEntropy(face, 6)` maps a face to the same value every time, so 64 identical taps accumulate 128 zero bits and the gate reports full entropy. Nothing downstream could tell a die from a finger, because the dice bytes went straight to `entropyToMnemonic` with no other source mixed in.

Tapping one face is also the **fastest way to fill the counter**, so this was reachable by impatience, not only by sabotage.

## Upstream never had this hole. We introduced it, and not on purpose

BlueWallet's `generateFromEntropy`:

```js
const random = await randomBytes(user.length < 32 ? 32 - user.length : 0);
const buf = Buffer.concat([user, random], 32);
```

Sixteen bytes of dice plus sixteen of CSPRNG, so all-zero dice still yield a seed with 128 real bits.

Our comment says why it went: *"Deliberately NOT generateFromEntropy(): the fork's version pads/concats to 32 bytes and would emit a 24-word seed, breaking this app's fixed-12-word recovery flow."* The RNG was dropped to solve a **word-count** problem. It was collateral, not a threat-model decision.

## Fix

Hash instead of concatenate: `sha256(dice || randomBytes(16))` truncated to 16 bytes. Sixteen bytes out, twelve words, both sources.

**This keeps the reason for rolling.** An attacker who fully controls the device RNG still cannot predict the seed without the dice, so the result is safe if **either** source is sound rather than only if the dice are. That is strictly stronger than what it replaces, under the same threat model that motivated going RNG-free.

## Second guard

Save now refuses a sequence of eight or more entries drawn from two or fewer distinct values.

This is a **usability guard, not the security boundary** — the mix already makes degenerate input harmless. It exists so someone who believes they contributed 128 bits actually did, rather than being silently carried by the RNG.

Deliberately crude: it catches what a real die cannot produce and a bored finger easily can, and does not otherwise judge randomness. Rejecting an unlucky but legitimate roll would be worse than accepting a lazy one the mix already covers.

## Verification

- `npx jest -b -i tests/unit`: **60 suites, 696 passed, 1 skipped**
- 7 new tests: the old path really did emit the all-zeros vector; the new one does not; identical dice give a different seed every time; and with the RNG pinned to a constant, distinct dice still give distinct seeds
- `tsc --noEmit`: **402**, zero differing normalized error lines against `main`

Note the tsc baseline is now **402, not 400**. `main` moved during the 0.1.8 release merges and brought two new errors with it, both pre-existing on main and unrelated to this.

## Worth deciding separately

Whether the dice feature is live in a build users already have. If it is, the question is not only fixing it but working out whether any vault was created that way. A vault generated from degenerate taps is compromised regardless of this patch, since the seed already exists.
