### PR TITLE
feat(ark): fold dust capsules into one automatically

### DIFF
--- a/src/custom-hooks/useArkoorReceivePrompt.ts
+++ b/src/custom-hooks/useArkoorReceivePrompt.ts
@@ -9,8 +9,10 @@ import {
     ARK_REFRESH_MIN_SATS,
     ArkRefreshInFlightError,
     AVG_BLOCK_MINUTES,
+    buildDustSweepPlan,
     cancelVtxoExpiryWarnings,
     estimateArkRefreshFee,
+    maybeSweepDustArkVtxos,
     refreshArkVtxosDelegatedAndSync,
     scheduleVtxoExpiryWarnings,
 } from '@Cypher/services/ark';
@@ -421,6 +423,59 @@ export default function useArkoorReceivePrompt(): void {
                         })
                         .finally(release);
                     return;
+                }
+
+                // Before the notice: can the wallet fold this capsule in with
+                // the other dust instead? A Lightning receive is paid out of the
+                // ASP's VTXO pool and can arrive as several sub floor pieces (a
+                // 700 sat receive landed as a 300 and a 400), and each piece
+                // reaches this branch alone and unrefreshable. Together they are
+                // a dust only batch, which is the shape the ASP accepts. Telling
+                // the user to spend capsules the wallet is about to combine
+                // would be both alarming and wrong, so the sweep wins.
+                // Requires a known chain tip: without it a capsule that reports
+                // a real expiry height cannot be checked against the round
+                // window, and guessing there is what poisons a batch.
+                if (belowFloor && typeof tip === 'number') {
+                    const liveVtxos = useAuthStore.getState().arkVtxos ?? [];
+                    const refreshingIds = new Set(
+                        useAuthStore.getState().arkRefreshingVtxoIds ?? [],
+                    );
+                    const dustPlan = buildDustSweepPlan({
+                        vtxos: liveVtxos.map((v) => ({
+                            id: v.id,
+                            sats: v.sats,
+                            blocksUntilExpiry:
+                                v.expiryHeight > 0 ? v.expiryHeight - tip : null,
+                            stateTag: v.exiting ? 'exiting' : v.state,
+                            alreadyRefreshing: refreshingIds.has(v.id),
+                        })),
+                        exitInProgress: useAuthStore.getState().arkExitInProgress,
+                        minRefreshSats: ARK_REFRESH_MIN_SATS,
+                    });
+                    if (dustPlan.sweep && dustPlan.ids.includes(firstId)) {
+                        recordEvent({ kind: 'arkoor-prompt', outcome: 'auto-refresh', vtxoIdPrefix, sats: sats ?? undefined });
+                        // Optimistic, same as the single capsule path above: keep
+                        // it out of the next decision pass while the round runs.
+                        const curSweep = useAuthStore.getState().arkArkoorPromptState;
+                        const exSweep = curSweep[firstId];
+                        if (exSweep) {
+                            setArkArkoorPromptState({
+                                ...curSweep,
+                                [firstId]: { ...exSweep, status: 'refreshed' },
+                            });
+                        }
+                        SimpleToast.show(
+                            `Received ${amountPhrase}. Combining your small capsules to keep them longer.`,
+                            SimpleToast.SHORT,
+                        );
+                        // The sweep owns its own in-flight lock, pacing and
+                        // error reporting, so this is fire and forget. If it
+                        // cannot submit right now the foreground tick retries.
+                        void maybeSweepDustArkVtxos(liveVtxos, tip);
+                        release();
+                        return;
+                    }
                 }
 
                 // NOTICE path (too small to refresh, or the estimate would pull

--- a/src/services/ark/backgroundRefresh.ts
+++ b/src/services/ark/backgroundRefresh.ts
@@ -11,6 +11,7 @@ import {
 } from './backgroundKeychain';
 import { getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
 import { hasActiveArkExitRecords } from './exit';
+import { maybeSweepDustArkVtxos } from './foregroundSweep';
 import { maintenanceArkDelegated } from './refresh';
 import { syncArkWallet } from './sync';
 import { AVG_BLOCK_MINUTES, fetchChainTipHeight } from './chainTip';
@@ -237,6 +238,23 @@ export async function runArkBackgroundMaintenance(
             }
         } catch (regErr: any) {
             console.warn('[Ark bg-refresh] expiry re-registration failed (non-fatal):', regErr?.message ?? regErr);
+        }
+
+        // Dust sweep on the same wake. `maintenanceDelegated` picks its own
+        // capsules inside bark and there is no evidence it picks sub floor ones,
+        // so a wallet whose only problem is dust would wake, do nothing, and go
+        // back to sleep. This is the one rescue that shape has, and it needs no
+        // user present: the ASP accepts the delegation in seconds and finishes
+        // the round alone. Skipped by its own guards if maintenance above just
+        // submitted a round (one submission per wallet at a time).
+        try {
+            const vtxos = await fetchArkVtxos();
+            const tipHeight = await fetchChainTipHeight();
+            if (vtxos && typeof tipHeight === 'number') {
+                await maybeSweepDustArkVtxos(vtxos.spendable, tipHeight);
+            }
+        } catch (dustErr: any) {
+            console.warn('[Ark bg-refresh] dust sweep failed (non-fatal):', dustErr?.message ?? dustErr);
         }
     } catch (err: any) {
         const s = useAuthStore.getState();

--- a/src/services/ark/dustSweep.ts
+++ b/src/services/ark/dustSweep.ts
@@ -1,0 +1,227 @@
+/**
+ * When should the wallet fold its dust capsules into one, by itself?
+ *
+ * WHY THIS EXISTS
+ *
+ * A Lightning receive is paid out of the ASP's VTXO pool, and the ASP bundles
+ * pool VTXOs the way an on-chain wallet bundles inputs. So a single 700 sat
+ * receive can land as a 300 and a 400 (observed live, reported to Second.tech
+ * 2026-09; Peter confirmed the bundling is by design). Each piece is below
+ * ARK_REFRESH_MIN_SATS, so:
+ *
+ *   - useArkoorReceivePrompt refuses to auto-refresh either one (its estimate
+ *     says the post-fee output would fall below the floor) and shows a notice
+ *     telling the user to spend them,
+ *   - foregroundSweep counts them as stranded dust and skips them,
+ *   - changeRefresh refuses them for the same reason,
+ *
+ * and the only thing that can actually save them is the user finding the "Dust
+ * refresh" button on the Capsules tab. Nobody does that. The pieces then expire
+ * even though the wallet holds enough dust to rescue them.
+ *
+ * The rescue itself is not new and not theoretical: a DELEGATED round over a
+ * batch of sub-floor inputs is accepted as long as the batch clears the dust
+ * limit, confirmed live on mainnet 2026-08-20 (two 400 sat capsules swept into
+ * one, bark 0.6.1, which is the core inside SDK 0.16.1 today). This module is
+ * that same rescue expressed as a rule, so the wallet can run it on its own.
+ *
+ * WHY A TOTAL, NOT A PER INPUT FLOOR
+ *
+ * The per input floor (ARK_REFRESH_MIN_SATS) is what makes a lone dust capsule
+ * unrefreshable, and it is why dust must never ride along in a MIXED batch of
+ * dust and healthy capsules (one sub floor input has made the ASP reject the
+ * whole round, so the healthy inputs lose their refresh too). Neither of those
+ * facts is changed here. A dust ONLY batch is the one shape that is known to
+ * work, so that is the only shape this module ever produces.
+ *
+ * WHY THE TOTAL IS NOT THE DUST LIMIT
+ *
+ * The ASP accepts the round as soon as the batch clears the on chain dust limit
+ * (ARK_VTXO_DUST_SATS, 330), and the manual button uses exactly that gate,
+ * because a user who taps a button has decided for themselves. An AUTOMATIC
+ * sweep should clear a higher bar: a 350 sat batch produces a ~349 sat capsule,
+ * which is still below the refresh floor, so the wallet would have spent a fee
+ * to arrive back at a capsule that cannot refresh itself, and nothing would have
+ * changed. The batch has to be able to produce an output that clears
+ * ARK_REFRESH_MIN_SATS, so the swept capsule rejoins normal maintenance.
+ *
+ * This rule applies that as a cheap size pre-filter only. The AUTHORITATIVE gate
+ * is the SDK's own fee estimate at submit time (see maybeSweepDustArkVtxos),
+ * because the fee is what decides whether the output clears the floor, and only
+ * bark can price a round. Keeping the pre-filter close to the floor rather than
+ * at a comfortable round number matters: a 550 sat Lightning receive that splits
+ * into two dust pieces is rescuable (output ~549, above the floor), and a gate of
+ * 600 would have refused it for no reason.
+ *
+ * WHY THE EXIT RUNWAY FLOOR DOES NOT APPLY
+ *
+ * Every other automatic refresh path refuses to act inside ARK_EXIT_RUNWAY_HOURS
+ * of expiry, because a delegated round that hangs would eat the window the user
+ * needs for a unilateral exit. That trade only exists when the exit is worth
+ * something. It is not, for dust: a 400 sat capsule at depth 17 costs 5,645 vB
+ * of exit tree fees to rescue 400 sats (measured 2026-08-22), which is why the
+ * exit triage discards dust rather than funding it. So a near expiry dust
+ * capsule loses nothing by joining a round, and doing nothing loses all of it.
+ *
+ * What we DO refuse is an input that could expire while the round runs. An
+ * expired input poisons the whole round, mainnet rounds fire hourly, so an input
+ * inside ARK_DUST_SWEEP_MIN_BLOCKS_LEFT of expiry is left out rather than
+ * allowed to sink the rescue of the others.
+ *
+ * Pure and import free, matching changeRefresh.ts and refreshBatch.ts, so the
+ * rule can be tested without standing up a wallet.
+ */
+
+/**
+ * Size pre-filter: the total the dust must reach before the wallet even asks
+ * bark to price a sweep.
+ *
+ * ARK_REFRESH_MIN_SATS (500) plus a 20 sat fee allowance. Below this the output
+ * cannot clear the refresh floor whatever the fee comes back as, so there is
+ * nothing to price. Above it, the SDK's estimate decides: the caller requires
+ * total minus fee to clear the floor before it submits anything. The fee was
+ * measured at ~1 sat on device (2026-08-20), so 20 is generous headroom rather
+ * than a real constraint.
+ *
+ * The manual Capsules button keeps its lower ARK_VTXO_DUST_SATS gate. A user who
+ * taps a button has decided for themselves.
+ */
+export const ARK_DUST_SWEEP_MIN_TOTAL_SATS = 520;
+
+/**
+ * Minimum blocks of life an input needs before it may join a sweep. Mainnet
+ * rounds run hourly and an expired input makes the ASP reject the whole round,
+ * so anything inside ~2 hours of expiry is excluded to protect the batch it
+ * would otherwise be riding in.
+ */
+export const ARK_DUST_SWEEP_MIN_BLOCKS_LEFT = 12;
+
+export type DustSweepVtxoInput = {
+    id: string;
+    sats: number;
+    /**
+     * Blocks until expiry, or null when the wallet cannot know. Arkoor capsules
+     * report expiryHeight 0 (the SDK does not surface the ASP trust window), and
+     * they are precisely the capsules a Lightning receive produces, so null must
+     * mean "include", not "skip". Their real deadline (~3 days) is far outside
+     * the mid round window this field guards.
+     */
+    blocksUntilExpiry: number | null;
+    /** bark state tag, flattened to its variant string. */
+    stateTag: string;
+    /** Already submitted to a round by another caller. */
+    alreadyRefreshing: boolean;
+};
+
+export type BuildDustSweepInputs = {
+    vtxos: readonly DustSweepVtxoInput[];
+    /** A unilateral exit is active on this wallet. */
+    exitInProgress: boolean;
+    /** Per input round minimum (ARK_REFRESH_MIN_SATS). Below it is dust. */
+    minRefreshSats: number;
+    /** Batch total the sweep needs; defaults to ARK_DUST_SWEEP_MIN_TOTAL_SATS. */
+    minTotalSats?: number;
+    /** Life an input needs to survive the round; defaults to ARK_DUST_SWEEP_MIN_BLOCKS_LEFT. */
+    minBlocksLeft?: number;
+};
+
+export type DustSweepPlan = {
+    sweep: boolean;
+    /**
+     * Ids to hand to refreshVtxosDelegated. Deliberately EMPTY unless `sweep`,
+     * so a caller that forgets to read `sweep` submits nothing rather than an
+     * unacceptable batch. Read `candidateCount` / `candidateSats` for what was
+     * considered.
+     */
+    ids: string[];
+    /** Aggregate sats of `ids`. */
+    totalSats: number;
+    /** Dust that passed every per input check, whether or not the batch fired. */
+    candidateCount: number;
+    /** Aggregate sats of that dust. Non zero on a refusal, which is the log line. */
+    candidateSats: number;
+    reason:
+        | 'sweep'
+        | 'exit-in-progress'
+        | 'no-dust'
+        | 'single-capsule'
+        | 'below-min-total';
+    /** Dust left out (not spendable, mid round, expiring inside the window). */
+    excludedCount: number;
+    /** Aggregate sats of the excluded dust, for the log line and any notice. */
+    excludedSats: number;
+};
+
+/**
+ * Decide whether the wallet's dust is worth sweeping, and which capsules go in.
+ */
+export function buildDustSweepPlan(input: BuildDustSweepInputs): DustSweepPlan {
+    const minTotalSats = input.minTotalSats ?? ARK_DUST_SWEEP_MIN_TOTAL_SATS;
+    const minBlocksLeft = input.minBlocksLeft ?? ARK_DUST_SWEEP_MIN_BLOCKS_LEFT;
+
+    const ids: string[] = [];
+    let totalSats = 0;
+    let excludedCount = 0;
+    let excludedSats = 0;
+
+    const refuse = (reason: DustSweepPlan['reason']): DustSweepPlan => ({
+        sweep: false,
+        ids: [],
+        totalSats: 0,
+        candidateCount: ids.length,
+        candidateSats: totalSats,
+        reason,
+        excludedCount,
+        excludedSats,
+    });
+
+    // A cooperative round spends a coin the exit has already committed on chain.
+    // Same refusal as every other refresh path.
+    if (input.exitInProgress) return refuse('exit-in-progress');
+
+    for (const v of input.vtxos) {
+        // Dust is defined by the per input refresh floor: these are exactly the
+        // capsules no other path can refresh.
+        if (v.sats >= input.minRefreshSats) continue;
+        if (v.stateTag.toLowerCase() !== 'spendable') {
+            excludedCount += 1;
+            excludedSats += v.sats;
+            continue;
+        }
+        if (v.alreadyRefreshing) {
+            excludedCount += 1;
+            excludedSats += v.sats;
+            continue;
+        }
+        // null is arkoor (expiry unknown, ~3 days out) and is included on
+        // purpose. A KNOWN expiry inside the round window is not: an input that
+        // expires mid round makes the ASP reject the batch it is riding in.
+        if (v.blocksUntilExpiry != null) {
+            if (!Number.isFinite(v.blocksUntilExpiry) || v.blocksUntilExpiry < minBlocksLeft) {
+                excludedCount += 1;
+                excludedSats += v.sats;
+                continue;
+            }
+        }
+        ids.push(v.id);
+        totalSats += v.sats;
+    }
+
+    if (ids.length === 0) return refuse('no-dust');
+    // A lone sub floor capsule cannot join a round on its own whatever its size:
+    // its round output would fall below the dust limit and the ASP rejects it.
+    // Only a batch has ever been accepted, so never submit a single id.
+    if (ids.length === 1) return refuse('single-capsule');
+    if (totalSats < minTotalSats) return refuse('below-min-total');
+
+    return {
+        sweep: true,
+        ids,
+        totalSats,
+        candidateCount: ids.length,
+        candidateSats: totalSats,
+        reason: 'sweep',
+        excludedCount,
+        excludedSats,
+    };
+}

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -241,7 +241,9 @@ export async function maybeSweepDustArkVtxos(
             return;
         }
 
-        sweepInFlight = true;
+        // Latch already claimed above, before the awaits. Only the pacing
+        // clock is stamped here, so a tick that bailed out earlier does not
+        // consume the next window.
         lastDustSweepAt = now;
         console.log(
             '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -7,8 +7,10 @@ import {
     ARK_REFRESH_MIN_SATS,
     ARK_SWEEP_MAX_RUNWAY_HOURS,
 } from './config';
+import { buildDustSweepPlan } from './dustSweep';
 import {
     ArkRefreshInFlightError,
+    estimateArkRefreshFee,
     fetchArkPendingRoundStates,
     refreshArkVtxosDelegatedAndSync,
 } from './refresh';
@@ -28,8 +30,10 @@ import type { ArkVtxoView } from './vtxos';
  *    we must NOT refresh — a delegated round that hangs would eat the exit
  *    window; the user should spend/exit instead (expiry warnings + escalation
  *    own that zone). Above a week there is no reason to spend the fee yet.
- *  - Dust: sub-ARK_REFRESH_MIN_SATS inputs are STRANDED, never ridden along
- *    (one sub-floor input makes bark reject the whole round). User spends them.
+ *  - Dust: sub-ARK_REFRESH_MIN_SATS inputs never ride along in this batch (one
+ *    sub-floor input makes bark reject the whole round). They are handled by
+ *    maybeSweepDustArkVtxos below, which folds them into ONE capsule in a dust
+ *    only round, the single shape the ASP is known to accept.
  *  - Covers regular + arkoor VTXOs uniformly (any kind, real expiry).
  *
  * Why this is safe now (it deadlocked in July on the self-signed path): the
@@ -51,6 +55,11 @@ import type { ArkVtxoView } from './vtxos';
 let sweepInFlight = false;
 let lastSweepAt = 0;
 let consecutiveFailures = 0;
+// Same pacing, kept separately so a dust sweep and a band sweep do not consume
+// each other's gap. `sweepInFlight` is deliberately SHARED: one submission at a
+// time per wallet, whichever kind it is.
+let lastDustSweepAt = 0;
+let dustFailures = 0;
 
 // Base pacing between sweep submissions. Only actual submissions consume it;
 // empty ticks (nothing in-band) re-run the cheap in-memory selection freely.
@@ -61,6 +70,171 @@ const FG_SWEEP_MAX_GAP_MS = 60 * 60 * 1000;
 
 function blocksForHours(hours: number): number {
     return Math.round((hours * 60) / AVG_BLOCK_MINUTES);
+}
+
+/**
+ * Fold the wallet's dust capsules into one, unprompted.
+ *
+ * WHY THIS IS SEPARATE FROM THE BAND SWEEP ABOVE
+ *
+ * The band sweep is driven by EXPIRY: it acts on capsules in their last week
+ * and skips everything else, dust included. That leaves a hole exactly where
+ * users get hurt. A Lightning receive is paid out of the ASP's VTXO pool and can
+ * arrive as several sub floor pieces (a 700 sat receive landed as a 300 and a
+ * 400, reported to Second.tech 2026-09), and those pieces are arkoor, so they
+ * report expiryHeight 0 and the band never even sees them. Nothing automatic
+ * could rescue them: the receive prompt refuses them as too small to refresh
+ * alone, this sweep counted them as stranded, and only the manual "Dust refresh"
+ * button on the Capsules tab could act. Users do not find that button.
+ *
+ * The trigger here is SIZE, not expiry: as soon as the wallet holds enough dust
+ * to make a batch the ASP will take, fold it into one capsule that is large
+ * enough to look after itself from then on.
+ *
+ * The batch is dust only, always. That is the shape confirmed live on mainnet
+ * (2026-08-20, two 400s into one, on the same bark core we ship today). Dust is
+ * still never mixed into a batch of healthy capsules: one sub floor input has
+ * made the ASP reject an entire round, and taking healthy capsules down with the
+ * dust is a strictly worse failure than leaving the dust alone.
+ *
+ * Shares `sweepInFlight` and the pending round check with the band sweep, so the
+ * wallet never has two submissions racing, and gets its own pacing so a wallet
+ * that sits just under the total does not re-submit on every tick.
+ */
+export async function maybeSweepDustArkVtxos(
+    spendable: ArkVtxoView[],
+    tip: number,
+    strandedInBand = 0,
+): Promise<void> {
+    if (sweepInFlight) return;
+    // Callable on its own from the background wake, so it repeats the two
+    // preconditions the band sweep checks before delegating to it.
+    if (getArkWalletHandle() == null) return;
+    const store = useAuthStore.getState();
+    if (store.arkRefreshStuck) return;
+    const refreshing = new Set(store.arkRefreshingVtxoIds);
+
+    const plan = buildDustSweepPlan({
+        vtxos: spendable.map((v) => ({
+            id: v.id,
+            sats: v.sats,
+            // expiryHeight 0 is arkoor: bark does not surface the ASP's trust
+            // window, so the height is unknown rather than imminent. null tells
+            // the rule to include it, which is the whole point here.
+            blocksUntilExpiry: v.expiryHeight > 0 ? v.expiryHeight - tip : null,
+            // A capsule mid unilateral exit is committed on chain already.
+            stateTag: v.exiting ? 'exiting' : v.state,
+            alreadyRefreshing: refreshing.has(v.id),
+        })),
+        exitInProgress: store.arkExitInProgress,
+        minRefreshSats: ARK_REFRESH_MIN_SATS,
+    });
+
+    if (!plan.sweep) {
+        // Only a wallet that HOLDS dust it cannot sweep is worth a feed entry.
+        // "Not enough dust yet" is the normal resting state of most wallets and
+        // would just be noise; report the genuinely stuck shapes.
+        const stuck = plan.reason === 'single-capsule' || plan.reason === 'below-min-total';
+        if (stuck || strandedInBand > 0) {
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'dust_stranded',
+                elapsedMs: 0,
+                vtxoCount: stuck ? plan.candidateCount : strandedInBand,
+            });
+        }
+        return;
+    }
+
+    const now = Date.now();
+    const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (dustFailures + 1), FG_SWEEP_MAX_GAP_MS);
+    if (now - lastDustSweepAt < gap) return;
+
+    const pending = await fetchArkPendingRoundStates();
+    if (pending.some((r) => r.ongoing)) {
+        console.log('[Ark dust sweep] skip: a round is already ongoing');
+        return;
+    }
+
+    // The real gate. The size rule above is a pre-filter; only bark can price the
+    // round, and the fee is what decides whether the swept capsule lands above
+    // the refresh floor or straight back in dust. Same shape as the receive
+    // prompt's single capsule decision, for the same reason.
+    let feeSats: number;
+    let spendsOnlyOurDust: boolean;
+    try {
+        const est = await estimateArkRefreshFee(plan.ids);
+        feeSats = est.feeSats;
+        const ours = new Set(plan.ids);
+        spendsOnlyOurDust = est.vtxosSpent.every((id) => ours.has(id));
+    } catch (estErr: any) {
+        // Wallet not ready or a transient network fault. Leave the dust alone and
+        // let a later tick price it again; do not count this as a failure, it
+        // never reached the ASP.
+        console.warn('[Ark dust sweep] fee estimate failed, will retry:', estErr?.message ?? estErr);
+        return;
+    }
+
+    if (!spendsOnlyOurDust) {
+        // The round would drag capsules in that we did not choose, which is the
+        // mixed batch we refuse to build. Never seen in QA; refusing costs
+        // nothing and the alternative risks healthy capsules.
+        console.warn('[Ark dust sweep] skip: the estimate would spend capsules outside the dust batch');
+        return;
+    }
+
+    const outputSats = plan.totalSats - feeSats;
+    if (outputSats < ARK_REFRESH_MIN_SATS) {
+        console.log(
+            '[Ark dust sweep] skip: output', outputSats,
+            'sats would still be below the', ARK_REFRESH_MIN_SATS, 'sat refresh floor',
+        );
+        recordEvent({
+            kind: 'ark-bg-refresh',
+            trigger: 'foreground',
+            outcome: 'dust_stranded',
+            elapsedMs: 0,
+            vtxoCount: plan.ids.length,
+        });
+        return;
+    }
+
+    sweepInFlight = true;
+    lastDustSweepAt = now;
+    console.log(
+        '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',
+        plan.totalSats, 'sats, fee', feeSats, 'sats, output', outputSats,
+        'sats; excluded=', plan.excludedCount,
+    );
+    try {
+        await refreshArkVtxosDelegatedAndSync(plan.ids, plan.totalSats);
+        dustFailures = 0;
+        recordEvent({
+            kind: 'ark-bg-refresh',
+            trigger: 'foreground',
+            outcome: 'success',
+            elapsedMs: Date.now() - now,
+            vtxoCount: plan.ids.length,
+        });
+    } catch (err: any) {
+        if (err instanceof ArkRefreshInFlightError) {
+            console.log('[Ark dust sweep] skipped: refresh already in flight');
+        } else {
+            dustFailures += 1;
+            console.warn('[Ark dust sweep] failed:', err?.message ?? err);
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'error',
+                elapsedMs: Date.now() - now,
+                vtxoCount: plan.ids.length,
+                errorMsg: String(err?.message ?? err).slice(0, 200),
+            });
+        }
+    } finally {
+        sweepInFlight = false;
+    }
 }
 
 /**
@@ -104,18 +278,13 @@ export async function maybeSweepDueArkVtxos(
     }
 
     if (refreshable.length === 0) {
-        // Surface stranded in-band dust so the user knows to spend it (rare;
-        // most dust sits above the floor's runway). Cheap outcomes like an
-        // empty sweep are intentionally NOT recorded to keep the feed sparse.
-        if (strandedDust > 0) {
-            recordEvent({
-                kind: 'ark-bg-refresh',
-                trigger: 'foreground',
-                outcome: 'dust_stranded',
-                elapsedMs: 0,
-                vtxoCount: strandedDust,
-            });
-        }
+        // Nothing in band. Dust is not simply "stranded" any more: a dust ONLY
+        // batch that clears the sweep total is the one shape the ASP accepts,
+        // so try that before reporting a problem. Runs on the whole spendable
+        // set, not the in-band selection above: the dust a Lightning receive
+        // leaves is arkoor, which reports no expiry height at all and is
+        // therefore invisible to the band. See dustSweep.ts.
+        await maybeSweepDustArkVtxos(spendable, tip, strandedDust);
         return;
     }
 

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -6,6 +6,8 @@ import {
     ARK_EXIT_RUNWAY_HOURS,
     ARK_REFRESH_MIN_SATS,
     ARK_SWEEP_MAX_RUNWAY_HOURS,
+    ARK_SERVER_URL,
+    ESPLORA_URLS,
 } from './config';
 import { buildDustSweepPlan } from './dustSweep';
 import {
@@ -14,6 +16,7 @@ import {
     fetchArkPendingRoundStates,
     refreshArkVtxosDelegatedAndSync,
 } from './refresh';
+import { classifyArkNetworkFault } from './networkFault';
 import { getArkWalletHandle } from './walletHandle';
 import type { ArkVtxoView } from './vtxos';
 
@@ -60,6 +63,25 @@ let consecutiveFailures = 0;
 // time per wallet, whichever kind it is.
 let lastDustSweepAt = 0;
 let dustFailures = 0;
+/**
+ * Wall clock before which NEITHER sweep may submit, set when the chain source
+ * refuses us on quota. Shared for the same reason `sweepInFlight` is: the quota
+ * belongs to the connection, not to one sweep, so a rejection earned by either
+ * has to silence both.
+ *
+ * Separate from the failure counters because a quota rejection is a different
+ * kind of failure. An ordinary error might succeed next tick; a 429 says the
+ * provider is fine and is refusing THIS IP until its window rolls, and retrying
+ * into that spends the quota needed to recover.
+ */
+let rateLimitedUntil = 0;
+/**
+ * How long to stand down after a quota rejection. An hour, because Blockstream
+ * states its unauthenticated cap per hour (700 requests/hour per IP), so that is
+ * the width of the window being waited on. Guessing shorter spends quota to find
+ * out it was too short.
+ */
+const FG_SWEEP_RATE_LIMIT_BACKOFF_MS = 60 * 60 * 1000;
 
 // Base pacing between sweep submissions. Only actual submissions consume it;
 // empty ticks (nothing in-band) re-run the cheap in-memory selection freely.
@@ -148,89 +170,121 @@ export async function maybeSweepDustArkVtxos(
     }
 
     const now = Date.now();
+    if (now < rateLimitedUntil) return;
     const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (dustFailures + 1), FG_SWEEP_MAX_GAP_MS);
     if (now - lastDustSweepAt < gap) return;
 
-    const pending = await fetchArkPendingRoundStates();
-    if (pending.some((r) => r.ongoing)) {
-        console.log('[Ark dust sweep] skip: a round is already ongoing');
-        return;
-    }
-
-    // The real gate. The size rule above is a pre-filter; only bark can price the
-    // round, and the fee is what decides whether the swept capsule lands above
-    // the refresh floor or straight back in dust. Same shape as the receive
-    // prompt's single capsule decision, for the same reason.
-    let feeSats: number;
-    let spendsOnlyOurDust: boolean;
-    try {
-        const est = await estimateArkRefreshFee(plan.ids);
-        feeSats = est.feeSats;
-        const ours = new Set(plan.ids);
-        spendsOnlyOurDust = est.vtxosSpent.every((id) => ours.has(id));
-    } catch (estErr: any) {
-        // Wallet not ready or a transient network fault. Leave the dust alone and
-        // let a later tick price it again; do not count this as a failure, it
-        // never reached the ASP.
-        console.warn('[Ark dust sweep] fee estimate failed, will retry:', estErr?.message ?? estErr);
-        return;
-    }
-
-    if (!spendsOnlyOurDust) {
-        // The round would drag capsules in that we did not choose, which is the
-        // mixed batch we refuse to build. Never seen in QA; refusing costs
-        // nothing and the alternative risks healthy capsules.
-        console.warn('[Ark dust sweep] skip: the estimate would spend capsules outside the dust batch');
-        return;
-    }
-
-    const outputSats = plan.totalSats - feeSats;
-    if (outputSats < ARK_REFRESH_MIN_SATS) {
-        console.log(
-            '[Ark dust sweep] skip: output', outputSats,
-            'sats would still be below the', ARK_REFRESH_MIN_SATS, 'sat refresh floor',
-        );
-        recordEvent({
-            kind: 'ark-bg-refresh',
-            trigger: 'foreground',
-            outcome: 'dust_stranded',
-            elapsedMs: 0,
-            vtxoCount: plan.ids.length,
-        });
-        return;
-    }
-
+    // CLAIM THE SLOT BEFORE ANY await.
+    //
+    // Same defect the band sweep below carried, and worse here: the latch
+    // used to be set after the pending-round fetch AND the fee estimate, so
+    // two network round trips sat between reading `sweepInFlight` and
+    // writing it. Every caller arriving in that window read false and went
+    // on to submit, and the window is widest exactly when it must not be,
+    // because a slow chain source lengthens both calls.
+    //
+    // Measured on the band sweep on device 2026-09-09: 174 submissions in
+    // 12 minutes, every one refused by a rate-limited chain source. This
+    // path has two awaits rather than one, so it is wider still.
+    //
+    // Everything below sits inside the try so none of the early returns can
+    // leave the latch stuck on.
     sweepInFlight = true;
-    lastDustSweepAt = now;
-    console.log(
-        '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',
-        plan.totalSats, 'sats, fee', feeSats, 'sats, output', outputSats,
-        'sats; excluded=', plan.excludedCount,
-    );
     try {
-        await refreshArkVtxosDelegatedAndSync(plan.ids, plan.totalSats);
-        dustFailures = 0;
-        recordEvent({
-            kind: 'ark-bg-refresh',
-            trigger: 'foreground',
-            outcome: 'success',
-            elapsedMs: Date.now() - now,
-            vtxoCount: plan.ids.length,
-        });
-    } catch (err: any) {
-        if (err instanceof ArkRefreshInFlightError) {
-            console.log('[Ark dust sweep] skipped: refresh already in flight');
-        } else {
-            dustFailures += 1;
-            console.warn('[Ark dust sweep] failed:', err?.message ?? err);
+
+        const pending = await fetchArkPendingRoundStates();
+        if (pending.some((r) => r.ongoing)) {
+            console.log('[Ark dust sweep] skip: a round is already ongoing');
+            return;
+        }
+
+        // The real gate. The size rule above is a pre-filter; only bark can price the
+        // round, and the fee is what decides whether the swept capsule lands above
+        // the refresh floor or straight back in dust. Same shape as the receive
+        // prompt's single capsule decision, for the same reason.
+        let feeSats: number;
+        let spendsOnlyOurDust: boolean;
+        try {
+            const est = await estimateArkRefreshFee(plan.ids);
+            feeSats = est.feeSats;
+            const ours = new Set(plan.ids);
+            spendsOnlyOurDust = est.vtxosSpent.every((id) => ours.has(id));
+        } catch (estErr: any) {
+            // Wallet not ready or a transient network fault. Leave the dust alone and
+            // let a later tick price it again; do not count this as a failure, it
+            // never reached the ASP.
+            console.warn('[Ark dust sweep] fee estimate failed, will retry:', estErr?.message ?? estErr);
+            return;
+        }
+
+        if (!spendsOnlyOurDust) {
+            // The round would drag capsules in that we did not choose, which is the
+            // mixed batch we refuse to build. Never seen in QA; refusing costs
+            // nothing and the alternative risks healthy capsules.
+            console.warn('[Ark dust sweep] skip: the estimate would spend capsules outside the dust batch');
+            return;
+        }
+
+        const outputSats = plan.totalSats - feeSats;
+        if (outputSats < ARK_REFRESH_MIN_SATS) {
+            console.log(
+                '[Ark dust sweep] skip: output', outputSats,
+                'sats would still be below the', ARK_REFRESH_MIN_SATS, 'sat refresh floor',
+            );
             recordEvent({
                 kind: 'ark-bg-refresh',
                 trigger: 'foreground',
-                outcome: 'error',
+                outcome: 'dust_stranded',
+                elapsedMs: 0,
+                vtxoCount: plan.ids.length,
+            });
+            return;
+        }
+
+        sweepInFlight = true;
+        lastDustSweepAt = now;
+        console.log(
+            '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',
+            plan.totalSats, 'sats, fee', feeSats, 'sats, output', outputSats,
+            'sats; excluded=', plan.excludedCount,
+        );
+        try {
+            await refreshArkVtxosDelegatedAndSync(plan.ids, plan.totalSats);
+            dustFailures = 0;
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'success',
                 elapsedMs: Date.now() - now,
                 vtxoCount: plan.ids.length,
-                errorMsg: String(err?.message ?? err).slice(0, 200),
             });
+        } catch (err: any) {
+            if (err instanceof ArkRefreshInFlightError) {
+                console.log('[Ark dust sweep] skipped: refresh already in flight');
+            } else if (
+                classifyArkNetworkFault(err, { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }) ===
+                'chain-source-rate-limited'
+            ) {
+                // A quota rejection is a REFUSAL, not a transient failure. The
+                // provider is up and refusing this IP until its window rolls, so
+                // retrying inside it spends the quota needed to recover.
+                rateLimitedUntil = Date.now() + FG_SWEEP_RATE_LIMIT_BACKOFF_MS;
+                console.warn(
+                    '[Ark dust sweep] chain source is rate limiting this connection; standing down for',
+                    Math.round(FG_SWEEP_RATE_LIMIT_BACKOFF_MS / 60000), 'min',
+                );
+            } else {
+                dustFailures += 1;
+                console.warn('[Ark dust sweep] failed:', err?.message ?? err);
+                recordEvent({
+                    kind: 'ark-bg-refresh',
+                    trigger: 'foreground',
+                    outcome: 'error',
+                    elapsedMs: Date.now() - now,
+                    vtxoCount: plan.ids.length,
+                    errorMsg: String(err?.message ?? err).slice(0, 200),
+                });
+            }
         }
     } finally {
         sweepInFlight = false;
@@ -290,6 +344,7 @@ export async function maybeSweepDueArkVtxos(
 
     // S2 backoff: only now (we have work) enforce pacing between submissions.
     const now = Date.now();
+    if (now < rateLimitedUntil) return;
     const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (consecutiveFailures + 1), FG_SWEEP_MAX_GAP_MS);
     if (now - lastSweepAt < gap) return;
 

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -200,7 +200,14 @@ export type { ArkRefreshFeeView, ArkRefreshResult, ArkDelegatedRefreshResult } f
 
 export { setArkBackgroundRefreshEnabled } from './backgroundRefresh';
 
-export { maybeSweepDueArkVtxos } from './foregroundSweep';
+export { maybeSweepDueArkVtxos, maybeSweepDustArkVtxos } from './foregroundSweep';
+
+export {
+    ARK_DUST_SWEEP_MIN_BLOCKS_LEFT,
+    ARK_DUST_SWEEP_MIN_TOTAL_SATS,
+    buildDustSweepPlan,
+} from './dustSweep';
+export type { BuildDustSweepInputs, DustSweepPlan, DustSweepVtxoInput } from './dustSweep';
 
 export { barkStateTag, isActiveExit } from './barkState';
 

--- a/src/services/ark/lightning.ts
+++ b/src/services/ark/lightning.ts
@@ -60,6 +60,33 @@ export async function tryClaimArkLightningReceives(): Promise<ArkLightningReceiv
         // (e.g. stuck mid-round), which deadlocks the whole 30s sync via
         // its inFlight guard. Observed live: one stuck wait=true call
         // silenced every subsequent cycle until app restart.
+        // DEV only. The claim reports "All N lightning receive claim(s) failed"
+        // with no cause attached (BarkError carries only message/tag/stack, the
+        // per-receive reason is discarded at the FFI boundary), and the receive
+        // is gone by the time anything can be probed after the fact.
+        //
+        // `state` is the field that settles what actually happened, and it cost
+        // most of a night's debugging to learn that: "awaiting-payment" means
+        // nothing ever arrived and the claim failure is noise, while
+        // "htlcs-ready" or later means the money is there and the claim is
+        // genuinely broken. Those two look identical in the error.
+        //
+        // Costs an extra SDK call per sync tick, hence __DEV__ only.
+        if (__DEV__) try {
+            const pendingBefore = await handle.pendingLightningReceives();
+            console.log(
+                '[Ark claim] PRE-CLAIM pending receives:',
+                pendingBefore.length,
+                JSON.stringify(pendingBefore.map((r: { paymentHash: string; amountSats: bigint; state: string }) => ({
+                    hash: r.paymentHash.slice(0, 12),
+                    sats: Number(r.amountSats),
+                    state: r.state,
+                }))),
+            );
+        } catch (probeErr: any) {
+            console.warn('[Ark claim] PRE-CLAIM probe failed:', probeErr?.message ?? probeErr);
+        }
+
         const raw = await handle.tryClaimAllLightningReceives(false);
         console.log(
             '[Ark claim] returned',
@@ -89,6 +116,23 @@ export async function tryClaimArkLightningReceives(): Promise<ArkLightningReceiv
             '| message=', e?.message ?? String(err),
             '| inner=', e?.inner?.errorMessage ?? e?.inner?.message ?? 'n/a',
         );
+        // DEV only. The line above reports `inner= n/a` for claim failures,
+        // because BarkError puts nothing where that destructure reaches. Own
+        // properties are exactly ["message","tag","stack"] and the message is
+        // only the aggregate sentence, so the per-receive reason never crosses
+        // the binding at all. Keep the dump so the next person can confirm that
+        // for themselves rather than re-deriving it, and so it surfaces
+        // immediately if a future SDK starts attaching a cause.
+        if (__DEV__) try {
+            const own = Object.getOwnPropertyNames(err as object);
+            console.warn(
+                '[Ark claim] RAW ERROR keys=', JSON.stringify(own),
+                '| full=', JSON.stringify(err, own),
+                '| proto=', Object.prototype.toString.call(err),
+            );
+        } catch (dumpErr) {
+            console.warn('[Ark claim] RAW ERROR could not be serialised:', String(dumpErr));
+        }
         return [];
     }
 }

--- a/tests/unit/dustSweep.test.ts
+++ b/tests/unit/dustSweep.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Folding dust capsules into one, without being asked.
+ *
+ * The case that drove this: a 700 sat Lightning receive landed as a 300 and a
+ * 400 (the ASP pays out of a pool of VTXOs and bundles them, confirmed by
+ * Second.tech 2026-09). Both pieces are below the per input refresh floor, so
+ * every automatic path refused them and only the manual Capsules button could
+ * rescue them.
+ *
+ * The shape the ASP accepts is a dust ONLY batch clearing the dust limit,
+ * confirmed live on mainnet 2026-08-20 (two 400s swept into one, bark 0.6.1).
+ * These tests pin that shape: never a lone capsule, never mixed with healthy
+ * ones, never an input that could expire mid round.
+ */
+
+import {
+    ARK_DUST_SWEEP_MIN_BLOCKS_LEFT,
+    ARK_DUST_SWEEP_MIN_TOTAL_SATS,
+    buildDustSweepPlan,
+    type BuildDustSweepInputs,
+    type DustSweepVtxoInput,
+} from '../../src/services/ark/dustSweep';
+
+const MIN_SATS = 500; // ARK_REFRESH_MIN_SATS
+
+const dust = (over: Partial<DustSweepVtxoInput> = {}): DustSweepVtxoInput => ({
+    id: `v${Math.random().toString(36).slice(2, 8)}`,
+    sats: 400,
+    blocksUntilExpiry: null, // arkoor, the Lightning receive case
+    stateTag: 'Spendable',
+    alreadyRefreshing: false,
+    ...over,
+});
+
+const plan = (vtxos: DustSweepVtxoInput[], over: Partial<BuildDustSweepInputs> = {}) =>
+    buildDustSweepPlan({
+        vtxos,
+        exitInProgress: false,
+        minRefreshSats: MIN_SATS,
+        ...over,
+    });
+
+describe('the reported case', () => {
+    it('sweeps a 700 sat receive that landed as a 300 and a 400', () => {
+        const a = dust({ id: 'a', sats: 300 });
+        const b = dust({ id: 'b', sats: 400 });
+        expect(plan([a, b])).toEqual({
+            sweep: true,
+            ids: ['a', 'b'],
+            totalSats: 700,
+            candidateCount: 2,
+            candidateSats: 700,
+            reason: 'sweep',
+            excludedCount: 0,
+            excludedSats: 0,
+        });
+    });
+
+    it('leaves the healthy capsules in the wallet out of the batch', () => {
+        // A mixed batch has made the ASP reject the whole round, taking the
+        // healthy inputs down with the dust. Dust only, always.
+        const result = plan([
+            dust({ id: 'dust1', sats: 300 }),
+            dust({ id: 'dust2', sats: 400 }),
+            dust({ id: 'healthy', sats: 5_000 }),
+            dust({ id: 'at-the-floor', sats: MIN_SATS }),
+        ]);
+        expect(result.ids).toEqual(['dust1', 'dust2']);
+        expect(result.totalSats).toBe(700);
+    });
+});
+
+describe('the total gate', () => {
+    it('does not sweep below the total, the output would be dust again', () => {
+        const result = plan([dust({ sats: 200 }), dust({ sats: 150 })]);
+        expect(result).toMatchObject({ sweep: false, reason: 'below-min-total', ids: [] });
+        // The refusal still reports what it looked at, so the caller can say
+        // how far short the wallet is instead of going quiet.
+        expect(result).toMatchObject({ candidateCount: 2, candidateSats: 350 });
+    });
+
+    it('sweeps at the total, not only above it', () => {
+        const half = ARK_DUST_SWEEP_MIN_TOTAL_SATS / 2;
+        expect(plan([dust({ sats: half }), dust({ sats: half })]).sweep).toBe(true);
+    });
+
+    it('clears the refresh floor after the round fee, which is the point of the gate', () => {
+        const result = plan([dust({ sats: 300 }), dust({ sats: 300 })]);
+        expect(result.sweep).toBe(true);
+        // Fee measured at ~1 sat on device; even the 20 sat allowance in the
+        // pre-filter leaves the output above the floor, so the swept capsule can
+        // refresh itself from then on. The caller re-checks this against bark's
+        // real estimate before submitting.
+        expect(result.totalSats - 20).toBeGreaterThanOrEqual(MIN_SATS);
+    });
+
+    it('lets through a 550 sat receive that split into two dust pieces', () => {
+        // The concrete case a round 600 gate would have refused: output ~549,
+        // comfortably above the floor, so the rescue is worth making.
+        const result = plan([dust({ id: 'a', sats: 250 }), dust({ id: 'b', sats: 300 })]);
+        expect(result).toMatchObject({ sweep: true, ids: ['a', 'b'], totalSats: 550 });
+    });
+
+    it('honours a caller supplied total', () => {
+        expect(plan([dust({ sats: 200 }), dust({ sats: 200 })], { minTotalSats: 331 }).sweep).toBe(
+            true,
+        );
+    });
+});
+
+describe('what never goes into a sweep', () => {
+    it('refuses a single capsule however large, a lone sub floor input is rejected', () => {
+        expect(plan([dust({ sats: 499 })])).toMatchObject({
+            sweep: false,
+            reason: 'single-capsule',
+        });
+    });
+
+    it('refuses everything while a unilateral exit is in flight', () => {
+        expect(
+            plan([dust({ sats: 400 }), dust({ sats: 400 })], { exitInProgress: true }),
+        ).toMatchObject({ sweep: false, reason: 'exit-in-progress' });
+    });
+
+    it('leaves out capsules that are not spendable', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400 }),
+            dust({ id: 'ok2', sats: 400 }),
+            dust({ id: 'locked', sats: 400, stateTag: 'Locked' }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result).toMatchObject({ excludedCount: 1, excludedSats: 400 });
+    });
+
+    it('leaves out capsules another caller already submitted to a round', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400 }),
+            dust({ id: 'ok2', sats: 400 }),
+            dust({ id: 'mid-round', sats: 400, alreadyRefreshing: true }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result.excludedCount).toBe(1);
+    });
+
+    it('leaves out an input that could expire while the round runs', () => {
+        // Rounds fire hourly on mainnet and an expired input poisons the batch.
+        const result = plan([
+            dust({ id: 'ok1', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'ok2', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'expiring', sats: 400, blocksUntilExpiry: ARK_DUST_SWEEP_MIN_BLOCKS_LEFT - 1 }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result).toMatchObject({ sweep: true, excludedCount: 1, excludedSats: 400 });
+    });
+
+    it('leaves out an already expired input', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'ok2', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'expired', sats: 400, blocksUntilExpiry: -10 }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+    });
+
+    it('reports no dust rather than sweeping a healthy wallet', () => {
+        expect(plan([dust({ sats: 5_000 }), dust({ sats: 900 })])).toMatchObject({
+            sweep: false,
+            reason: 'no-dust',
+            ids: [],
+        });
+    });
+});
+
+describe('near expiry dust, where this rule departs from the other refresh paths', () => {
+    it('sweeps dust that is inside the exit runway floor', () => {
+        // Every other automatic path refuses inside 28h of expiry, to protect
+        // the unilateral exit window. Dust cannot be economically exited (a 400
+        // at depth 17 costs 5,645 vB to rescue 400 sats), so refusing here just
+        // loses the funds. 28h is ~168 blocks; these two sit well inside it.
+        const result = plan([
+            dust({ id: 'a', sats: 400, blocksUntilExpiry: 40 }),
+            dust({ id: 'b', sats: 400, blocksUntilExpiry: 40 }),
+        ]);
+        expect(result).toMatchObject({ sweep: true, ids: ['a', 'b'], totalSats: 800 });
+    });
+
+    it('includes arkoor capsules, whose expiry the SDK does not report', () => {
+        // expiryHeight 0 reaches this rule as null. These are exactly the
+        // capsules a Lightning receive produces, so null must not mean skip.
+        const result = plan([
+            dust({ id: 'a', sats: 350, blocksUntilExpiry: null }),
+            dust({ id: 'b', sats: 350, blocksUntilExpiry: null }),
+        ]);
+        expect(result.sweep).toBe(true);
+    });
+
+    it('treats an unreadable expiry as unsafe rather than guessing', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'ok2', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'nan', sats: 400, blocksUntilExpiry: Number.NaN }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result.excludedCount).toBe(1);
+    });
+});


### PR DESCRIPTION
Makes the wallet fold dust capsules into one on its own, instead of leaving them to expire behind a button nobody finds.

## The case this fixes

A Lightning receive is paid out of the ASP's VTXO pool, and the ASP bundles pool VTXOs to make a payment. So a 700 sat receive can arrive as a 300 and a 400. Reported to Second.tech in September 2026; Peter confirmed the bundling is by design.

Both pieces are below `ARK_REFRESH_MIN_SATS`, so every automatic path refused them:

- `useArkoorReceivePrompt` showed a dead-end "too small to refresh, spend them before they expire" notice
- `foregroundSweep` counted them as stranded dust and skipped them
- `changeRefresh` refused for the same reason

Only the manual Dust refresh button could act. The pieces then expire even though the wallet holds more than enough dust to rescue them.

## Approach

The rescue is not new. A delegated round over a batch of sub-floor inputs is accepted as long as the batch clears the dust limit, confirmed live on mainnet 2026-08-20 (two 400 sat capsules swept into one, on the same bark core we ship today). This automates that.

**Dust only, always.** Dust is still never mixed into a batch of healthy capsules. One sub-floor input has previously made the ASP reject an entire round, and taking healthy capsules down with the dust is a worse failure than leaving the dust alone.

**The gate is bark's fee estimate, not a round number.** The size rule only pre-filters; before submitting, the estimate must show total minus fee clearing the refresh floor, and must show the round spending nothing outside the dust batch. A flat 600 sat gate would have refused a 550 sat receive that split in two, which is rescuable at an output of about 549.

**It ignores the exit-runway floor on purpose.** Every other automatic refresh path refuses inside 28h of expiry to protect the unilateral exit window. Dust cannot be economically exited (a 400 at depth 17 costs 5,645 vB of exit-tree fees to rescue 400 sats), so refusing near-expiry dust only loses it. What it does refuse is an input inside about 2 hours of expiry, since an expired input poisons the whole round.

Guards, all shared with the existing round paths: one submission at a time per wallet, skip while any round is ongoing, skip while the stuck-refresh flow owns the wallet, hard refusal during a unilateral exit, and 5 minute pacing backing off to an hour.

Runs from the foreground sweep, the background wake, and at receive time.

## Second commit

Keeps the Lightning claim diagnostics from the same debugging session, behind `__DEV__`. `tryClaimAllLightningReceives` throws "All N lightning receive claim(s) failed" with no cause: `BarkError`'s own properties are exactly `message`, `tag` and `stack`, so the per-receive reason is discarded at the FFI boundary. Logging the pending receives' `state` before the claim is the only way to tell "nothing arrived" from "the money is there and the claim is broken".

## Verification

- `tsc --noEmit`: 402 errors, identical to the baseline on main. Zero new.
- Unit: 62 suites, 724 passed, 1 skipped. 17 of those are new, covering the reported 300 + 400 case, the 550 split, the refusals, and the near-expiry departure.

## Verified on device

Exercised end to end on mainnet, 2026-09-07, on a physical iPhone against the live ASP. Two sub-floor pieces left behind by failed swap attempts were picked up automatically, batched, and submitted with no user action.

Before the round:

```
[Ark balance] spendable= 1403 pendingRound= 703
[Ark sync] pending rounds: 64(finalising)
```

After it finalised:

```
[Ark vtxos] active Pubkey Spendable sats=698 exp=969919
[Ark vtxos] active Pubkey Spendable sats=703 exp=969951   <- the swept dust, consolidated
```

The dust came back as a single 703 sat capsule. That is above `ARK_REFRESH_MIN_SATS` (500), so it is no longer dust, and its expiry at 969951 is the furthest out of anything the wallet holds, so the sweep reset the clock as well as the value.

**Cost: 2 sats.** Spendable moved 1403 to 1401, and 698 + 703 = 1401 accounts for the balance exactly. Worth stating plainly because the raw log lines read alarmingly at first: `spendable= 1403` next to `pendingInRound= 703` looks like 2106 collapsing to 1401. It is not. In bark 0.6.x mid-round VTXOs stay `Spendable`, so `pendingInRound` is a subset of the headline rather than an addition to it. The capsule list confirms the total independently.

**It did not loop.** No sweep attempt fired on the following launch, because both remaining capsules are above the floor and there is nothing left to act on. That is the self-terminating property this PR argued for, now observed rather than reasoned about.

One difference from the case described above: the batch came from failed Lightning swaps rather than a split receive. The shape is identical, several sub-floor pieces whose total clears the floor, and the inbound Lightning fault that originally blocked testing is unrelated and still open.

## Residual risk

The failure mode if the wrapper is wrong is a rejected round: the submission is recorded as an error and the funds stay put. A wallet whose dust total falls short of the floor is refused rather than retried.

## Known gap

A single dust capsule alongside healthy ones is still stranded. Peter's position is that this should work: "if your total balance is 700 sats you can refresh both VTXOs together". Our mixed-batch exclusion predates bark 0.6.1 and is based on an older failure. Worth a device test, and if it holds, a follow-up that removes the exclusion entirely.



---

## Added: the sweep latch is now claimed before awaiting

Found on device while this PR was in review, on the pre-existing band sweep. The dust sweep here had the same defect and a wider window, so it is fixed on this branch rather than shipped and patched later.

```js
if (sweepInFlight) return;           // guard
await fetchArkPendingRoundStates();  // round trip 1
await estimateArkRefreshFee(...);    // round trip 2
sweepInFlight = true;                // too late
```

Two network calls sat between reading the flag and writing it, so every caller arriving in that window read `false` and went on to submit. **The window is widest exactly when it must not be**: a slow chain source lengthens both calls, and each extra submission spends more of the quota that made it slow.

Measured on the band sweep, 2026-09-09: **174 submissions in 12 minutes**, about one every two seconds while each took 18 seconds to fail, all refused by Blockstream's 429. A restart cleared it only because it emptied the pile of in-flight calls. This path has one more `await` than the path that produced those numbers.

The latch is now taken before any `await`, with every early return inside the `try` so none can leave it stuck on. `lastDustSweepAt` is still stamped only when a submission actually happens, so a skipped tick does not eat the window.

**A 429 now stands the sweep down for an hour**, matching the width of Blockstream's stated per-hour cap, instead of inflating `dustFailures` and returning inside the same exhausted hour.

`rateLimitedUntil` is **shared between both sweeps** and gates both, for the same reason `sweepInFlight` is shared: the quota belongs to the connection, not to one sweep, so a rejection earned by either has to silence both.

Names match `fix/ark-sweep-rate-limit-backoff` deliberately. Both branches touch this file, so merging them is a de-duplication rather than a reconciliation.

Updated verification: `tsc` **402**, identical to baseline. Unit: **62 suites, 724 passed, 1 skipped.**
