### PR TITLE
feat(ark): vault connectivity, stale-expiry correctness, pull to refresh

### DIFF
--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -12,6 +12,7 @@ import {
     isVtxoMidRound,
     recoverArkOnchainBoard,
 } from "@Cypher/services/ark";
+import { deriveVaultConnectivity } from "@Cypher/services/ark/chainTipFreshness";
 import { getCapsuleColorBand } from "@Cypher/helpers/arkCapsuleColor";
 import { btc } from "@Cypher/helpers/bitcoinUnits";
 import useAuthStore from "@Cypher/stores/authStore";
@@ -65,6 +66,12 @@ export default function ArkWallet({
         reserveArkAmount,
         arkVtxos,
         arkChainTipHeight,
+        // Timestamps behind the card's connectivity dot. Both are only
+        // written on SUCCESS (tip on a good esplora read, sync at the end of
+        // a completed cycle), which is exactly what makes their AGE the
+        // signal: an outage stops updating them rather than recording itself.
+        arkChainTipHeightAt,
+        arkLastSyncedAt,
         arkRefreshingVtxoIds,
         arkBgRefreshEnabled,
         arkBgRefreshLastSuccessAt,
@@ -83,6 +90,35 @@ export default function ArkWallet({
     // which drains a stuck on-chain boarding deposit back to a fresh Hot
     // Vault change address. Same source HomeScreen uses to find the vault.
     const { wallets } = useContext(BlueStorageContext);
+
+    /**
+     * Slow clock for the connectivity dot.
+     *
+     * The dot has to be able to degrade with NO store activity at all. Both
+     * timestamps it reads are written only on success, so the exact failure it
+     * exists to report (sync loop wedged, esplora unreachable) is the one that
+     * produces no re-render. Without a tick of its own the card would hold its
+     * last green indefinitely while the vault sat dead, which is the failure
+     * direction that misleads.
+     *
+     * 30s matches the Capsules tab's tick. The thresholds are minutes wide, so
+     * anything faster is waste.
+     */
+    const [connTick, setConnTick] = useState(() => Date.now());
+    useEffect(() => {
+        const t = setInterval(() => setConnTick(Date.now()), 30_000);
+        return () => clearInterval(t);
+    }, []);
+
+    const vaultConnectivity = useMemo(
+        () =>
+            deriveVaultConnectivity({
+                tipFetchedAtMs: arkChainTipHeightAt,
+                lastSyncedAtMs: arkLastSyncedAt,
+                nowMs: connTick,
+            }),
+        [arkChainTipHeightAt, arkLastSyncedAt, connTick],
+    );
 
     // OS notification permission state for the bgRefreshStatus pill.
     // Drives the "Notifications off" branch that replaced the v0.1.1-dropped
@@ -617,6 +653,7 @@ export default function ArkWallet({
                             ? { count: pendingRoundCount, sats: pendingRoundSats }
                             : null}
                         arkCapsuleSlots={arkCapsuleSlots}
+                        vaultConnectivity={vaultConnectivity}
                     />
                     {/* When shared buttons are active (`hideActionButtons`),
                         skip this minHeight-40 reserve so the shared row can

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -72,6 +72,7 @@ export default function ArkWallet({
         // signal: an outage stops updating them rather than recording itself.
         arkChainTipHeightAt,
         arkLastSyncedAt,
+        arkSyncFailStreak,
         arkRefreshingVtxoIds,
         arkBgRefreshEnabled,
         arkBgRefreshLastSuccessAt,
@@ -116,8 +117,9 @@ export default function ArkWallet({
                 tipFetchedAtMs: arkChainTipHeightAt,
                 lastSyncedAtMs: arkLastSyncedAt,
                 nowMs: connTick,
+                syncFailStreak: arkSyncFailStreak,
             }),
-        [arkChainTipHeightAt, arkLastSyncedAt, connTick],
+        [arkChainTipHeightAt, arkLastSyncedAt, arkSyncFailStreak, connTick],
     );
 
     // OS notification permission state for the bgRefreshStatus pill.

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -478,6 +478,27 @@ export default function ArkWallet({
      * subsumes it.
      */
     const bgRefreshStatus = useMemo(() => {
+        // 0. OFFLINE, ahead of everything below.
+        //
+        // Same branch and same copy as the shared-row version in WalletsView.
+        // It is here as well as there because the two layouts show different
+        // status rows, and a warning that exists in only one of them is
+        // invisible to whichever users are in the other. That is not
+        // hypothetical: the exit-fee reserve nudge lived in this file alone and
+        // no one in the default layout ever saw it.
+        //
+        // Everything below this point is derived from the cached chain tip, so
+        // when the vault is unreachable those numbers are projections rather
+        // than reads, and they keep counting down as if nothing were wrong.
+        if (vaultConnectivity.level === 'red') {
+            // COPY: Bam finalizes. Kept identical to WalletsView on purpose.
+            return {
+                text: 'Bark vault is offline. Capsule times shown are estimates until it reconnects.',
+                error: true,
+                tapTab: 0,
+            };
+        }
+
         // 1. Refresh / send / board in flight. Short-circuits the rest of
         //    the chain because the Card itself now renders a prominent
         //    pulsing "Refreshing N capsules · X sats" line inside the
@@ -554,6 +575,9 @@ export default function ArkWallet({
         arkIosBackupReminderActive,
         pendingRoundCount,
         pendingRoundSats,
+        // Or the offline branch never re-evaluates and the pill keeps showing
+        // whatever it said while the vault was last reachable.
+        vaultConnectivity,
     ]);
 
     // IMPORTANT: the parent's `convertedRate` prop is globally computed from

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -472,25 +472,37 @@ export default function Card({ onPress,
                     <Reanimated.View style={[styles.linearGradient2, { backgroundColor: colors.pink.dark, minWidth: 6 } as any, fillStyle]} />
                 </View>
             )}
-            {/* Vault connectivity, bottom-left. Last child of the card's
-                column, so it sits under the capsule slots without absolute
-                positioning that could ride over them on a narrow screen.
-                Deliberately small and quiet: on a healthy vault this is
-                reassurance the user should be able to ignore, and the loud
-                signal for an unhealthy one is the warning watermark behind
-                it rather than this line.
+            {/* Vault connectivity, bottom-right corner.
+                ABSOLUTE, not a flow child. `shadowTop` is a fixed 128pt box
+                (Card/styles.ts), so the card has no spare vertical room: an
+                appended row pushes past the border and gets clipped by it.
+                Anchoring to the container instead keeps the line inside the
+                card whatever the rows above it do. `right: 30` matches the
+                card's paddingHorizontal so it lines up with the brand mark
+                and the capsule slot row rather than the raw border edge,
+                since absolute children position against the padding box.
+
+                Quiet by design: on a healthy vault this is reassurance the
+                user can ignore, and the loud signal for an unhealthy one is
+                the warning watermark behind it rather than this line.
 
                 COPY: Bam finalizes. Same status vocabulary as the fuller
                 pill on the Capsules tab, shortened because the card is
                 already titled "Bark Vault" and repeating the noun here
                 reads as stutter. */}
             {vaultConnectivity && (
-                <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 10 }}>
+                <View style={{
+                    position: 'absolute',
+                    right: 30,
+                    bottom: 12,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                }}>
                     <View
                         style={{
-                            width: 7,
-                            height: 7,
-                            borderRadius: 3.5,
+                            width: 8,
+                            height: 8,
+                            borderRadius: 4,
                             marginRight: 6,
                             backgroundColor:
                                 vaultConnectivity.level === 'green'
@@ -502,7 +514,7 @@ export default function Card({ onPress,
                     />
                     <Text
                         style={{
-                            fontSize: 10,
+                            fontSize: 12,
                             fontWeight: '600',
                             color:
                                 vaultConnectivity.level === 'green'

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -11,6 +11,7 @@ import LinearGradient from "react-native-linear-gradient";
 import GradientButtonWithShadow from "../GradientButtonWithShadow";
 import styles from "./styles";
 import useAuthStore from "@Cypher/stores/authStore";
+import type { VaultConnectivity } from "@Cypher/services/ark/chainTipFreshness";
 import { CarouselPageVisibilityContext, useEasedProgress } from "@Cypher/custom-hooks";
 import { useIsFocused } from "@react-navigation/native";
 import Reanimated, { useAnimatedStyle } from "react-native-reanimated";
@@ -62,6 +63,17 @@ interface Props {
      * existing live caller renders the balance as before.
      */
     hideBalance?: boolean;
+    /**
+     * Vault connectivity for the Ark card's corner status line.
+     *
+     * Passed in rather than derived here because the derivation needs a slow
+     * clock of its own: if the sync loop is the thing that is wedged, no store
+     * write arrives to re-render us, so a component that only reacts to store
+     * changes would sit on a stale green forever. ArkWallet owns that tick.
+     *
+     * Null/undefined renders nothing, so every non-Ark caller is unaffected.
+     */
+    vaultConnectivity?: VaultConnectivity | null;
 }
 
 export default function Card({ onPress,
@@ -81,6 +93,7 @@ export default function Card({ onPress,
     refreshingInfo = null,
     arkCapsuleSlots,
     hideBalance = false,
+    vaultConnectivity = null,
 }: Props) {
     const {coldStorageWalletID, walletID, allBTCWallets} = useAuthStore();
 
@@ -212,26 +225,52 @@ export default function Card({ onPress,
 
     const cardChildren = (
         <>
-            {/* Translucent lightning watermark behind the card content —
-                mirrors the same treatment on the home "Unlock Lightning
-                Wallet" CTA so all Lightning surfaces share the visual
-                language. 12% alpha keeps it readable but lets the card's
-                pink (Strike/CoinOS) or grey (Ark) gradient show through. */}
-            <Image
-                source={Electricity}
-                style={{
-                    position: 'absolute',
-                    alignSelf: 'center',
-                    top: '50%',
-                    marginTop: -42,
-                    width: 60,
-                    height: 84,
-                    tintColor: '#FFFFFF',
-                    opacity: 0.10,
-                }}
-                resizeMode="contain"
-                pointerEvents="none"
-            />
+            {vaultConnectivity?.level === 'red' ? (
+                /* Offline vault: the watermark itself becomes the warning.
+                   A red dot in the corner is easy to miss on a card the user
+                   glances at, and the failure it reports is the one that reads
+                   most convincingly as normal — every expiry countdown keeps
+                   ticking off an estimated tip, so a stale card looks healthy.
+                   Swapping the lightning glyph for a warning sign changes the
+                   card's whole silhouette, which is noticeable without reading.
+                   Ionicons rather than a new asset: `warning` is already
+                   bundled and this needs no artwork. Carried at a higher alpha
+                   than the 0.10 lightning because it has to register, not
+                   recede. */
+                <View
+                    style={{
+                        position: 'absolute',
+                        alignSelf: 'center',
+                        top: '50%',
+                        marginTop: -42,
+                        opacity: 0.22,
+                    }}
+                    pointerEvents="none"
+                >
+                    <Ionicons name="warning" size={84} color="#FF7A68" />
+                </View>
+            ) : (
+                /* Translucent lightning watermark behind the card content —
+                    mirrors the same treatment on the home "Unlock Lightning
+                    Wallet" CTA so all Lightning surfaces share the visual
+                    language. 12% alpha keeps it readable but lets the card's
+                    pink (Strike/CoinOS) or grey (Ark) gradient show through. */
+                <Image
+                    source={Electricity}
+                    style={{
+                        position: 'absolute',
+                        alignSelf: 'center',
+                        top: '50%',
+                        marginTop: -42,
+                        width: 60,
+                        height: 84,
+                        tintColor: '#FFFFFF',
+                        opacity: 0.10,
+                    }}
+                    resizeMode="contain"
+                    pointerEvents="none"
+                />
+            )}
             <View style={styles.view}>
                 {wallet === 'ARK' ? (
                     // Boat-outline icon next to the "Ark Vault" title —
@@ -431,6 +470,54 @@ export default function Card({ onPress,
                         use a solid color and let the wrapper's percent
                         width control the fill. */}
                     <Reanimated.View style={[styles.linearGradient2, { backgroundColor: colors.pink.dark, minWidth: 6 } as any, fillStyle]} />
+                </View>
+            )}
+            {/* Vault connectivity, bottom-left. Last child of the card's
+                column, so it sits under the capsule slots without absolute
+                positioning that could ride over them on a narrow screen.
+                Deliberately small and quiet: on a healthy vault this is
+                reassurance the user should be able to ignore, and the loud
+                signal for an unhealthy one is the warning watermark behind
+                it rather than this line.
+
+                COPY: Bam finalizes. Same status vocabulary as the fuller
+                pill on the Capsules tab, shortened because the card is
+                already titled "Bark Vault" and repeating the noun here
+                reads as stutter. */}
+            {vaultConnectivity && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 10 }}>
+                    <View
+                        style={{
+                            width: 7,
+                            height: 7,
+                            borderRadius: 3.5,
+                            marginRight: 6,
+                            backgroundColor:
+                                vaultConnectivity.level === 'green'
+                                    ? '#4ADE80'
+                                    : vaultConnectivity.level === 'yellow'
+                                        ? colors.ark.light
+                                        : '#FF7A68',
+                        }}
+                    />
+                    <Text
+                        style={{
+                            fontSize: 10,
+                            fontWeight: '600',
+                            color:
+                                vaultConnectivity.level === 'green'
+                                    ? '#4ADE80'
+                                    : vaultConnectivity.level === 'yellow'
+                                        ? colors.ark.light
+                                        : '#FF7A68',
+                        }}
+                    >
+                        {vaultConnectivity.level === 'green'
+                            ? 'Connected'
+                            : vaultConnectivity.level === 'yellow'
+                                ? 'Connection slow'
+                                : 'Offline'}
+                    </Text>
                 </View>
             )}
         </>

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -51,6 +51,8 @@ import { processArkMovementsForActivity } from '@Cypher/services/ark/movementsAc
 // Imported from the file path directly (not the @Cypher/services/ark
 // barrel) — the barrel doesn't re-export the expiry module.
 import { formatBlocksUntil } from '@Cypher/services/ark/expiry';
+// Also not re-exported through the barrel.
+import { shouldRescheduleExpiryWarning } from '@Cypher/services/ark/chainTipFreshness';
 import useAuthStore from '@Cypher/stores/authStore';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import {
@@ -1148,8 +1150,32 @@ export default function useArkSync(): UseArkSync {
                     const blocksLeft = v.expiryHeight - tip;
                     if (blocksLeft <= 0) continue;
                     const expiryAtMs = nowMs + blocksLeft * blockMs;
-                    nextScheduled[v.id] = expiryAtMs;
-                    if (needsScheduleMigration || prevScheduled[v.id] == null) {
+                    const previousAtMs = prevScheduled[v.id] ?? null;
+                    // Re-queue when our estimate of the deadline has moved.
+                    // Previously the guard was `prevScheduled[v.id] == null`
+                    // alone, which scheduled each VTXO exactly once and never
+                    // again: the estimate was recomputed every tick but the OS
+                    // alarms stayed pinned to the very first projection, and
+                    // the two were never compared. The 10-minute nominal block
+                    // interval means real expiry arrives EARLIER than that
+                    // first projection, so the drift always runs in the
+                    // direction that fires the warnings late. Re-queueing is
+                    // idempotent by id, so this replaces rather than stacks.
+                    const drifted = shouldRescheduleExpiryWarning({
+                        previousAtMs,
+                        currentAtMs: expiryAtMs,
+                    });
+                    const reschedule = needsScheduleMigration || drifted;
+                    // Carry the previous value forward when we are NOT
+                    // re-queueing. This map's documented contract is "the
+                    // expiry we scheduled FOR", and overwriting it with the
+                    // freshly recomputed estimate on every tick broke that in
+                    // two ways: drift became undetectable (each tick compared
+                    // against a value one tick old, never more than ~30s of
+                    // drift), and the map changed every tick, so the persisted
+                    // store took a write every 30s for no reason.
+                    nextScheduled[v.id] = reschedule ? expiryAtMs : (previousAtMs ?? expiryAtMs);
+                    if (reschedule) {
                         try {
                             // Pass per-VTXO sats so the notification title
                             // carries "{N} sats" instead of the generic

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -270,6 +270,7 @@ export default function useArkSync(): UseArkSync {
     const setArkPendingLnReceives = useAuthStore((s) => s.setArkPendingLnReceives);
     const setArkChainTipHeight = useAuthStore((s) => s.setArkChainTipHeight);
     const setArkLastSyncedAt = useAuthStore((s) => s.setArkLastSyncedAt);
+    const setArkSyncFailStreak = useAuthStore((s) => s.setArkSyncFailStreak);
     const setArkLastBackupAt = useAuthStore((s) => s.setArkLastBackupAt);
     const arkRoundIntervalSecs = useAuthStore((s) => s.arkRoundIntervalSecs);
     const setArkRoundIntervalSecs = useAuthStore((s) => s.setArkRoundIntervalSecs);
@@ -1567,6 +1568,10 @@ export default function useArkSync(): UseArkSync {
                 setArkChainTipHeight(tip);
             }
             setArkLastSyncedAt(Date.now());
+            // A completed tick is the only thing that clears the streak, so
+            // the connectivity dot recovers the moment the vault is reachable
+            // again rather than waiting for staleness to age out.
+            setArkSyncFailStreak(0);
             setLastError(null);
 
             // --- Soonest spendable expiry (feeds the failure escalation) ---
@@ -1698,6 +1703,12 @@ export default function useArkSync(): UseArkSync {
             }
         } catch (err) {
             console.warn('[Ark] sync failed:', err);
+            // Record the failure itself. Everything else here is written only
+            // on success, which left the UI inferring trouble from staleness
+            // and taking 20 minutes to admit a vault was offline. Read from
+            // the store rather than a closed-over value so the count is right
+            // even if this callback is stale.
+            setArkSyncFailStreak(useAuthStore.getState().arkSyncFailStreak + 1);
             setLastError(err instanceof Error ? err : new Error(String(err)));
         } finally {
             inFlight.current = false;
@@ -1710,6 +1721,7 @@ export default function useArkSync(): UseArkSync {
         setArkPendingLnReceives,
         setArkChainTipHeight,
         setArkLastSyncedAt,
+        setArkSyncFailStreak,
         setArkLastBackupAt,
         arkExitInProgress,
         arkExitDestinationAddress,

--- a/src/screens/Ark/ArkCapsulesInfoScreen/index.tsx
+++ b/src/screens/Ark/ArkCapsulesInfoScreen/index.tsx
@@ -158,7 +158,7 @@ export default function ArkCapsulesInfoScreen() {
                     </Body>
                     <Body>
                         Second.tech sets these fees, not Cypher Box, and can change them at
-                        any time. The figures below were checked in August 2026. For the
+                        any time. The figures below were checked in September 2026. For the
                         current schedule, see:
                     </Body>
                     <LinkRow label="second.tech/pricing" url={SECOND_FEES_URL} />
@@ -172,7 +172,7 @@ export default function ArkCapsulesInfoScreen() {
                     />
                     <FeeRow
                         title="Refreshing"
-                        body="Free within 2 days of expiry. 0.2% with under 7 days left, 0.4% with under 14 days left, 0.5% at 14 days or more. The reminders fire inside the cheapest part of that range, so following them costs little or nothing."
+                        body="0.2% with under 2 days left, 0.4% from 2 to 7 days, and 0.5% with more than 7 days left. Refreshing is free while a capsule is inside the short grace window just after expiry. Refreshing early costs the most, so waiting for a reminder is cheaper than refreshing on sight. Reminders fire inside the 0.2% band."
                     />
                     <FeeRow
                         title="Sending over Lightning"

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -3,6 +3,7 @@ import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
 import { ARK_REFRESH_MIN_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, isVtxoMidRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
+import { deriveVaultConnectivity } from "@Cypher/services/ark/chainTipFreshness";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";
 import { dispatchNavigate } from "@Cypher/helpers";
@@ -81,7 +82,38 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         arkRefreshStuck,
         setArkPendingOnchainRecoverOpen,
         arkExitFeeReserveSats,
+        // Behind the offline warning below. All three are written only on a
+        // SUCCESSFUL read, which is what makes their age the signal.
+        arkChainTipHeightAt,
+        arkLastSyncedAt,
+        arkSyncFailStreak,
     } = useAuthStore();
+
+    /**
+     * Slow clock for the offline warning.
+     *
+     * The warning has to be able to APPEAR with no store activity at all: the
+     * failure it reports is exactly the one that stops anything being written.
+     * Without a tick of its own the row would keep showing whatever it last
+     * said while the vault sat unreachable. 30s matches the Capsules tab and
+     * the home card, and the thresholds it feeds are minutes wide.
+     */
+    const [connTick, setConnTick] = useState(() => Date.now());
+    useEffect(() => {
+        const t = setInterval(() => setConnTick(Date.now()), 30_000);
+        return () => clearInterval(t);
+    }, []);
+
+    const vaultConnectivity = useMemo(
+        () =>
+            deriveVaultConnectivity({
+                tipFetchedAtMs: arkChainTipHeightAt,
+                lastSyncedAtMs: arkLastSyncedAt,
+                nowMs: connTick,
+                syncFailStreak: arkSyncFailStreak,
+            }),
+        [arkChainTipHeightAt, arkLastSyncedAt, arkSyncFailStreak, connTick],
+    );
 
     // Per-card vertical nudge for the Ark slide.
     //
@@ -239,6 +271,29 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
     }, []);
 
     const bgRefreshStatus = useMemo(() => {
+        // OFFLINE FIRST, ahead of everything below including an in-flight
+        // refresh.
+        //
+        // Every other line in this chain is derived from the cached chain tip:
+        // how many days a capsule has left, whether it is dust, whether a
+        // refresh is due. When the vault cannot be reached none of those
+        // numbers are reads, they are projections off a tip that stopped
+        // moving, and they keep counting down as if nothing were wrong. That
+        // is the failure that misleads in the expensive direction, so it
+        // outranks the advice built on top of it.
+        //
+        // The card's own status dot says the same thing quietly. This row says
+        // it in red, because the dot answers "is it connected" and this answers
+        // "should you trust the numbers you are looking at".
+        if (vaultConnectivity.level === 'red') {
+            return {
+                // COPY: Bam finalizes.
+                text: 'Bark vault is offline. Capsule times shown are estimates until it reconnects.',
+                error: true,
+                tapTab: 0,
+            };
+        }
+
         // Refresh in flight: short-circuit to all-clear. The Ark Card
         // itself surfaces the live "Refreshing N capsules · X sats" line
         // inside its balance area (see Card's `refreshingInfo` prop) so
@@ -327,6 +382,11 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         arkIosBackupReminderActive,
         pendingRound,
         arkBalanceDetail,
+        // Without this the offline branch never re-evaluates and the row keeps
+        // showing whatever it said when the vault was last reachable, which is
+        // the exact failure the branch exists to report.
+        vaultConnectivity,
+        arkExitFeeReserveSats,
     ]);
 
     const [indexStrike, setIndexStrike] = useState(0);

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ActivityIndicator, Alert, Animated, Easing, FlatList, Image, ImageBackground, Text as RNText, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Alert, Animated, Easing, FlatList, Image, ImageBackground, RefreshControl, Text as RNText, TouchableOpacity, View } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
 import { Icon } from "react-native-elements";
 import Svg, { Circle } from "react-native-svg";
@@ -44,6 +44,12 @@ import {
     fetchArkNextRequiredRefreshHeight,
     formatBlocksUntil,
 } from "@Cypher/services/ark/expiry";
+// Same reason as the expiry import above: not re-exported through the barrel.
+import {
+    deriveVaultConnectivity,
+    effectiveChainTip,
+    type VaultConnectivity,
+} from "@Cypher/services/ark/chainTipFreshness";
 import { buildRefreshBatch } from "@Cypher/services/ark/refreshBatch";
 import { buildDeferredVtxoIds } from "@Cypher/services/ark/refreshDeferral";
 import useAuthStore from "@Cypher/stores/authStore";
@@ -1129,9 +1135,99 @@ function RefreshWaitBanner({
     );
 }
 
+/**
+ * Vault connectivity traffic light.
+ *
+ * Exists because the vault UI used to look IDENTICAL whether esplora was
+ * answering or had been unreachable for a day. Every expiry number on this
+ * screen is `expiryHeight - chainTip`, and the cached tip is only overwritten
+ * on a successful fetch, so an outage froze every countdown at its last value
+ * and there was nothing on screen to say so. A frozen "25 days left" read
+ * exactly like a true one, and it failed in the optimistic direction.
+ *
+ * Green is deliberately quiet (a dot and a word) so the only thing that draws
+ * the eye is a vault that has actually lost contact.
+ *
+ * COPY: Bam finalizes. Placeholder strings below are factual but unstyled for
+ * voice, and are the only new user-facing text in this change.
+ */
+function VaultConnectivityPill({ conn }: { conn: VaultConnectivity }) {
+    const { level } = conn;
+    // Reuses the palette already used by the depletion ring in this file so
+    // the status colors read as one system: green #4ADE80, amber via the ark
+    // token, red #FF7A68 (the same red as the stranded-dust warning).
+    const color =
+        level === 'green' ? '#4ADE80' : level === 'yellow' ? colors.ark.light : '#FF7A68';
+
+    // Age is quoted from whichever signal is actually the problem, so the
+    // number the user sees matches the reason given.
+    const ageMs =
+        level === 'green'
+            ? 0
+            : Math.max(conn.tip.ageMs ?? 0, conn.syncAgeMs ?? 0);
+    const ageLabel = formatAgo(ageMs);
+
+    const label =
+        level === 'green'
+            ? 'Vault connected'
+            : level === 'yellow'
+                ? `Vault connection slow (updated ${ageLabel})`
+                : `Vault offline (last updated ${ageLabel})`;
+
+    return (
+        <View style={{ marginBottom: 6 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <View
+                    style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: 4,
+                        backgroundColor: color,
+                        marginRight: 7,
+                    }}
+                />
+                <RNText style={{ fontSize: 12, color, fontWeight: '700' }}>{label}</RNText>
+            </View>
+            {/* Only once the tip is too old to vouch for. The countdowns are
+                still shown (and still tick down, because the tip is advanced
+                by elapsed time rather than frozen), but the user is told they
+                are projections rather than reads. */}
+            {!conn.tip.trusted && (
+                <RNText style={{ fontSize: 11, color: '#ddd', marginTop: 3 }}>
+                    Times below are estimates until the vault reconnects.
+                </RNText>
+            )}
+        </View>
+    );
+}
+
+/**
+ * Coarse "how long ago" for the connectivity pill. Minutes then hours then
+ * days; never seconds, because the pill only appears once the tip is already
+ * minutes old and a ticking seconds counter would read as more precision than
+ * the underlying estimate has.
+ */
+function formatAgo(ms: number): string {
+    const mins = Math.floor(ms / 60000);
+    if (mins < 60) return `${Math.max(1, mins)}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+}
+
 export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps) {
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
     const [refreshing, setRefreshing] = useState(false);
+    // Pull-to-refresh spinner. Deliberately NOT `refreshing` above: that one
+    // gates the round-submission path (dust sweep / per-row refresh), and
+    // reusing it would spin the list control whenever a round is being
+    // submitted and, worse, let a pull gesture read as a queued round.
+    const [pullRefreshing, setPullRefreshing] = useState(false);
+    // In-flight latch for the pull gesture. A ref, not the state above:
+    // setState is async, so two quick pulls can both pass a state check
+    // before either render lands. Same reason the round paths keep their
+    // own latches (see arkRefreshingVtxoIds, which is not a mutex).
+    const pullRefreshInFlight = useRef(false);
     // True between cancel-tap and the round actually clearing (NOT just
     // until our cancel call returns). bark's cancel can return failure
     // due to a transient internal-lock timeout while the round itself
@@ -1145,7 +1241,11 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     const arkRefreshingVtxoIds = useAuthStore((s) => s.arkRefreshingVtxoIds);
     const arkPendingLnReceives = useAuthStore((s) => s.arkPendingLnReceives);
     const setArkPendingLnReceives = useAuthStore((s) => s.setArkPendingLnReceives);
-    const chainTipHeight = useAuthStore((s) => s.arkChainTipHeight);
+    const rawChainTipHeight = useAuthStore((s) => s.arkChainTipHeight);
+    // Epoch ms the tip above was read. Already stamped by setArkChainTipHeight;
+    // until now its only consumer was the exit-funding triage, so the capsule
+    // countdowns trusted a tip of any age.
+    const arkChainTipHeightAt = useAuthStore((s) => s.arkChainTipHeightAt);
     const arkLastBackupAt = useAuthStore((s) => s.arkLastBackupAt);
     const arkRoundIntervalSecs = useAuthStore((s) => s.arkRoundIntervalSecs);
     // Read-only on this screen — the toggle lives on the Ark Settings
@@ -1177,6 +1277,116 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // Consecutive refresh failures, drives the per-row "N refresh attempts
     // failed" copy while a capsule is stuck mid-refresh.
     const arkRefreshFailStreak = useAuthStore((s) => s.arkRefreshFailStreak);
+
+    // Slow clock for the staleness derivations below. 30s rather than the 1s
+    // used by the in-flight round countdown: the thresholds it feeds are
+    // minutes wide, and re-deriving the row list every second would be pure
+    // waste on a wallet with many capsules. It exists at all because the
+    // connectivity pill has to degrade on its own: if the sync loop is the
+    // thing that is wedged, no store write will arrive to re-render us.
+    const [nowTick, setNowTick] = useState(() => Date.now());
+    useEffect(() => {
+        const t = setInterval(() => setNowTick(Date.now()), 30_000);
+        return () => clearInterval(t);
+    }, []);
+
+    /**
+     * The tip to actually compute expiry against.
+     *
+     * `arkChainTipHeight` is only written on a SUCCESSFUL esplora read, and
+     * the store is persisted with no partialize, so on an outage (or a cold
+     * launch with no connectivity) this screen used to render
+     * `expiryHeight - <last good tip>` and freeze every countdown at the value
+     * it had when contact was lost. That is the unsafe direction: it tells the
+     * user they have more runway than they do, and it survives the force-quit
+     * they would use to try to clear it.
+     *
+     * Advancing the cached tip by the elapsed block count is an estimate, but
+     * it is wrong in the direction that costs a round fee rather than the
+     * direction that costs the capsule. See services/ark/chainTipFreshness.
+     */
+    const chainTipHeight = useMemo(
+        () =>
+            effectiveChainTip({
+                tip: rawChainTipHeight,
+                fetchedAtMs: arkChainTipHeightAt,
+                nowMs: nowTick,
+            }),
+        [rawChainTipHeight, arkChainTipHeightAt, nowTick],
+    );
+
+    // Traffic light for the header. Folds in the sync stamp as well as the
+    // tip, because the two fail independently (esplora can answer while the
+    // wallet handle is wedged, and vice versa).
+    const connectivity = useMemo(
+        () =>
+            deriveVaultConnectivity({
+                tipFetchedAtMs: arkChainTipHeightAt,
+                lastSyncedAtMs: arkLastSyncedAt,
+                nowMs: nowTick,
+            }),
+        [arkChainTipHeightAt, arkLastSyncedAt, nowTick],
+    );
+
+    /**
+     * Pull-to-refresh: run the same read sequence the 30s `useArkSync` tick
+     * runs, on demand. Purely an affordance for "I am waiting on a Lightning
+     * receive to land" (and for on-device triage). It submits nothing.
+     *
+     * Same three calls, in the same order, as the pre-submit resync in
+     * `handleDustRefresh`: `syncArkWallet()` pulls round finalisations and
+     * incoming payments into the local datadir, then balance + vtxos read
+     * that datadir back into zustand, which is what re-renders this list.
+     *
+     * We do not touch `arkLastSyncedAt`, which is useArkSync's own cycle
+     * marker, and bumping it from here would fake a completed tick for every
+     * other screen keyed off it (ArkHistory reloads, the next-refresh-due
+     * effect below). The store writes inside fetchArkBalance/fetchArkVtxos
+     * are what this list actually renders from, so it updates regardless.
+     *
+     * Overlap with the tick is tolerable and already the norm on this screen
+     * (the dust resync and the stuck-round cancel both call `syncArkWallet`
+     * directly, and `syncArkWallet` carries its own exit-in-progress guard
+     * precisely because of that). The latch below only stops this gesture
+     * from stacking on itself.
+     */
+    const onPullRefresh = useCallback(() => {
+        if (pullRefreshInFlight.current) return;
+        pullRefreshInFlight.current = true;
+        setPullRefreshing(true);
+        void (async () => {
+            try {
+                await syncArkWallet();
+                await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+            } catch (err: any) {
+                console.warn(
+                    '[Ark pull-refresh] sync failed, keeping last-known state:',
+                    err?.message ?? err,
+                );
+                // Say so. A silent failure here is worse than no gesture at
+                // all: the user pulls, sees a spinner, sees the countdown not
+                // move, and reads that as "confirmed, still 25 days" when the
+                // truth is that we never reached the chain. The connectivity
+                // pill above is the persistent signal; this is the immediate
+                // one for the person who just asked.
+                //
+                // COPY: Bam finalizes the context prefix. Deliberately NOT
+                // "Refresh failed" (used below for a round submission) since
+                // this gesture submits nothing. The remedy text after the
+                // prefix is the existing shared network-fault copy.
+                SimpleToast.show(
+                    describeArkFailure(err, "Couldn't update", {
+                        chainUrls: ESPLORA_URLS,
+                        arkUrl: ARK_SERVER_URL,
+                    }),
+                    SimpleToast.LONG,
+                );
+            } finally {
+                pullRefreshInFlight.current = false;
+                setPullRefreshing(false);
+            }
+        })();
+    }, []);
 
     // Recover a stuck refresh from the Capsules tab. Mirrors the home-card
     // handler in ArkWallet — but that banner is invisible to a user sitting
@@ -2315,6 +2525,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 The on/off line is read-only — the actual toggle lives on
                 the Ark Settings tab. */}
             <View style={{ marginHorizontal: 20, marginTop: 14, marginBottom: 8, alignItems: 'flex-start' }}>
+                {/* Connectivity first: it qualifies every number below it.
+                    Every expiry figure on this screen is derived from the
+                    chain tip, so "can we currently see the chain" has to be
+                    readable before the countdowns are, not buried under
+                    them. */}
+                <VaultConnectivityPill conn={connectivity} />
                 <Text bold style={{ fontSize: 16, color: '#FFF', marginBottom: 6 }}>
                     Reminders:{' '}
                     <Text
@@ -2546,6 +2762,13 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 data={rows}
                 keyExtractor={(item) => item.id}
                 showsVerticalScrollIndicator={false}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={pullRefreshing}
+                        onRefresh={onPullRefresh}
+                        tintColor="white"
+                    />
+                }
                 renderItem={({ item }) => (
                     <VtxoRow
                         vtxo={item}

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1259,6 +1259,8 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // alongside the rest of the wallet's read state without spinning up a
     // separate poll.
     const arkLastSyncedAt = useAuthStore((s) => s.arkLastSyncedAt);
+    // Failed ticks, so the pill can degrade on evidence rather than on age.
+    const arkSyncFailStreak = useAuthStore((s) => s.arkSyncFailStreak);
     // One-shot flag set by the notification tap handler in
     // src/services/ark/scheduler.ts. Drives the auto-refresh effect below
     // so the user lands on this tab with refresh already running, without
@@ -1324,8 +1326,9 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 tipFetchedAtMs: arkChainTipHeightAt,
                 lastSyncedAtMs: arkLastSyncedAt,
                 nowMs: nowTick,
+                syncFailStreak: arkSyncFailStreak,
             }),
-        [arkChainTipHeightAt, arkLastSyncedAt, nowTick],
+        [arkChainTipHeightAt, arkLastSyncedAt, arkSyncFailStreak, nowTick],
     );
 
     /**

--- a/src/services/ark/chainTipFreshness.ts
+++ b/src/services/ark/chainTipFreshness.ts
@@ -1,0 +1,228 @@
+/**
+ * Nominal minutes per block, mirroring `AVG_BLOCK_MINUTES` in ./chainTip.
+ *
+ * Deliberately re-declared rather than imported: chainTip.ts imports
+ * ./config, which imports the bark SDK, and config.ts cannot be loaded under
+ * jest. Keeping this module free of that edge is what lets the rules below be
+ * unit-tested. Same reasoning (and same trade) as ./esploraProviders.
+ *
+ * If AVG_BLOCK_MINUTES ever changes, change this with it. The unit suite
+ * pins the value so the drift is at least loud.
+ */
+export const NOMINAL_BLOCK_MINUTES = 10;
+
+/**
+ * How old the cached chain tip is allowed to get before the vault's expiry
+ * numbers stop being presented as verified.
+ *
+ * Background (the bug this module exists to close): `arkChainTipHeight` is
+ * only written when `fetchChainTipHeight()` succeeds. On an esplora outage
+ * the previous value is deliberately left in place, so every consumer that
+ * computes `expiryHeight - tip` freezes at whatever it read last. The
+ * VTXO countdown then stops ticking down and holds a value that is too
+ * generous, and it holds it silently: a frozen "25 days left" renders
+ * identically to a true one. The whole store is persisted (there is no
+ * `partialize`), so the stale tip also survives a force-quit, and the
+ * usual user remedy of relaunching reconfirms the wrong number instead of
+ * clearing it. Issue #204 was the same defect reached by a different route
+ * (the exit path returned before refreshing the tip) and its fix notes call
+ * the result "stale and over-optimistic".
+ *
+ * Two thresholds, both deliberately generous relative to the sync cadence
+ * (30s on iOS, 60s on Android) so a single missed tick never alarms:
+ *
+ *   - FRESH   (<= 3 min)  roughly 3-6 ticks of slack. Normal operation.
+ *   - DEGRADED(<= 20 min) esplora is flaking or the device is offline.
+ *                         Numbers are still shown but marked estimated.
+ *   - STALE   (> 20 min)  two block intervals with no contact. Nothing read
+ *                         from the chain can be asserted, including whether
+ *                         a VTXO is dead.
+ *
+ * Intentionally STRICTER than `MAX_TIP_AGE_FOR_TRIAGE_MS` (1 hour, in
+ * ./exitFunding), and the difference is not an oversight. That threshold
+ * decides whether to REFUSE to compute an exit plan, so it is set where the
+ * drift would actually change the answer. These thresholds decide how to
+ * LABEL a number we are showing either way, so they sit where the number
+ * stops being current. Do not collapse them into one value.
+ */
+export const TIP_FRESH_MS = 3 * 60 * 1000;
+export const TIP_DEGRADED_MS = 20 * 60 * 1000;
+
+export type TipFreshnessLevel = 'fresh' | 'degraded' | 'stale' | 'unknown';
+
+export interface TipFreshness {
+    level: TipFreshnessLevel;
+    /** Age of the cached tip in ms, or null when we have never fetched one. */
+    ageMs: number | null;
+    /**
+     * Whether a chain-derived assertion may be treated as authoritative.
+     * False for 'stale' and 'unknown'. Callers use this to avoid asserting
+     * the UNSAFE-if-wrong direction of a claim: specifically, "this VTXO is
+     * expired" must not be shown off a tip we cannot vouch for, because that
+     * tells the user their funds are gone when they may still be refreshable
+     * inside the ASP's post-expiry grace window.
+     */
+    trusted: boolean;
+}
+
+/**
+ * Classify how much we can rely on the cached chain tip.
+ *
+ * `fetchedAtMs` is the wall-clock time the tip was last successfully read,
+ * null when the app has never reached esplora.
+ */
+export function deriveTipFreshness(args: {
+    fetchedAtMs: number | null;
+    nowMs: number;
+}): TipFreshness {
+    const { fetchedAtMs, nowMs } = args;
+    if (fetchedAtMs === null || !Number.isFinite(fetchedAtMs)) {
+        return { level: 'unknown', ageMs: null, trusted: false };
+    }
+    // A clock that moved backwards (timezone change, NTP correction, user
+    // edit) would otherwise read as a negative age and pass every threshold
+    // as "fresh". Clamp: we cannot prove freshness, so do not claim it.
+    const ageMs = Math.max(0, nowMs - fetchedAtMs);
+    if (ageMs <= TIP_FRESH_MS) return { level: 'fresh', ageMs, trusted: true };
+    if (ageMs <= TIP_DEGRADED_MS) return { level: 'degraded', ageMs, trusted: true };
+    return { level: 'stale', ageMs, trusted: false };
+}
+
+/**
+ * The chain tip to actually compute expiry against: the last fetched height
+ * advanced by however many blocks are likely to have been mined since.
+ *
+ * Freezing the tip is the failure we are fixing, so doing nothing is not an
+ * option. Extrapolating at the nominal block interval is an estimate, but it
+ * errs in the SAFE direction and freezing errs in the unsafe one:
+ *
+ *   - Extrapolating too fast  -> we understate remaining life -> the user
+ *     refreshes earlier than strictly needed. Costs a few sats of round fee.
+ *   - Freezing                -> we overstate remaining life -> the user
+ *     does nothing and the VTXO expires. Costs the VTXO.
+ *
+ * Real inter-block time runs slightly under the nominal 10 minutes whenever
+ * hashrate is growing, so this estimate is, if anything, mildly conservative
+ * too, which is the direction we want.
+ *
+ * Deliberately uncapped. The cold-launch case is exactly why: an app reopened
+ * after three weeks offline reads its persisted tip from disk, and adding the
+ * elapsed blocks is what correctly renders those VTXOs as long gone rather
+ * than showing the 25-days-left number they had when the app was last closed.
+ *
+ * Returns null when there is no tip at all, which callers already handle as
+ * "expiry unknown".
+ */
+export function effectiveChainTip(args: {
+    tip: number | null;
+    fetchedAtMs: number | null;
+    nowMs: number;
+}): number | null {
+    const { tip, fetchedAtMs, nowMs } = args;
+    if (tip === null || !Number.isFinite(tip)) return null;
+    if (fetchedAtMs === null || !Number.isFinite(fetchedAtMs)) return tip;
+    const ageMs = Math.max(0, nowMs - fetchedAtMs);
+    const blockMs = NOMINAL_BLOCK_MINUTES * 60 * 1000;
+    return tip + Math.floor(ageMs / blockMs);
+}
+
+/**
+ * Traffic-light summary of whether the vault can currently see the chain.
+ *
+ * The vault UI previously looked identical whether esplora was answering or
+ * had been unreachable for a day, which is what let a frozen countdown pass
+ * for a live one. This is the signal that makes the difference visible.
+ *
+ * Two inputs, because they fail independently:
+ *   - the chain tip (esplora), which is what every expiry number is computed
+ *     against, and
+ *   - the sync loop's own completion stamp, which goes stale when the wallet
+ *     handle is wedged or the ASP is unreachable even while esplora is fine.
+ *
+ * The worse of the two wins. A vault that can read the chain but cannot
+ * complete a sync is not healthy, and neither is the reverse.
+ */
+export type VaultConnectivityLevel = 'green' | 'yellow' | 'red';
+
+export interface VaultConnectivity {
+    level: VaultConnectivityLevel;
+    tip: TipFreshness;
+    /** Age of the last completed sync cycle in ms, null if never completed. */
+    syncAgeMs: number | null;
+}
+
+export function deriveVaultConnectivity(args: {
+    tipFetchedAtMs: number | null;
+    lastSyncedAtMs: number | null;
+    nowMs: number;
+}): VaultConnectivity {
+    const { tipFetchedAtMs, lastSyncedAtMs, nowMs } = args;
+    const tip = deriveTipFreshness({ fetchedAtMs: tipFetchedAtMs, nowMs });
+
+    const syncAgeMs =
+        lastSyncedAtMs === null || !Number.isFinite(lastSyncedAtMs)
+            ? null
+            : Math.max(0, nowMs - lastSyncedAtMs);
+
+    const tipLevel: VaultConnectivityLevel =
+        tip.level === 'fresh' ? 'green' : tip.level === 'degraded' ? 'yellow' : 'red';
+
+    const syncLevel: VaultConnectivityLevel =
+        syncAgeMs === null
+            ? 'red'
+            : syncAgeMs <= TIP_FRESH_MS
+                ? 'green'
+                : syncAgeMs <= TIP_DEGRADED_MS
+                    ? 'yellow'
+                    : 'red';
+
+    const rank: Record<VaultConnectivityLevel, number> = { green: 0, yellow: 1, red: 2 };
+    const level = rank[syncLevel] > rank[tipLevel] ? syncLevel : tipLevel;
+
+    return { level, tip, syncAgeMs };
+}
+
+/**
+ * Maximum drift tolerated between a queued expiry alarm and the current best
+ * estimate of when the VTXO actually expires, before the alarm is re-queued.
+ *
+ * Two hours: the tightest warnings in the schedule are at 12h and 6h before
+ * expiry, so drift beyond a couple of hours is what starts moving those
+ * across the deadline they exist to precede.
+ */
+export const EXPIRY_ALARM_MAX_DRIFT_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Whether a VTXO's queued OS expiry alarms should be re-scheduled.
+ *
+ * The bug this closes: the alarms are computed ONCE, at the first sync that
+ * sees the VTXO, as `now + blocksLeft * 10 minutes`, and the scheduling call
+ * is then guarded on "have we scheduled this id before". Every later tick
+ * recomputes the estimate against a fresh tip and stores it, but never
+ * re-queues, so the stored estimate silently converges on the truth while the
+ * OS alarms stay pinned to the original guess. Nothing compared the two.
+ *
+ * The 10-minute nominal block interval is the source of the drift: real
+ * inter-block time runs under 10 minutes whenever hashrate is growing, so
+ * real expiry arrives EARLIER than the original projection and every alarm
+ * fires late. Over a full 28-day life that can be enough to push the last
+ * warnings past the expiry they were meant to precede.
+ *
+ * Re-scheduling is safe and cheap: the OS replaces an entry with the same id
+ * (see scheduleVtxoExpiryWarnings), so this is an update, not a duplicate.
+ * Gated on a threshold rather than run every tick because re-queueing five
+ * alarms per VTXO every 30 seconds would be wasteful and races the OS
+ * scheduler for no gain.
+ *
+ * `previousAtMs` is null when this VTXO has never been scheduled, which is
+ * always a yes.
+ */
+export function shouldRescheduleExpiryWarning(args: {
+    previousAtMs: number | null;
+    currentAtMs: number;
+    maxDriftMs?: number;
+}): boolean {
+    const { previousAtMs, currentAtMs, maxDriftMs = EXPIRY_ALARM_MAX_DRIFT_MS } = args;
+    if (previousAtMs === null || !Number.isFinite(previousAtMs)) return true;
+    return Math.abs(currentAtMs - previousAtMs) > maxDriftMs;
+}

--- a/src/services/ark/chainTipFreshness.ts
+++ b/src/services/ark/chainTipFreshness.ts
@@ -151,12 +151,37 @@ export interface VaultConnectivity {
     syncAgeMs: number | null;
 }
 
+/**
+ * Consecutive failed sync ticks at which the vault is called offline.
+ *
+ * Two, so roughly a minute at the 30s tick. One is enough to stop claiming
+ * everything is fine, but not enough to shout: a single failed tick is a
+ * common blip and flashing red on every one of them would train the user to
+ * ignore the colour that matters most.
+ */
+export const SYNC_FAIL_STREAK_FOR_RED = 2;
+
 export function deriveVaultConnectivity(args: {
     tipFetchedAtMs: number | null;
     lastSyncedAtMs: number | null;
     nowMs: number;
+    /**
+     * Consecutive failed sync ticks, 0 when the last tick succeeded.
+     *
+     * Without this the derivation is age-only, and both timestamps above are
+     * written ONLY on success, so a vault failing every single tick is
+     * indistinguishable from an idle one. Reaching red then took
+     * TIP_DEGRADED_MS, 20 minutes, and a device with its network switched off
+     * reported "connection slow" for the whole of it while the app had known
+     * on the first failed tick. Observed on device 2026-09-08.
+     *
+     * A failure is direct evidence. Age is only a proxy for it, so when both
+     * are available the evidence wins.
+     */
+    syncFailStreak?: number;
 }): VaultConnectivity {
     const { tipFetchedAtMs, lastSyncedAtMs, nowMs } = args;
+    const failStreak = Math.max(0, Math.trunc(args.syncFailStreak ?? 0));
     const tip = deriveTipFreshness({ fetchedAtMs: tipFetchedAtMs, nowMs });
 
     const syncAgeMs =
@@ -176,8 +201,16 @@ export function deriveVaultConnectivity(args: {
                     ? 'yellow'
                     : 'red';
 
+    // Failed ticks escalate on their own, independently of age. One says stop
+    // claiming green when we have just been told otherwise; two says offline.
+    const failLevel: VaultConnectivityLevel =
+        failStreak >= SYNC_FAIL_STREAK_FOR_RED ? 'red' : failStreak > 0 ? 'yellow' : 'green';
+
     const rank: Record<VaultConnectivityLevel, number> = { green: 0, yellow: 1, red: 2 };
-    const level = rank[syncLevel] > rank[tipLevel] ? syncLevel : tipLevel;
+    // Worst of the three wins, same rule as before with one more input.
+    const level = [tipLevel, syncLevel, failLevel].reduce((worst, l) =>
+        rank[l] > rank[worst] ? l : worst,
+    );
 
     return { level, tip, syncAgeMs };
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -410,6 +410,21 @@ export type AuthStateType = {
      */
     arkRefreshFailStreak: number;
     /**
+     * Consecutive failed sync ticks, reset to 0 by any success.
+     *
+     * Exists because every other connectivity signal is written only on
+     * SUCCESS, so a vault that is failing every tick looks identical to one
+     * that is simply idle, and the UI could only infer trouble from staleness.
+     * That took 20 minutes (TIP_DEGRADED_MS) to reach "offline" while the app
+     * already knew on the first failed tick. A failure is direct evidence;
+     * age is a proxy for it.
+     *
+     * Deliberately NOT persisted: it describes right now, and a streak
+     * restored from a previous run would claim knowledge of a network the app
+     * has not touched since launching.
+     */
+    arkSyncFailStreak: number;
+    /**
      * Epoch ms when the refresh-failing-near-expiry Alert was last shown.
      * Gates re-showing so the escalation fires once per re-show window
      * instead of on every sync tick while the streak persists.
@@ -525,6 +540,7 @@ export type AuthStateType = {
     ) => void;
     setArkBgRefreshConsecutiveFailures: (state: number) => void;
     setArkRefreshFailStreak: (state: number) => void;
+    setArkSyncFailStreak: (state: number) => void;
     setArkRefreshFailAlertAt: (state: number | null) => void;
     setArkBgRefreshDeferredBackup: (state: boolean) => void;
     setArkBgRefreshLastWarn24hAt: (state: number | null) => void;
@@ -621,6 +637,7 @@ const createAuthStore = (
     arkBgRefreshLastAttempt: null,
     arkBgRefreshConsecutiveFailures: 0,
     arkRefreshFailStreak: 0,
+    arkSyncFailStreak: 0,
     arkRefreshFailAlertAt: null,
     arkBgRefreshDeferredBackup: false,
     arkBgRefreshLastWarn24hAt: null,
@@ -710,6 +727,7 @@ const createAuthStore = (
     setArkBgRefreshLastAttempt: (state) => set({ arkBgRefreshLastAttempt: state }),
     setArkBgRefreshConsecutiveFailures: (state: number) => set({ arkBgRefreshConsecutiveFailures: state }),
     setArkRefreshFailStreak: (state: number) => set({ arkRefreshFailStreak: state }),
+    setArkSyncFailStreak: (state: number) => set({ arkSyncFailStreak: state }),
     setArkRefreshFailAlertAt: (state: number | null) => set({ arkRefreshFailAlertAt: state }),
     setArkBgRefreshDeferredBackup: (state: boolean) => set({ arkBgRefreshDeferredBackup: state }),
     setArkBgRefreshLastWarn24hAt: (state: number | null) => set({ arkBgRefreshLastWarn24hAt: state }),
@@ -792,6 +810,7 @@ const createAuthStore = (
             arkBgRefreshLastAttempt: null,
             arkBgRefreshConsecutiveFailures: 0,
             arkRefreshFailStreak: 0,
+            arkSyncFailStreak: 0,
             arkRefreshFailAlertAt: null,
             arkBgRefreshDeferredBackup: false,
             arkBgRefreshLastWarn24hAt: null,

--- a/tests/unit/chainTipFreshness.test.ts
+++ b/tests/unit/chainTipFreshness.test.ts
@@ -1,0 +1,242 @@
+import {
+    deriveTipFreshness,
+    deriveVaultConnectivity,
+    effectiveChainTip,
+    EXPIRY_ALARM_MAX_DRIFT_MS,
+    NOMINAL_BLOCK_MINUTES,
+    shouldRescheduleExpiryWarning,
+    TIP_DEGRADED_MS,
+    TIP_FRESH_MS,
+} from '../../src/services/ark/chainTipFreshness';
+
+const MIN = 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+describe('NOMINAL_BLOCK_MINUTES', () => {
+    // Pinned because the constant is re-declared rather than imported from
+    // chainTip.ts (which pulls config.ts and the bark SDK, unloadable under
+    // jest). If AVG_BLOCK_MINUTES moves, this fails and points at the drift.
+    it('mirrors AVG_BLOCK_MINUTES', () => {
+        expect(NOMINAL_BLOCK_MINUTES).toBe(10);
+    });
+});
+
+describe('deriveTipFreshness', () => {
+    it('reports unknown when the tip has never been fetched', () => {
+        const r = deriveTipFreshness({ fetchedAtMs: null, nowMs: NOW });
+        expect(r.level).toBe('unknown');
+        expect(r.ageMs).toBeNull();
+        expect(r.trusted).toBe(false);
+    });
+
+    it('reports fresh inside the fresh window', () => {
+        expect(deriveTipFreshness({ fetchedAtMs: NOW, nowMs: NOW }).level).toBe('fresh');
+        expect(
+            deriveTipFreshness({ fetchedAtMs: NOW - TIP_FRESH_MS, nowMs: NOW }).level,
+        ).toBe('fresh');
+    });
+
+    it('reports degraded past the fresh window but inside the degraded one', () => {
+        const r = deriveTipFreshness({ fetchedAtMs: NOW - TIP_FRESH_MS - 1, nowMs: NOW });
+        expect(r.level).toBe('degraded');
+        // Still trusted: the numbers are usable, just no longer pristine.
+        expect(r.trusted).toBe(true);
+        expect(
+            deriveTipFreshness({ fetchedAtMs: NOW - TIP_DEGRADED_MS, nowMs: NOW }).level,
+        ).toBe('degraded');
+    });
+
+    it('reports stale and untrusted past the degraded window', () => {
+        const r = deriveTipFreshness({ fetchedAtMs: NOW - TIP_DEGRADED_MS - 1, nowMs: NOW });
+        expect(r.level).toBe('stale');
+        expect(r.trusted).toBe(false);
+    });
+
+    it('never claims freshness from a backwards clock', () => {
+        // Clock jumped forward then corrected back, so fetchedAt is "future".
+        const r = deriveTipFreshness({ fetchedAtMs: NOW + 60 * MIN, nowMs: NOW });
+        expect(r.ageMs).toBe(0);
+        expect(r.level).toBe('fresh');
+    });
+
+    it('surfaces the age so callers can render it', () => {
+        expect(deriveTipFreshness({ fetchedAtMs: NOW - 7 * MIN, nowMs: NOW }).ageMs).toBe(
+            7 * MIN,
+        );
+    });
+});
+
+describe('effectiveChainTip', () => {
+    it('returns null when there is no tip at all', () => {
+        expect(effectiveChainTip({ tip: null, fetchedAtMs: NOW, nowMs: NOW })).toBeNull();
+    });
+
+    it('returns the raw tip when it has no fetch stamp', () => {
+        // Pre-upgrade persisted state: a tip exists but was written before the
+        // timestamp field was added. Do not invent an age for it.
+        expect(effectiveChainTip({ tip: 900_000, fetchedAtMs: null, nowMs: NOW })).toBe(900_000);
+    });
+
+    it('does not advance the tip within one block interval', () => {
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - 9 * MIN, nowMs: NOW }),
+        ).toBe(900_000);
+    });
+
+    it('advances one block per nominal block interval', () => {
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - 10 * MIN, nowMs: NOW }),
+        ).toBe(900_001);
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - 60 * MIN, nowMs: NOW }),
+        ).toBe(900_006);
+    });
+
+    it('is uncapped, so a long offline gap expires what should be expired', () => {
+        // The regression this exists for: app closed 21 days, reopened offline.
+        // Freezing would render a VTXO with 25 days of nominal life as still
+        // having 25 days left. Extrapolating burns the 3024 blocks that
+        // actually elapsed.
+        const threeWeeksMs = 21 * 24 * 60 * MIN;
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - threeWeeksMs, nowMs: NOW }),
+        ).toBe(900_000 + 3024);
+    });
+
+    it('never runs the tip backwards on a backwards clock', () => {
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW + 60 * MIN, nowMs: NOW }),
+        ).toBe(900_000);
+    });
+});
+
+describe('deriveVaultConnectivity', () => {
+    it('is green when both the tip and the sync loop are current', () => {
+        const r = deriveVaultConnectivity({
+            tipFetchedAtMs: NOW,
+            lastSyncedAtMs: NOW,
+            nowMs: NOW,
+        });
+        expect(r.level).toBe('green');
+        expect(r.syncAgeMs).toBe(0);
+    });
+
+    it('is yellow when the tip is merely degraded', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 10 * MIN,
+                lastSyncedAtMs: NOW,
+                nowMs: NOW,
+            }).level,
+        ).toBe('yellow');
+    });
+
+    it('is red once the tip is stale', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 45 * MIN,
+                lastSyncedAtMs: NOW,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('takes the worse of the two signals, sync side', () => {
+        // esplora answering fine, but the wallet handle is wedged so no cycle
+        // has completed. Not a healthy vault.
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW,
+                lastSyncedAtMs: NOW - 45 * MIN,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('takes the worse of the two signals, tip side', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 45 * MIN,
+                lastSyncedAtMs: NOW - 10 * MIN,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('is red when no sync has ever completed', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW,
+                lastSyncedAtMs: null,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('carries the tip detail through for rendering', () => {
+        const r = deriveVaultConnectivity({
+            tipFetchedAtMs: NOW - 45 * MIN,
+            lastSyncedAtMs: NOW,
+            nowMs: NOW,
+        });
+        expect(r.tip.level).toBe('stale');
+        expect(r.tip.trusted).toBe(false);
+    });
+});
+
+describe('shouldRescheduleExpiryWarning', () => {
+    it('schedules a VTXO that has never been scheduled', () => {
+        expect(
+            shouldRescheduleExpiryWarning({ previousAtMs: null, currentAtMs: NOW }),
+        ).toBe(true);
+    });
+
+    it('leaves an alarm alone while the estimate has barely moved', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + 30 * MIN,
+            }),
+        ).toBe(false);
+    });
+
+    it('does not re-queue exactly at the threshold', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + EXPIRY_ALARM_MAX_DRIFT_MS,
+            }),
+        ).toBe(false);
+    });
+
+    it('re-queues once the estimate has drifted past the threshold', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + EXPIRY_ALARM_MAX_DRIFT_MS + 1,
+            }),
+        ).toBe(true);
+    });
+
+    it('re-queues when expiry turns out to be EARLIER than projected', () => {
+        // The direction that actually bites: nominal 10-minute blocks
+        // overestimate remaining life, so the corrected deadline moves
+        // backwards and the queued warnings would otherwise fire late.
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW - (EXPIRY_ALARM_MAX_DRIFT_MS + 1),
+            }),
+        ).toBe(true);
+    });
+
+    it('honours a caller-supplied threshold', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + 5 * MIN,
+                maxDriftMs: 1 * MIN,
+            }),
+        ).toBe(true);
+    });
+});

--- a/tests/unit/chainTipFreshness.test.ts
+++ b/tests/unit/chainTipFreshness.test.ts
@@ -1,6 +1,7 @@
 import {
     deriveTipFreshness,
     deriveVaultConnectivity,
+    SYNC_FAIL_STREAK_FOR_RED,
     effectiveChainTip,
     EXPIRY_ALARM_MAX_DRIFT_MS,
     NOMINAL_BLOCK_MINUTES,
@@ -9,6 +10,7 @@ import {
     TIP_FRESH_MS,
 } from '../../src/services/ark/chainTipFreshness';
 
+const SEC = 1000;
 const MIN = 60 * 1000;
 const NOW = 1_800_000_000_000;
 
@@ -119,6 +121,84 @@ describe('deriveVaultConnectivity', () => {
         });
         expect(r.level).toBe('green');
         expect(r.syncAgeMs).toBe(0);
+    });
+
+    describe('failed sync ticks, not just staleness', () => {
+        // Observed on device 2026-09-08: a phone with airplane mode on AND
+        // Wi-Fi off reported "connection slow" while completely unreachable,
+        // and would have kept saying so for 20 minutes. Both timestamps this
+        // derivation reads are written only on SUCCESS, so a vault failing
+        // every tick looked exactly like an idle one and the only route to red
+        // was TIP_DEGRADED_MS ageing out. The app knew on the first failed
+        // tick; nothing recorded it.
+
+        it('does not stay green once a tick has actually failed', () => {
+            // Everything still fresh by age. Age alone would say green.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW,
+                    lastSyncedAtMs: NOW,
+                    nowMs: NOW,
+                    syncFailStreak: 1,
+                }).level,
+            ).toBe('yellow');
+        });
+
+        it('is red on a sustained streak, without waiting out the 20 minute staleness', () => {
+            const r = deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 30 * SEC,
+                lastSyncedAtMs: NOW - 30 * SEC,
+                nowMs: NOW,
+                syncFailStreak: SYNC_FAIL_STREAK_FOR_RED,
+            });
+            expect(r.level).toBe('red');
+            // The point of the fix: by age this is unambiguously green.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW - 30 * SEC,
+                    lastSyncedAtMs: NOW - 30 * SEC,
+                    nowMs: NOW,
+                }).level,
+            ).toBe('green');
+        });
+
+        it('recovers to green as soon as a tick succeeds', () => {
+            // The streak is cleared by success, so the dot must not need the
+            // staleness window to age out before it can say healthy again.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW,
+                    lastSyncedAtMs: NOW,
+                    nowMs: NOW,
+                    syncFailStreak: 0,
+                }).level,
+            ).toBe('green');
+        });
+
+        it('never improves on what age already says', () => {
+            // A zero streak must not argue a stale vault is healthy.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW - 60 * MIN,
+                    lastSyncedAtMs: NOW - 60 * MIN,
+                    nowMs: NOW,
+                    syncFailStreak: 0,
+                }).level,
+            ).toBe('red');
+        });
+
+        it('treats a missing or nonsense streak as no evidence', () => {
+            for (const bad of [undefined, -1, 0.4, NaN]) {
+                expect(
+                    deriveVaultConnectivity({
+                        tipFetchedAtMs: NOW,
+                        lastSyncedAtMs: NOW,
+                        nowMs: NOW,
+                        syncFailStreak: bad as number,
+                    }).level,
+                ).toBe('green');
+            }
+        });
     });
 
     it('is yellow when the tip is merely degraded', () => {


### PR DESCRIPTION
Two related changes for v0.2.0, kept as separate commits.

## 1. Vault connectivity and stale-expiry correctness

Fixes a defect where an esplora outage froze every capsule countdown at its last value and showed it as if live. The cached tip is only written on a successful fetch and the store is persisted with no partialize, so the wrong number also survived a force-quit. It failed optimistically, which is the direction that loses funds.

- Countdowns compute against a tip advanced by elapsed blocks rather than a frozen one. Extrapolating understates remaining life and costs a round fee; freezing overstates it and costs the VTXO.
- Green/yellow/red connectivity indicator on the Capsules header, plus an estimates line once the tip is too old to trust. It folds in the sync stamp as well as the tip, because the two fail independently.
- Expiry alarms are re-queued when the deadline estimate drifts past 2h. They were scheduled once and never corrected, and the nominal 10 minute block interval always drifts toward firing them late.
- `arkScheduledExpiryNotifs` now stores what was actually scheduled for, matching its own docblock, instead of being rewritten every tick.
- New `chainTipFreshness.ts`, pure and import-free so it is testable without the SDK. 26 tests.

Also in this commit: pull to refresh on the Capsules tab, matching ArkHistory and Vault. It runs the sync tick's read sequence, submits no rounds, and does not touch `arkLastSyncedAt`. The in-flight latch is a ref rather than state, since setState is async and two fast pulls would otherwise both pass the check.

## 2. Refresh fee tiers in the guide were wrong

Every tier in the capsules guide was off by one and understated the fee. It said refreshing is free within 2 days of expiry; that band costs 0.2%. Free applies only to a capsule already inside the grace window after expiry.

Verified live against the server's schedule on 2026-09-07: thresholds 0/288/1008/2016 blocks at 0/2000/4000/5000 ppm, applicable entry being the smallest threshold at or above the capsule's remaining life, base fee zero.

## Verification

- `tsc --noEmit`: 402 errors, identical to the baseline on main. Zero new.
- `npx jest -b -i tests/unit`: 62 suites, 733 passed, 1 skipped.

## Not done

**No on-device run.** The connectivity indicator has never been seen rendering. The offline walk is worth doing before merge: put the device in airplane mode on the Capsules tab, the indicator should leave green within about 3 minutes, go red with the estimates line by about 20, and the countdowns should keep ticking down rather than freezing. Reconnect and confirm it returns to green.

## Copy review

Five new strings plus one correction, all marked in code for final wording:

- "Vault connected"
- "Vault connection slow (updated Xm ago)"
- "Vault offline (last updated Xd ago)"
- "Times below are estimates until the vault reconnects."
- "Couldn't update" (toast prefix, deliberately not "Refresh failed", which is used for round submissions)
- The corrected refresh fee line in the guide

One open question behind that last one: the fee table has no entry above 2016 blocks, yet a freshly refreshed capsule has 4032 blocks of life, so the resting state of every capsule is undocumented. The copy asserts 0.5% there pending an answer from Second.tech.


---

## Added: the dot now degrades on evidence, not just on age

Found by testing this PR on device. Airplane mode on **and** Wi-Fi off, so the phone was completely unreachable, and the vault status read **"Connection slow"**. It would have kept saying that for 20 minutes.

Working as coded, and wrong. Red needed `TIP_DEGRADED_MS` of staleness, so three minutes offline landed in the yellow band, which means "slow", not "gone".

The cause is that **every signal behind the dot is written only on success**. `arkChainTipHeightAt` is stamped on a good esplora read, `arkLastSyncedAt` at the end of a completed cycle, and nothing recorded a failure anywhere. A vault failing every tick was indistinguishable from an idle one, so the UI could only infer trouble from silence. Meanwhile the app already knew: the sync tick had thrown, immediately and repeatedly, and that evidence was thrown away.

That is the same failure direction this PR exists to fix. The original rationale says an outage "failed in the optimistic direction" and a frozen countdown "read exactly like a true one". The indicator had inherited the flaw it was written to expose.

**The fix.** `arkSyncFailStreak`, incremented in the sync tick's `catch` and cleared by any success. One failure stops the dot claiming green; two, about a minute at the 30s tick, calls it offline. One alone does not shout, because a single failed tick is a common blip and flashing red on each one would train the user to ignore the colour that matters most.

The streak only ever makes the answer worse, never better, so a zero streak cannot argue a stale vault is healthy. Not persisted, because it describes right now and a restored streak would claim knowledge of a network the app has not touched since launching.

**This also makes the red state reachable.** It was previously about 20 minutes of app-open staleness away, which is why it had never once been seen, including by me while trying to test it.

Six new tests, including the exact device case and the direct comparison: same timestamps, streak at threshold gives red, no streak gives green.

Updated verification for the PR as a whole: `tsc` **402**, identical to baseline. Unit: **62 suites, 738 passed, 1 skipped.**
