### PR TITLE
fix(vault): the reassurance line pointed at the wrong thing

### DIFF
--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -487,7 +487,7 @@ const Entropy = () => {
           {`Tapping the same ${landedNoun} again and again, or any pattern you make up yourself, does not count as random. The number above still goes up, but your key gets no safer.`}
         </Text>
         <Text style={[styles.guidanceCalm, stylesHook.entropyText]}>
-          Your phone always adds randomness of its own as well, so doing this can only make your key safer, never weaker.
+          {`Your phone always adds randomness of its own as well, so adding real ${throwsNoun} can only make your key safer, never weaker.`}
         </Text>
       </View>
 


### PR DESCRIPTION
The reassurance line sat directly under the warning:

> Tapping the same face again and again, or any pattern you make up yourself,
> does not count as random. The number above still goes up, but your key gets no
> safer.
>
> Your phone always adds randomness of its own as well, so **doing this** can
> only make your key safer, never weaker.

The nearest thing "doing this" could attach to was the tapping. Read straight
through, the two lines told the user that repeated tapping makes their key
safer, which is the exact belief that produced the 0.1.8 seeds.

Now:

> ...so **adding real rolls** can only make your key safer, never weaker.

## Also made it tab-aware

The line was static, so once it named the action it would have said "rolls" on
the coin tab. It now takes `throwsNoun` like the two lines above it, giving
"rolls" or "flips" to match the tab.

"real" rather than "genuine", to match the wording already on this screen:
"Flip a real coin", "Roll a real die".

Copy only. Unit gate green: 61 suites, 707 tests. Lint clean.