### PR TITLE
fix(vault): tell people to verify offline, and with rolls they throw away

### DIFF
--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -420,17 +420,21 @@ const Entropy = () => {
           {row('Phone randomness', verify.rng)}
           {row('Final key entropy', verify.final)}
 
-          <Text style={[styles.verifyHow, stylesHook.entropyText]}>
-            To check your rolls: enter them at iancoleman.io/bip39, choose Dice, and the entropy shown there should equal "Your rolls"
-            above.
+          <Text style={styles.verifyWarning}>
+            Verify with throwaway rolls, not these. Typing your real rolls into a web page hands over half of what protects this key, and
+            leaves it resting on the phone alone. Either practise the check with rolls you discard, or download Ian Coleman's tool and run it
+            with this device offline.
           </Text>
           <Text style={[styles.verifyHow, stylesHook.entropyText]}>
-            To check the rest: "Final key entropy" is the SHA-256 of your rolls followed by the phone randomness, cut to 16 bytes. Paste it
-            into the same page as hex entropy to see the 12 words you are about to get.
+            To check the rolls: enter them in Ian Coleman's BIP39 tool, choose Dice, and the entropy it shows should equal "Your rolls" above.
+            That is the part that proves this screen read your dice honestly.
+          </Text>
+          <Text style={[styles.verifyHow, stylesHook.entropyText]}>
+            To check the rest: "Final key entropy" is the SHA-256 of your rolls followed by the phone randomness, cut to 16 bytes. Paste that
+            in as hex entropy to see the 12 words you are about to get.
           </Text>
           <Text style={styles.verifyWarning}>
-            These values are your key. Anyone who copies them can spend your funds. Do not photograph them or type them into anything you do
-            not trust.
+            These values are your key. Anyone who copies them can spend your funds. Do not photograph them.
           </Text>
         </ScrollView>
         <FContainer>

--- a/src/screens/SavingVaultIntro/index.tsx
+++ b/src/screens/SavingVaultIntro/index.tsx
@@ -335,7 +335,7 @@ export default function SavingVaultIntro() {
                             style={{ marginTop: 14 }}
                         >
                             <Text bold style={{ color: colors.green, fontSize: 14 }}>
-                                Optional: create your own entropy via your dice rolls 🎲
+                                Advanced: create your own entropy via your dice rolls 🎲
                             </Text>
                         </TouchableOpacity>
                     )}


### PR DESCRIPTION
The verify panel added in #249 named the online BIP39 page, which invited the
one action that undoes the reason for rolling at all.

Retyping **real** rolls into a web page hands over the dice half of the key. What
is left resting on the phone alone is exactly the single-source position the mix
exists to avoid. The screen was recommending a step that quietly halved its own
guarantee.

## What changes

The safe ways to get the same proof are to practise the check with rolls that are
then discarded, or to run Ian Coleman's tool downloaded and offline. Both confirm
the machine is honest without spending the real rolls to do it.

That guidance now **leads** the panel, ahead of the how-to rather than buried
under it, so the easy reading is the safe one:

> Verify with throwaway rolls, not these. Typing your real rolls into a web page
> hands over half of what protects this key, and leaves it resting on the phone
> alone. Either practise the check with rolls you discard, or download Ian
> Coleman's tool and run it with this device offline.

The page is no longer named by URL. The tool is named, with the instruction to
run it offline attached.

## Also

The dice entry point read "Optional", which undersold it as something not worth
bothering with. It now reads "Advanced", which is what it is: a path for people
who want to contribute their own entropy and check the result.

## Verification

Copy only, no logic touched.

- Unit gate green: 61 suites, 707 tests
- tsc unchanged at the 402 baseline
- No new lint errors: 21 before and after, one fewer problem overall