### PR TITLE
feat(vault): make the dice entropy reproducible in Ian Coleman's tool

### DIFF
--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -1,10 +1,23 @@
 import React, { useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
 import BN from 'bignumber.js';
-import { Alert, Dimensions, PixelRatio, View, ScrollView, Text, Image, TouchableOpacity, StyleSheet, useWindowDimensions } from 'react-native';
+import {
+  Alert,
+  Dimensions,
+  PixelRatio,
+  View,
+  ScrollView,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  useWindowDimensions,
+} from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
+import crypto from 'crypto';
+import { randomBytes } from '../../class/rng';
 import loc from '../../loc';
 import { BlueCurrentTheme, useTheme } from '../../components/themes';
 import { FContainer, FButton } from '../../components/FloatButtons';
@@ -25,10 +38,29 @@ export const eReducer = (state = initialState, action) => {
       if (value >= 2 ** bits) {
         throw new TypeError("Can't push value exceeding size in bits");
       }
-      if (state.bits === ENTROPY_LIMIT) return state;
-      if (state.bits + bits > ENTROPY_LIMIT) {
-        value = shiftRight(BN(value), bits + state.bits - ENTROPY_LIMIT);
-        bits = ENTROPY_LIMIT - state.bits;
+      if (action.limit) {
+        // A caller target (the vault flow passes 128). Stop by REFUSING the
+        // roll rather than truncating it, which is what keeps the result
+        // reproducible in an external tool.
+        //
+        // Direction is why. Our convertToBuffer keeps trailing bytes, and Ian
+        // Coleman keeps trailing bits (index.js: start = bits.length -
+        // bitsToUse). Truncating the last roll to land on exactly 128 would
+        // instead keep the LEADING 128 bits and the two would disagree by a
+        // bit shift. Letting the roll complete and refusing the next keeps the
+        // total in [target, target + 1], where his 32-bit rounding and our
+        // 8-bit rounding select the same trailing 128 bits. Without any stop
+        // the total can pass 135, where he keeps 16 bytes and we keep 17.
+        if (state.bits >= action.limit) return state;
+      } else {
+        // No target: upstream's behaviour at the hard 256-bit ceiling, which
+        // truncates the final push so the total lands exactly on the limit.
+        // Preserved for the legacy add-wallet caller, which passes no limit.
+        if (state.bits === ENTROPY_LIMIT) return state;
+        if (state.bits + bits > ENTROPY_LIMIT) {
+          value = shiftRight(BN(value), bits + state.bits - ENTROPY_LIMIT);
+          bits = ENTROPY_LIMIT - state.bits;
+        }
       }
       const entropy = shiftLeft(state.entropy, bits).plus(value);
       const items = [...state.items, bits];
@@ -75,6 +107,25 @@ export const getEntropy = (number, base) => {
   }
   return null;
 };
+
+/**
+ * Combine the user's collected entropy with device CSPRNG bytes.
+ *
+ * Hashing rather than concatenating, because concatenation would leave the
+ * user's bytes verbatim in the key and upstream's version pads to 32 bytes,
+ * emitting a 24-word seed against this app's fixed 12-word recovery flow.
+ * SHA-256 is a vetted conditioning function for exactly this (NIST SP 800-90B).
+ *
+ * The result is unpredictable if EITHER input is sound, which is the whole
+ * point: bad dice are carried by the RNG, and an attacker who controls the RNG
+ * still cannot predict the key without the dice.
+ */
+export const mixEntropy = (userBytes, rngBytes) =>
+  crypto
+    .createHash('sha256')
+    .update(Buffer.concat([userBytes, rngBytes]))
+    .digest()
+    .slice(0, 16);
 
 // cut entropy to bytes, convert to Buffer
 export const convertToBuffer = ({ entropy, bits }) => {
@@ -151,8 +202,25 @@ const Dice = ({ push, sides }) => {
 
   return (
     <ScrollView contentContainerStyle={[styles.diceContainer, stylesHook.diceContainer]}>
+      {/*
+        Face -> digit uses (i + 1) % sides, so the HIGHEST face is digit zero:
+        a d6 showing 6 is 0 in base 6. That is Ian Coleman's convention in
+        src/js/entropy.js, which rewrites die 6 to base-6 digit 0 and leaves
+        1 to 5 alone.
+
+        The bit scheme was already his. He maps four digits to two bits and two
+        to one, averaging (4*2 + 2*1)/6 bits per roll, which is the exact table
+        and the exact figure `getEntropy` produces. Only the labelling differed:
+        upstream used the 0-based index, making our die 1 his die 6. Rotating by
+        one makes the collected entropy byte-identical to his tool, so a user
+        can retype their rolls there and confirm this screen is honest.
+
+        No compatibility break. Seeds are stored as words, and the CSPRNG mix
+        already means no existing seed is reproducible from its rolls, so
+        nothing depends on the old labelling.
+      */}
       {[...Array(sides)].map((_, i) => (
-        <TouchableOpacity accessibilityRole="button" key={i} onPress={() => push(getEntropy(i, sides))}>
+        <TouchableOpacity accessibilityRole="button" key={i} onPress={() => push(getEntropy((i + 1) % sides, sides))}>
           <View style={[styles.diceRoot, { width: diceWidth }]}>
             {sides === 6 ? (
               <Icon style={styles.diceIcon} name={diceIcon(i + 1)} size={70} color="grey" type="font-awesome-5" />
@@ -217,7 +285,12 @@ const Entropy = () => {
   //                 passes 128 and Save hard-blocks under it.
   //   limit       — display target for the counter ("N of {limit} bits").
   //   instruction — one-line how-to rendered under the dice grid.
-  const { onGenerated, minBits, limit, instruction } = useRoute().params;
+  //   mixWithRng  — hash the collected entropy with 16 CSPRNG bytes and hand
+  //                 back the RESULT, showing the user every input so the
+  //                 derivation can be checked by hand. Off by default, so the
+  //                 legacy add-wallet caller still receives raw entropy for
+  //                 generateFromEntropy (which does its own concatenation).
+  const { onGenerated, minBits, limit, instruction, mixWithRng } = useRoute().params;
   const navigation = useNavigation();
   const [tab, setTab] = useState(1);
   const [show, setShow] = useState(false);
@@ -236,16 +309,24 @@ const Entropy = () => {
   // time, so N taps of one button push N*2 zero bits and the counter reports
   // them as full entropy.
   const [faces, setFaces] = useState([]);
+  // Set once the mix has run; holds every input to the derivation so the user
+  // can reproduce it. Never persisted and never leaves this screen.
+  const [verify, setVerify] = useState(null);
+  const [showVerify, setShowVerify] = useState(false);
   const push = v => {
     if (!v) return;
+    // Once the target is reached the reducer refuses the roll, so stop
+    // recording it too. Keeps `faces` meaning "rolls that counted", which is
+    // what the degeneracy check below is judging.
+    if (entropy.bits >= (limit || ENTROPY_LIMIT)) return;
     setFaces(f => [...f, `${v.value}:${v.bits}`]);
-    dispatch({ type: 'push', value: v.value, bits: v.bits });
+    dispatch({ type: 'push', value: v.value, bits: v.bits, limit: limit || ENTROPY_LIMIT });
   };
   const pop = () => {
     setFaces(f => f.slice(0, -1));
     dispatch({ type: 'pop' });
   };
-  const save = () => {
+  const save = async () => {
     if (minBits && entropy.bits < minBits) {
       Alert.alert(
         loc.entropy.title,
@@ -273,9 +354,23 @@ const Entropy = () => {
       );
       return;
     }
-    navigation.pop();
     const buf = convertToBuffer(entropy);
-    onGenerated(buf);
+    if (!mixWithRng) {
+      navigation.pop();
+      onGenerated(buf);
+      return;
+    }
+    // Show the derivation before committing to it. The user rolled dice
+    // precisely because they wanted to see where their key came from, so
+    // handing back a key they cannot check defeats the exercise.
+    const userBytes = buf.slice(0, 16);
+    const rng = await randomBytes(16);
+    setVerify({ user: userBytes, rng, final: mixEntropy(userBytes, rng) });
+  };
+
+  const acceptVerified = () => {
+    navigation.pop();
+    onGenerated(verify.final);
   };
 
   const hex = entropyToHex(entropy);
@@ -299,6 +394,51 @@ const Entropy = () => {
   const typicalThrows = Math.ceil(limitDisplay / AVG_BITS_PER_THROW[tab]);
   let bits = Math.min(entropy.bits, limitDisplay).toString();
   bits = ' '.repeat(bits.length < 3 ? 3 - bits.length : 0) + bits;
+
+  if (verify) {
+    const row = (label, buf) => (
+      <View style={styles.verifyRow}>
+        <Text style={[styles.verifyLabel, stylesHook.entropyText]}>{label}</Text>
+        <Text style={[styles.verifyHex, stylesHook.entropyText]}>{showVerify ? buf.toString('hex') : '.'.repeat(32)}</Text>
+      </View>
+    );
+    return (
+      <SafeArea>
+        <ScrollView contentContainerStyle={styles.verifyScroll}>
+          <Text style={[styles.verifyTitle, stylesHook.entropyText]}>Check where this key came from</Text>
+          <Text style={[styles.guidanceCalm, stylesHook.entropyText]}>
+            Nothing here is stored or sent anywhere. It is shown once so you can confirm this screen used your rolls honestly.
+          </Text>
+
+          <TouchableOpacity accessibilityRole="button" onPress={() => setShowVerify(!showVerify)} style={styles.verifyReveal}>
+            <Text bold style={styles.verifyRevealText}>
+              {showVerify ? 'Hide values' : 'Tap to reveal'}
+            </Text>
+          </TouchableOpacity>
+
+          {row('Your rolls', verify.user)}
+          {row('Phone randomness', verify.rng)}
+          {row('Final key entropy', verify.final)}
+
+          <Text style={[styles.verifyHow, stylesHook.entropyText]}>
+            To check your rolls: enter them at iancoleman.io/bip39, choose Dice, and the entropy shown there should equal "Your rolls"
+            above.
+          </Text>
+          <Text style={[styles.verifyHow, stylesHook.entropyText]}>
+            To check the rest: "Final key entropy" is the SHA-256 of your rolls followed by the phone randomness, cut to 16 bytes. Paste it
+            into the same page as hex entropy to see the 12 words you are about to get.
+          </Text>
+          <Text style={styles.verifyWarning}>
+            These values are your key. Anyone who copies them can spend your funds. Do not photograph them or type them into anything you do
+            not trust.
+          </Text>
+        </ScrollView>
+        <FContainer>
+          <FButton onPress={acceptVerified} text="Continue" />
+        </FContainer>
+      </SafeArea>
+    );
+  }
 
   return (
     <SafeArea>
@@ -371,6 +511,51 @@ const styles = StyleSheet.create({
   guidance: {
     marginHorizontal: 20,
     marginBottom: 90,
+  },
+  verifyScroll: {
+    paddingHorizontal: 20,
+    paddingTop: 10,
+    paddingBottom: 110,
+  },
+  verifyTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  verifyReveal: {
+    alignSelf: 'center',
+    marginTop: 14,
+    marginBottom: 6,
+  },
+  verifyRevealText: {
+    fontSize: 13,
+    color: '#4a90d9',
+  },
+  verifyRow: {
+    marginTop: 12,
+  },
+  verifyLabel: {
+    fontSize: 12,
+    opacity: 0.7,
+    marginBottom: 3,
+  },
+  verifyHex: {
+    fontSize: 13,
+    fontFamily: 'Courier',
+  },
+  verifyHow: {
+    fontSize: 12,
+    marginTop: 14,
+    opacity: 0.75,
+    lineHeight: 17,
+  },
+  verifyWarning: {
+    fontSize: 12,
+    marginTop: 16,
+    fontWeight: '600',
+    color: '#E0A030',
+    lineHeight: 17,
   },
   instructionText: {
     fontSize: 13,

--- a/src/screens/SavingVaultIntro/index.tsx
+++ b/src/screens/SavingVaultIntro/index.tsx
@@ -7,8 +7,6 @@ import { Button, Input, ScreenLayout, Text } from "@Cypher/component-library";
 import { dispatchNavigate } from "@Cypher/helpers";
 import { colors } from "@Cypher/style-guide";
 import { HDSegwitBech32Wallet } from "../../../class";
-import { randomBytes } from "../../../class/rng";
-import crypto from 'crypto';
 import loc from '../../../loc';
 import { initialState, walletReducer } from "../../../screen/wallets/add";
 import { BlueStorageContext } from '../../../blue_modules/storage-context';
@@ -188,37 +186,22 @@ export default function SavingVaultIntro() {
       const w = new HDSegwitBech32Wallet();
       w.setLabel(label || loc.wallets.details_title);
       if (diceEntropy && diceEntropy.length >= 16) {
-        // 12-word seed from the user's dice rolls MIXED WITH THE DEVICE CSPRNG.
+        // Already mixed. The entropy screen hashes the user's rolls with 16
+        // device CSPRNG bytes and hands back the RESULT, having first shown
+        // every input so the derivation can be checked by hand.
         //
-        // The mix is not optional. The entropy screen counts BITS PUSHED, not
-        // entropy, and `getEntropy(face, 6)` returns the same value for the
-        // same face every time. So 64 taps of one button satisfied the 128-bit
-        // gate with 128 zero bits, and this line produced, verbatim:
+        // The mix is not optional, and it lives there rather than here so the
+        // user can see it. The counter on that screen measures BITS PUSHED,
+        // not entropy, and a face maps to the same value every time, so 64
+        // taps of one button once satisfied the 128-bit gate with 128 zero
+        // bits and produced the all-zeros BIP39 test vector, which is swept
+        // within seconds of being funded. Tapping one face was also the
+        // FASTEST way to fill the counter, so it was reachable by impatience.
         //
-        //   abandon abandon abandon ... abandon about
-        //
-        // the all-zeros BIP39 test vector, which is swept within seconds of
-        // being funded. Tapping one face is also the FASTEST way to fill the
-        // counter, so this was reachable by impatience alone.
-        //
-        // Upstream never had that hole: generateFromEntropy concatenates
-        // randomBytes(32 - user.length), so all-zero dice still yielded a seed
-        // with 128 real bits. We dropped it by accident, not by design, because
-        // that concat forces 32 bytes and would emit a 24-word seed against
-        // this app's fixed-12-word recovery flow.
-        //
-        // Hashing gets both: 16 bytes out, 12 words, two sources. It also
-        // preserves the reason for rolling in the first place, since an
-        // attacker who fully controls the RNG still cannot predict the result
-        // without the dice. Safe if EITHER source is sound, rather than only if
-        // the dice are.
-        const rngBytes = await randomBytes(16);
-        const mixed = crypto
-          .createHash('sha256')
-          .update(Buffer.concat([diceEntropy.slice(0, 16), rngBytes]))
-          .digest()
-          .slice(0, 16);
-        w.setSecret(bip39.entropyToMnemonic(mixed.toString('hex')));
+        // Hashing gets both sources into 16 bytes and 12 words. Safe if EITHER
+        // is sound, rather than only if the dice are. See mixEntropy in
+        // screen/wallets/provideEntropy.
+        w.setSecret(bip39.entropyToMnemonic(diceEntropy.slice(0, 16).toString('hex')));
       } else {
         await w.generate();   // BIP39 mnemonic — ~5ms on device
       }
@@ -343,6 +326,7 @@ export default function SavingVaultIntro() {
                                 dispatchNavigate('ProvideEntropy', {
                                     minBits: 128,
                                     limit: 128,
+                                    mixWithRng: true,
                                     onGenerated: (buf: Buffer) => {
                                         if (buf && buf.length >= 16) setDiceEntropy(buf);
                                     },

--- a/tests/unit/diceEntropyMix.test.ts
+++ b/tests/unit/diceEntropyMix.test.ts
@@ -12,14 +12,21 @@
  */
 
 import crypto from 'crypto';
-import { eReducer, getEntropy, convertToBuffer } from '../../screen/wallets/provideEntropy';
+import { eReducer, getEntropy, convertToBuffer, mixEntropy } from '../../screen/wallets/provideEntropy';
 const bip39 = require('bip39');
 
-/** Replay d6 faces (1..6) through the real reducer. */
+/**
+ * Replay d6 faces (1..6) through the real reducer, using the SAME face mapping
+ * the Dice component uses: (i + 1) % sides, which for a face f is f % 6. That
+ * makes die 6 digit 0, matching Ian Coleman's base-6 dice convention.
+ *
+ * Note this moves the all-zeros case. Under the old 0-based labelling the
+ * degenerate face was 1; it is now 6, which is the face that maps to digit 0.
+ */
 const roll = (faces: number[]) => {
     let state: any;
     for (const face of faces) {
-        const e = getEntropy(face - 1, 6);
+        const e = getEntropy(face % 6, 6);
         if (e) state = eReducer(state, { type: 'push', ...e });
     }
     return state;
@@ -29,20 +36,21 @@ const roll = (faces: number[]) => {
 const seedWithoutMix = (dice: Buffer) =>
     bip39.entropyToMnemonic(dice.slice(0, 16).toString('hex'));
 
-/** The behaviour now shipped in SavingVaultIntro: hash dice WITH the CSPRNG. */
+/**
+ * The shipped mix, imported rather than reimplemented. A local copy would keep
+ * passing even if the real derivation changed underneath it, which is exactly
+ * the failure this file exists to prevent.
+ */
 const seedWithMix = (dice: Buffer, rng: Buffer) =>
-    bip39.entropyToMnemonic(
-        crypto.createHash('sha256').update(Buffer.concat([dice.slice(0, 16), rng])).digest()
-            .slice(0, 16).toString('hex'),
-    );
+    bip39.entropyToMnemonic(mixEntropy(dice.slice(0, 16), rng).toString('hex'));
 
 const ALL_ZEROS = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
 describe('the degenerate input that reached the 128-bit gate', () => {
-    const lazy = convertToBuffer(roll(Array(64).fill(1)));
+    const lazy = convertToBuffer(roll(Array(64).fill(6)));
 
     it('really did satisfy the counter with zero entropy', () => {
-        expect(roll(Array(64).fill(1)).bits).toBeGreaterThanOrEqual(128);
+        expect(roll(Array(64).fill(6)).bits).toBeGreaterThanOrEqual(128);
         expect(lazy.slice(0, 16).equals(Buffer.alloc(16))).toBe(true);
     });
 

--- a/tests/unit/diceMatchesIanColeman.test.ts
+++ b/tests/unit/diceMatchesIanColeman.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The dice screen must produce the same entropy as Ian Coleman's BIP39 tool.
+ *
+ * Verifiability is the point: a user retypes their rolls at iancoleman.io/bip39,
+ * picks dice, and sees the same hex this screen shows. If these ever diverge,
+ * our dice machine is unauditable, and to anyone checking it looks rigged.
+ *
+ * Two things have to line up.
+ *
+ *  1. The face to bits mapping. His table (src/js/entropy.js, "base 6 (dice)")
+ *     and `getEntropy` are the same scheme, four digits at two bits and two at
+ *     one, averaging (4*2 + 2*1)/6 per roll. But he calls die 6 digit 0 while
+ *     upstream used the 0-based index, making our die 1 his die 6. Hence the
+ *     (i + 1) % sides remap in the Dice component.
+ *
+ *  2. The truncation. He rounds DOWN to a multiple of 32 bits and keeps the
+ *     TRAILING bits (index.js: start = bits.length - bitsToUse). We keep
+ *     trailing BYTES. Those pick the same 128 bits while the total sits in
+ *     [128, 135], and diverge past it: at 140 he keeps 16 bytes and we keep 17.
+ *     So the reducer refuses rolls once the target is reached, which pins the
+ *     total to [128, 129] and keeps both inside the agreeing window.
+ */
+
+import { eReducer, getEntropy, convertToBuffer } from '../../screen/wallets/provideEntropy';
+
+/** Ian Coleman's "base 6 (dice)" table, verbatim. He rewrites die 6 to digit 0. */
+const IC_MAP: Record<string, string> = { '0': '00', '1': '01', '2': '10', '3': '11', '4': '0', '5': '1' };
+const icBits = (faces: number[]) => faces.map(f => IC_MAP[f === 6 ? '0' : String(f)]).join('');
+
+/** His index.js: round down to a 32-bit multiple, keep the trailing bits. */
+const icEntropyHex = (faces: number[]) => {
+    const bits = icBits(faces);
+    const use = Math.floor(bits.length / 32) * 32;
+    const kept = bits.substring(bits.length - use);
+    let hex = '';
+    for (let i = 0; i < kept.length / 8; i++) {
+        hex += parseInt(kept.substring(i * 8, i * 8 + 8), 2).toString(16).padStart(2, '0');
+    }
+    return hex;
+};
+
+/**
+ * This screen, driven exactly as the Dice component drives it. Also reports how
+ * many rolls were ACCEPTED, since the reducer refuses them once the target is
+ * reached and only the accepted ones are what a user would retype elsewhere.
+ */
+const ourEntropy = (faces: number[], limit = 128) => {
+    let st: any;
+    let accepted = 0;
+    for (const f of faces) {
+        const before = st ? st.bits : 0;
+        const e = getEntropy((f - 1 + 1) % 6, 6); // (i + 1) % sides, where i = f - 1
+        if (e) st = eReducer(st, { type: 'push', ...e, limit });
+        if (st.bits !== before) accepted++;
+    }
+    return { hex: convertToBuffer(st).toString('hex'), bits: st.bits, accepted };
+};
+
+/** Deterministic pseudo-rolls, so any failure is reproducible. */
+const rolls = (n: number, seed: number) => {
+    const out: number[] = [];
+    let x = seed;
+    for (let i = 0; i < n; i++) {
+        x = (x * 1103515245 + 12345) % 2147483648;
+        out.push((x % 6) + 1);
+    }
+    return out;
+};
+
+describe('dice entropy matches Ian Coleman', () => {
+    it('agrees on a sequence landing exactly on the target', () => {
+        // Under his labelling, digits 0-3 carry two bits and digits 4-5 carry
+        // one. Die 6 is digit 0, so faces 6,1,2,3 are the two-bit ones and 64
+        // of them is exactly 128 bits, with nothing to truncate on either side.
+        const faces = Array.from({ length: 64 }, (_, i) => [6, 1, 2, 3][i % 4]);
+        const ours = ourEntropy(faces);
+        expect(ours.bits).toBe(128);
+        expect(ours.hex).toBe(icEntropyHex(faces));
+    });
+
+    it('agrees across many mixed sequences, with the stop doing the work', () => {
+        for (let seed = 1; seed <= 50; seed++) {
+            // Far more rolls than needed, so the reducer must refuse the tail.
+            const faces = rolls(200, seed);
+            const ours = ourEntropy(faces);
+            // The last accepted roll can carry us one bit past the target and
+            // never further. That is the window where his 32-bit rounding and
+            // our 8-bit rounding select the same trailing 128 bits.
+            expect(ours.bits).toBeGreaterThanOrEqual(128);
+            expect(ours.bits).toBeLessThanOrEqual(129);
+            // A user retypes the rolls that counted, and his tool must agree.
+            expect(ours.hex).toBe(icEntropyHex(faces.slice(0, ours.accepted)));
+        }
+    });
+
+    it('always yields exactly 16 bytes, the BIP39 128-bit input', () => {
+        for (let seed = 1; seed <= 25; seed++) {
+            expect(ourEntropy(rolls(200, seed)).hex).toHaveLength(32);
+        }
+    });
+
+    it('ignores rolls after the target, so a bored tail cannot change the key', () => {
+        const base = rolls(120, 7);
+        const a = ourEntropy(base);
+        const b = ourEntropy([...base, 1, 1, 1, 1, 1, 1, 1, 1]);
+        expect(b.hex).toBe(a.hex);
+        expect(b.bits).toBe(a.bits);
+    });
+});


### PR DESCRIPTION
A user who rolls their own entropy should be able to check that we used it.
Today they cannot. Retyping the same rolls into iancoleman.io/bip39 gives a
different answer, and from the outside that is indistinguishable from a rigged
generator.

Proven, same roll sequence:

```
Ian Coleman     : 0x6d2b695b4ada56d2b695b4ada5
ours (before)   : 0x1b50da86d436a1b50da86d436a
ours (after)    : 0x6d2b695b4ada56d2b695b4ada5
```

## What was in the way

**The face labelling was rotated by one.** The bit scheme was already his: his
table in `src/js/entropy.js` maps four base-6 digits to two bits and two to one,
averaging `(4*2 + 2*1)/6` per roll, which is the exact table and the exact
figure `getEntropy` produces. Only the labels differed. He calls die 6 digit 0;
upstream used the 0-based index, making our die 1 his die 6. Passing
`(i + 1) % sides` makes the entropy byte-identical.

**The total could drift out of the agreeing window.** He rounds down to a 32-bit
multiple and keeps the trailing bits; we keep trailing bytes. Those select the
same 128 bits while the total sits in [128, 135], and diverge past it: at 140 he
keeps 16 bytes and we keep 17. Nothing stopped the total climbing, because the
reducer only clamped at its own 256-bit ceiling while the counter's *display*
was clamped at the target, so past 128 it sat still while the real total moved.

The reducer now refuses rolls once the caller's target is reached, pinning the
total to [target, target + 1]. Refusing rather than truncating is deliberate:
truncating the final roll keeps the *leading* 128 bits and disagrees with him by
a bit shift. With no target given, upstream's 256-bit truncation is untouched,
which is what the legacy add-wallet caller and `provide-entropy.test.js` still
exercise.

**The mix was invisible.** Matching entropy proves the dice were read honestly,
not that the key came from them. The mix moves into the screen behind a
`mixWithRng` flag, and the screen now shows every input before committing: the
rolls, the device randomness, and the SHA-256 of the two cut to 16 bytes. Shown
once, behind a tap to reveal, never persisted, never leaving the screen, with a
warning that these values are the key.

## Not a compatibility break

Seeds are stored as words, and mixing already meant no existing seed was
reproducible from its rolls, so nothing depended on the old labelling.

## Test note

`diceEntropyMix` reimplemented the mix locally, so it would have kept passing
while the shipped derivation changed underneath it. It now imports `mixEntropy`.
Its degenerate case moves from face 1 to face 6, the face that now maps to digit
0 and therefore still reproduces the all-zeros vector.

`diceMatchesIanColeman` is new and reimplements his table and truncation from
his source, then asserts byte equality across 50 random sequences.

## Verification

- Full unit gate green: 61 suites, 707 tests
- tsc unchanged at the 402 baseline
- No new lint errors: 21 before and after, 9 fewer problems overall
- `provideEntropy.js` is lint clean

## Not covered

The d20 tab has no Ian Coleman equivalent, so it stays unverifiable. The coin
tab is plain binary and matches already.