### PR TITLE
fix(vault): say where the checking tool runs, and plainer dice wording

### DIFF
--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -330,7 +330,7 @@ const Entropy = () => {
     if (minBits && entropy.bits < minBits) {
       Alert.alert(
         loc.entropy.title,
-        `Not enough yet. You are at ${entropy.bits} of ${minBits}. Keep rolling until it gets there.`,
+        `Not enough entropy yet: ${entropy.bits} of ${minBits} bits. Keep rolling until the counter reaches ${minBits}.`,
       );
       return;
     }
@@ -422,16 +422,18 @@ const Entropy = () => {
 
           <Text style={styles.verifyWarning}>
             Do this with practice rolls, not your real ones. Typing your real rolls into a website gives away one of the two things
-            protecting this key, and it would then rest on your phone's secure entropy generator only. Either do a practice run with rolls you
-            throw away afterwards, or download Ian Coleman's tool and run it with this device offline.
+            protecting this key, and it would then rest on your phone's secure entropy generator only. The safe way is a practice run: roll
+            a few times, check those, then throw them away and start again for real. If you do want to check your real rolls, put Ian
+            Coleman's tool on a separate computer, disconnect that computer from the internet, and check there. Not on this phone, and never
+            on a website.
           </Text>
           <Text style={[styles.verifyHow, stylesHook.entropyText]}>
-            To check your rolls: type them into Ian Coleman's BIP39 tool and choose Dice. What it shows should match "Your rolls" above. That
-            is what proves this screen read your dice correctly.
+            To check your rolls: on that separate computer, type them into Ian Coleman's BIP39 tool and choose Dice. What it shows should
+            match "Your rolls" above. That is what proves this screen read your dice correctly.
           </Text>
           <Text style={[styles.verifyHow, stylesHook.entropyText]}>
-            To check the result: it is a SHA-256 hash of your rolls followed by your phone's randomness, shortened to 16 bytes. Paste it into
-            the same tool as hex entropy to see the 12 words you are about to get.
+            To check the result: it is a SHA-256 hash of your rolls followed by your phone's randomness, shortened to 16 bytes. Paste it
+            into the same tool as hex entropy to see the 12 words you are about to get.
           </Text>
           <Text style={styles.verifyWarning}>
             These values are your key. Anyone who copies them can spend your money. Do not photograph them.

--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -330,7 +330,7 @@ const Entropy = () => {
     if (minBits && entropy.bits < minBits) {
       Alert.alert(
         loc.entropy.title,
-        `Not enough entropy yet: ${entropy.bits} of ${minBits} bits. Keep rolling until the counter reaches ${minBits}.`,
+        `Not enough yet. You are at ${entropy.bits} of ${minBits}. Keep rolling until it gets there.`,
       );
       return;
     }
@@ -349,8 +349,8 @@ const Entropy = () => {
       Alert.alert(
         loc.entropy.title,
         distinct <= 1
-          ? 'Every entry is the same value, so this carries no randomness. Roll a real die and enter what it lands on.'
-          : 'These entries repeat only two values, so this carries very little randomness. Roll a real die and enter what it lands on.',
+          ? 'Every tap is the same number, so there is no randomness here at all. Roll a real die and tap what it lands on.'
+          : 'These taps only use two numbers, so there is almost no randomness here. Roll a real die and tap what it lands on.',
       );
       return;
     }
@@ -407,7 +407,7 @@ const Entropy = () => {
         <ScrollView contentContainerStyle={styles.verifyScroll}>
           <Text style={[styles.verifyTitle, stylesHook.entropyText]}>Check where this key came from</Text>
           <Text style={[styles.guidanceCalm, stylesHook.entropyText]}>
-            Nothing here is stored or sent anywhere. It is shown once so you can confirm this screen used your rolls honestly.
+            None of this is saved or sent anywhere. It is shown once, so you can check for yourself that this screen really used your rolls.
           </Text>
 
           <TouchableOpacity accessibilityRole="button" onPress={() => setShowVerify(!showVerify)} style={styles.verifyReveal}>
@@ -417,24 +417,24 @@ const Entropy = () => {
           </TouchableOpacity>
 
           {row('Your rolls', verify.user)}
-          {row('Phone randomness', verify.rng)}
-          {row('Final key entropy', verify.final)}
+          {row("Your phone's randomness", verify.rng)}
+          {row('The result, which becomes your key', verify.final)}
 
           <Text style={styles.verifyWarning}>
-            Verify with throwaway rolls, not these. Typing your real rolls into a web page hands over half of what protects this key, and
-            leaves it resting on the phone alone. Either practise the check with rolls you discard, or download Ian Coleman's tool and run it
-            with this device offline.
+            Do this with practice rolls, not your real ones. Typing your real rolls into a website gives away one of the two things
+            protecting this key, and it would then rest on your phone's secure entropy generator only. Either do a practice run with rolls you
+            throw away afterwards, or download Ian Coleman's tool and run it with this device offline.
           </Text>
           <Text style={[styles.verifyHow, stylesHook.entropyText]}>
-            To check the rolls: enter them in Ian Coleman's BIP39 tool, choose Dice, and the entropy it shows should equal "Your rolls" above.
-            That is the part that proves this screen read your dice honestly.
+            To check your rolls: type them into Ian Coleman's BIP39 tool and choose Dice. What it shows should match "Your rolls" above. That
+            is what proves this screen read your dice correctly.
           </Text>
           <Text style={[styles.verifyHow, stylesHook.entropyText]}>
-            To check the rest: "Final key entropy" is the SHA-256 of your rolls followed by the phone randomness, cut to 16 bytes. Paste that
-            in as hex entropy to see the 12 words you are about to get.
+            To check the result: it is a SHA-256 hash of your rolls followed by your phone's randomness, shortened to 16 bytes. Paste it into
+            the same tool as hex entropy to see the 12 words you are about to get.
           </Text>
           <Text style={styles.verifyWarning}>
-            These values are your key. Anyone who copies them can spend your funds. Do not photograph them.
+            These values are your key. Anyone who copies them can spend your money. Do not photograph them.
           </Text>
         </ScrollView>
         <FContainer>
@@ -479,13 +479,13 @@ const Entropy = () => {
       <View style={styles.guidance}>
         {instruction ? <Text style={[styles.instructionText, stylesHook.entropyText]}>{instruction}</Text> : null}
         <Text style={[styles.guidanceHow, stylesHook.entropyText]}>
-          {`${isCoin ? 'Flip' : 'Roll'} a real ${sourceNoun} and tap the ${landedNoun} it lands on. About ${typicalThrows} ${throwsNoun} fills the counter.`}
+          {`${isCoin ? 'Flip' : 'Roll'} a real ${sourceNoun}, then tap the ${landedNoun} it landed on. It takes about ${typicalThrows} ${throwsNoun}.`}
         </Text>
         <Text style={styles.guidanceWarning}>
-          {`Tapping the same ${landedNoun} over and over, or any pattern you make up, adds no randomness. The counter cannot tell the difference, but your key can.`}
+          {`Tapping the same ${landedNoun} again and again, or any pattern you make up yourself, does not count as random. The number above still goes up, but your key gets no safer.`}
         </Text>
         <Text style={[styles.guidanceCalm, stylesHook.entropyText]}>
-          Your phone always mixes in its own randomness, so doing this can only make your key stronger, never weaker.
+          Your phone always adds randomness of its own as well, so doing this can only make your key safer, never weaker.
         </Text>
       </View>
 


### PR DESCRIPTION
#250 merged at its first commit, so these two follow-ups did not land with it.
Main currently carries the wording both of these correct.

## 1. "run it with this device offline" said the wrong thing

It read as an instruction to run the checking tool **on the phone**, which is the
opposite of the point. The reason to reach for that tool is that it is a second,
independent implementation. Running it on the device being checked proves
nothing, and getting there would mean putting it on the phone holding the key.

It now names the machine and the state it should be in, and rules out the two
wrong answers explicitly:

> The safe way is a practice run: roll a few times, check those, then throw them
> away and start again for real. If you do want to check your real rolls, put Ian
> Coleman's tool on a separate computer, disconnect that computer from the
> internet, and check there. Not on this phone, and never on a website.

It also leads with the practice run, since that is what most people should do.
It needs no second computer and spends nothing.

## 2. "half of what protects this key" overstated the loss

Exposing the rolls still leaves the phone's 128 bits unknown, so the key stays
128-bit secure. What is actually lost is the second independent source. Now:
"gives away one of the two things protecting this key, and it would then rest on
your phone's secure entropy generator only."

Precision matters more than usual here, since this release invites people to
check our arithmetic.

## 3. Plainer wording elsewhere

Ordinary words for the same meaning: "does not count as random. The number above
still goes up, but your key gets no safer"; "Every tap is the same number";
"The result, which becomes your key"; "spend your money".

SHA-256 and 16 bytes stay in the verify panel. Someone reproducing the derivation
by hand needs the real names.

`Not enough entropy yet: 96 of 128 bits` is kept as it was, since the counter it
refers to is labelled in bits.

## Verification

Copy only, no logic touched.

- Unit gate green: 61 suites, 707 tests
- tsc unchanged at the 402 baseline
- No new lint errors