### PR TITLE
chore(ios): allow local networking in debug builds only

### DIFF
--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 				4B36CFF6FE55027DCA5CB6E1 /* Upload Bugsnag dSYM */,
 				9FF41DE89C69AED2AC3BAA92 /* [CP] Embed Pods Frameworks */,
 				98840B4C0BAF250AB1154EC4 /* [CP] Copy Pods Resources */,
+				D69E95167DDF706690AF1C07 /* Debug only: allow local networking */,
 			);
 			buildRules = (
 			);
@@ -1073,6 +1074,25 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		D69E95167DDF706690AF1C07 /* Debug only: allow local networking */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Debug only: allow local networking";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Debug builds only. Permits cleartext HTTP to private-range addresses so a\n# physical device can reach the Metro dev server over the LAN. Release and\n# archive builds ship Info.plist exactly as committed, with neither key.\nif [ \"${CONFIGURATION}\" != \"Debug\" ]; then\n  exit 0\nfi\n\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nPB=/usr/libexec/PlistBuddy\nDESC=\"Development builds connect to a Metro server on your local network.\"\n\nif [ ! -f \"${PLIST}\" ]; then\n  echo \"warning: no Info.plist at ${PLIST}, skipping local networking patch\"\n  exit 0\nfi\n\n\"${PB}\" -c \"Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool true\" \"${PLIST}\" 2>/dev/null \\\n  || \"${PB}\" -c \"Set :NSAppTransportSecurity:NSAllowsLocalNetworking true\" \"${PLIST}\"\n\n\"${PB}\" -c \"Add :NSLocalNetworkUsageDescription string ${DESC}\" \"${PLIST}\" 2>/dev/null \\\n  || \"${PB}\" -c \"Set :NSLocalNetworkUsageDescription ${DESC}\" \"${PLIST}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Moves the two ATS keys out of the committed `Info.plist` and into a Debug-only build phase, so physical-device Metro keeps working without either key reaching a shipped build.

## Why not just commit the keys

Reaching Metro from a physical iPhone needs cleartext HTTP to a private-range address, which ATS blocks. `NSAllowsLocalNetworking` fixes that, and `NSLocalNetworkUsageDescription` is the purpose string Apple requires alongside it.

Committing them to `Info.plist` means they also ship. That buys nothing: the app has no production use for local networking. There is no user-configurable node or Electrum server surface, and the chain and Ark hosts are hardcoded, so a release build never requests a private address.

It also means there is no honest wording for the purpose string. Anything that reads correctly to an App Store user would describe a feature that does not exist, and the dev-honest sentence mentions a development server in a finance app's permission prompt, which reviewers read.

## What this does instead

A script phase on the `BlueWallet` target, last in the build phase list so it runs after `ProcessInfoPlistFile`, adds both keys to the packaged plist with PlistBuddy. It exits immediately unless `CONFIGURATION` is `Debug`.

Release and archive builds package `Info.plist` exactly as committed, with neither key present.

Scope is unchanged in every other respect. `NSAllowsArbitraryLoads` stays `false`, and local networking reaches private-range addresses only, which is the same scope Android already permits through `network_security_config.xml`. The block already carried cleartext exceptions for `.onion`, `tailscale.net` and `ts.net`.

## Target choice

Only `BlueWallet` needs it. `BlueWallet-NoLDK` already sets `NSAllowsArbitraryLoads` to true in its own plist, so local networking is permitted there already. `ENABLE_USER_SCRIPT_SANDBOXING` is unset on both app targets, so the phase can write to the packaged plist. It is `YES` only on `BlueWalletUITests`, which is untouched.

Info.plist preprocessing was the other candidate and was rejected: the C preprocessor strips `//`, which would mangle the DOCTYPE on line 2.

## Verification

- PlistBuddy commands run against a real copy of `Info.plist`: both keys land with the correct values, the description string survives its spaces and trailing period, `NSAllowsArbitraryLoads` stays `false`, and `plutil -lint` passes.
- Run twice to simulate an incremental build where the packaged plist still carries the patch. The `Add` falls back to `Set`, exit 0, one key not two, still lints clean.
- `plutil -lint` on `project.pbxproj` passes, and `xcodebuild -list` resolves all three targets and eight schemes.
- Diff is 20 added lines. The `xcodeproj` gem did not reformat the file.

## Not done

No Xcode build was run against this. The phase's placement and guard are verified by inspection and the PlistBuddy behavior is verified directly, but the first real Debug build on a device is the check that matters. The failure mode if the placement is wrong is that the keys do not land and LAN Metro stays broken, the same as today. It cannot affect a release build, which takes the `exit 0` path.

## Follow-up on merge

`ios/BlueWallet/Info.plist` is still modified in the main tree with the manual version of these keys. Once this lands that edit is redundant and should be reverted, otherwise the keys ship after all.
