### PR TITLE
fix(ark): offer the exit-fee reserve on the home banner too

### DIFF
--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -10,6 +10,7 @@ import { CarouselPageVisibilityContext } from "@Cypher/custom-hooks";
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { Animated, AppState, FlatList, Image, NativeScrollEvent, NativeSyntheticEvent, Platform, TouchableOpacity, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
+import SimpleToast from "react-native-simple-toast";
 
 interface Props {
     balance: any;
@@ -81,6 +82,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         arkRefreshStuck,
         setArkPendingOnchainRecoverOpen,
         arkExitFeeReserveSats,
+        setArkExitFeeReserveSats,
     } = useAuthStore();
 
     // Per-card vertical nudge for the Ark slide.
@@ -265,11 +267,19 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
             // and the recover section this deep-links to is hidden anyway.
             if (stuckSats > 0 && stuckSats < STUCK_BOARD_MIN_SATS && (arkExitFeeReserveSats ?? 0) <= 0) {
                 return {
-                    text: `You have ${stuckSats.toLocaleString()} sats failing to board your Bark vault. Recover here.`,
+                    text: `You have ${stuckSats.toLocaleString()} sats failing to board your Bark vault. Recover here, or use them for Emergency Exit fees.`,
                     linkText: 'here',
                     tapTab: 0, // Capsules tab
                     openOnchainRecover: true,
                     error: true,
+                    // Drives the second action under this banner. The in-card
+                    // path (ArkWallet) has offered this since the reserve
+                    // landed, but that whole block is gated behind
+                    // `!hideActionButtons`, so in shared-button mode (the
+                    // default home layout) the only option ever shown was
+                    // Recover. Same call and same wording as the in-card link
+                    // so the two surfaces stay one feature.
+                    reserveExitFeeSats: stuckSats,
                 };
             }
         }
@@ -1094,6 +1104,45 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                                 {body}
                             </Text>
                         </TouchableOpacity>
+                        {/* Second action: keep the un-boardable funds on-chain
+                            as the exit-fee reserve instead of recovering them.
+                            Arms arkExitFeeReserveSats, which tells sync.ts to
+                            stop trying to board them and suppresses this
+                            banner on the next tick.
+
+                            Separate TouchableOpacity rather than a second link
+                            inside `body`, because the banner's whole text is
+                            already one tap target routing to Recover, and
+                            nesting a differently-routed link inside it makes
+                            the hit areas ambiguous. */}
+                        {Number((bgRefreshStatus as any).reserveExitFeeSats ?? 0) > 0 && (
+                            <TouchableOpacity
+                                onPress={() => {
+                                    setArkExitFeeReserveSats(
+                                        Number((bgRefreshStatus as any).reserveExitFeeSats),
+                                    );
+                                    SimpleToast.show('Kept on-chain for exit fees.', SimpleToast.SHORT);
+                                }}
+                                activeOpacity={0.7}
+                                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                                accessibilityRole="button"
+                                accessibilityLabel="Leave on-chain funds as exit fees"
+                                style={{ marginTop: 6 }}
+                            >
+                                <Text
+                                    h4
+                                    bold
+                                    style={{
+                                        color: colors.gray.light,
+                                        textAlign: 'center',
+                                        textDecorationLine: 'underline',
+                                        paddingHorizontal: 12,
+                                    }}
+                                >
+                                    Leave on-chain funds as exit fees
+                                </Text>
+                            </TouchableOpacity>
+                        )}
                     </Animated.View>
                 );
             })()}


### PR DESCRIPTION
Makes the exit-fee reserve reachable from the home screen in the layout most users actually run.

## The problem

Funds below the server's board minimum sit in bark's on-chain wallet and can never become a VTXO. There are two reasonable things to do with them: recover them back to the Hot Vault, or hold them on-chain as the CPFP reserve for a future unilateral exit. Arming the reserve also tells `sync.ts` to stop trying to board them.

Both paths already existed. Which one you were offered depended on a layout flag.

The in-card boarding row in `ArkWallet` offers both, `Recover` and `Leave on-chain funds as exit fees`. But that entire block is wrapped in `{!hideActionButtons && (` at [ArkWallet/index.tsx:664](src/components/ArkWallet/index.tsx#L664). When the shared Send/Receive row is active, which is the default home layout, none of it renders. A separate banner from `WalletsView` takes over, and that one only ever offered:

> You have N sats failing to board your Bark vault. Recover here.

So a user in the common layout was shown exactly one option, with nothing indicating the other existed. The only other place it surfaces is the Emergency Exit settings box, which you have to already know to look for. There is a comment at [line 658](src/components/ArkWallet/index.tsx#L658) acknowledging that shared mode drops these nudges.

Reported from a live case: an on-chain amount intended as exit fees, where the home screen offered only to release it.

## The change

Adds the second action to the `WalletsView` banner. It calls the same setter with the same label and the same toast as the in-card version, so the two surfaces stay one feature instead of drifting.

It is a separate tap target rather than a second link inside the sentence. The banner text is already one tap area routing to Recover, and nesting a differently-routed link inside it would make the hit areas ambiguous.

**No new capability.** No new state, no new call, no change to how the reserve behaves once armed. This is purely about which surface exposes it.

## Verification

- `tsc --noEmit`: 402 errors, identical to baseline on main. Zero new, none in the touched file.
- Unit: 63 suites, 750 passed, 1 skipped.

## Not done

**Not exercised on device.** The banner only appears when the on-chain wallet holds a confirmed balance below the board minimum, and the test wallet currently reports `pendingBoard = 0`, so there was no way to render it. The code path it drives is the one the in-card version has used since the reserve landed.

## Worth a follow-up

This fixes the one case that was reported, but the underlying gap is wider: `hideActionButtons` gates a whole block of Ark nudges, and only some of them have an equivalent in the shared-mode banner. An audit of what else is invisible in the default layout is probably worth doing separately.
