### PR TITLE
feat(ark): warn during an exit that battery must be Unrestricted, and link there

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -358,6 +358,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     coldStorageWalletID,
     arkBalanceDetail,
     arkExitInProgress,
+    arkExitBatteryNoticeDismissed,
+    setArkExitBatteryNoticeDismissed,
     arkExitDestinationAddress,
     arkExitStartedAt,
     arkExitFeeReserveSats,
@@ -2349,6 +2351,63 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
               <Text style={{ fontSize: 12, color: '#AAA', marginBottom: 6 }}>
                 {exitPhase.detail}
               </Text>
+            )}
+
+            {/* BATTERY NOTICE, Android only, during an exit only.
+                An earlier version of this banner lived on the auto-refresh
+                setting and was dropped with FGS_DATA_SYNC in v0.1.1. It matters
+                far more here: the exit drive is foreground-only, so on a device
+                that is not battery-exempt the OS suspends the app the moment
+                the screen goes off and the exit stops dead. Measured on a
+                Galaxy A14 2026-08-29: zero progressExits calls and zero log
+                output across a lock window, with the process alive but frozen.
+
+                Deliberately NOT probed. The native
+                isIgnoringBatteryOptimizations() went with the background
+                machinery in b8226f9, so nothing can read the OS allowlist any
+                more. Rather than guess, this asks once and lets the user say it
+                is done; the dismissal is persisted because an exit spans days
+                and many launches.
+
+                Linking.openSettings() opens this app's own settings page,
+                which is where Battery > Unrestricted lives, and is the same
+                call three other prompts in this screen already use. */}
+            {Platform.OS === 'android' && !arkExitBatteryNoticeDismissed && (
+              <View
+                style={{
+                  marginTop: 4,
+                  marginBottom: 8,
+                  padding: 10,
+                  borderRadius: 8,
+                  backgroundColor: 'rgba(251, 146, 60, 0.12)',
+                  borderWidth: 1,
+                  borderColor: 'rgba(251, 146, 60, 0.45)',
+                }}>
+                <Text bold style={{ fontSize: 12, color: '#FB923C', marginBottom: 3 }}>
+                  Set Cypher Box battery to Unrestricted
+                </Text>
+                <Text style={{ fontSize: 11, color: colors.white, lineHeight: 16 }}>
+                  The exit stops while your phone sleeps unless Cypher Box is
+                  allowed to run in the background. Open settings, choose
+                  Battery, and set it to Unrestricted.
+                </Text>
+                <View style={{ flexDirection: 'row', marginTop: 8 }}>
+                  <TouchableOpacity
+                    onPress={() => {
+                      Linking.openSettings().catch((err) => {
+                        console.warn('[Ark exit battery notice] open settings failed:', err);
+                      });
+                    }}
+                    style={{ marginRight: 18 }}>
+                    <Text bold style={{ fontSize: 12, color: '#FB923C' }}>
+                      Open settings
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => setArkExitBatteryNoticeDismissed(true)}>
+                    <Text style={{ fontSize: 12, color: '#888' }}>Already done</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
             )}
             {arkExitDestinationAddress && (
               <Text style={{ fontSize: 12, color: '#888' }} numberOfLines={1}>

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -277,6 +277,17 @@ export type AuthStateType = {
      */
     arkExitInProgress: boolean;
     /**
+     * Has the user dismissed the "set battery to Unrestricted" notice shown
+     * during an exit? Persisted, because an exit spans days and many launches,
+     * and re-nagging someone who already did it is how a real warning gets
+     * trained into background noise.
+     *
+     * Nothing auto-clears this. The native isIgnoringBatteryOptimizations()
+     * went with the background-refresh machinery in b8226f9, so the app can no
+     * longer read the OS allowlist and has to take the user's word for it.
+     */
+    arkExitBatteryNoticeDismissed: boolean;
+    /**
      * Where the user wants the on-chain funds to land after the timelock.
      * Captured at exit-start so the auto-claim loop has the address without
      * reprompting the user. Bitcoin address (mainnet bech32 / legacy / etc).
@@ -358,6 +369,7 @@ export type AuthStateType = {
         maxVtxoExitDepth: number | null;
     }) => void;
     setArkExitInProgress: (state: boolean) => void;
+    setArkExitBatteryNoticeDismissed: (state: boolean) => void;
     setArkExitDestinationAddress: (state: string | null) => void;
     setArkExitStartedAt: (state: number | null) => void;
     setArkExitClaimBatchSince: (state: number | null) => void;
@@ -586,6 +598,7 @@ const createAuthStore = (
     arkMaxVtxoExitDepth: null,
     arkExitFeeDeadlineHeight: null,
     arkExitInProgress: false,
+    arkExitBatteryNoticeDismissed: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
     arkExitClaimBatchSince: null,
@@ -679,6 +692,8 @@ const createAuthStore = (
         arkMaxVtxoExitDepth: state.maxVtxoExitDepth,
     }),
     setArkExitInProgress: (state: boolean) => set({ arkExitInProgress: state }),
+    setArkExitBatteryNoticeDismissed: (state: boolean) =>
+        set({ arkExitBatteryNoticeDismissed: state }),
     setArkExitDestinationAddress: (state: string | null) => set({ arkExitDestinationAddress: state }),
     setArkExitStartedAt: (state: number | null) => set({ arkExitStartedAt: state }),
     setArkExitClaimBatchSince: (state: number | null) => set({ arkExitClaimBatchSince: state }),


### PR DESCRIPTION
Brings back the battery banner that was dropped with `FGS_DATA_SYNC` in v0.1.1, but in the context where it actually matters.

## Why here rather than on auto-refresh

The exit drive is foreground-only. On a device that is not battery-exempt, the OS suspends the app the moment the screen goes off, and the exit does not slow down, **it stops**.

Measured on a Galaxy A14 on 2026-08-29: across a lock window, **zero** `progressExits` calls and zero log output of any kind. The process stayed alive and frozen, so this is Doze suspension rather than a kill.

That device also had Samsung's "never sleeping apps" set for Cypher Box. That is a **different list** from Android's Doze allowlist and does not help, which is exactly the kind of thing a user cannot be expected to know.

Auto-refresh missing a window costs a retry. An exit missing its windows can leave someone unable to finish a withdrawal they started because they believed the server was hostile. Same banner, far higher stakes.

## Scope

Android only, and only while an exit is in progress. Tapping opens the app's own settings page via `Linking.openSettings()`, where `Battery > Unrestricted` lives. That is the same call three other prompts on this screen already use, and it is OEM-independent, unlike the generic battery-optimisation allowlist intent.

## Deliberately not probed

The old banner self-cleared by calling `isIgnoringBatteryOptimizations()`. That native module went with the background-refresh machinery in `b8226f9`, so **nothing in the app can read the OS allowlist any more**.

Rather than guess, the notice asks once and offers "Already done". The dismissal is persisted, because an exit spans days and many app launches, and re-nagging someone who has already acted is how a real warning gets trained into background noise.

**The honest limitation:** a user who dismisses without acting gets no second warning. Restoring a probe would fix that and is separate work.

## Testing

- Full suite: 61 suites, 707 passing.
- `tsc` 402, identical to main, empty error-kind diff.
- No em dashes in user-facing copy.

Not yet seen on device. The A14 is mid-exit on the pre-0.1.8 build and must not be reinstalled until it finishes.