### PR TITLE
fix(ark): put the unknown case on the safe side

### DIFF
--- a/src/services/ark/datadir.ts
+++ b/src/services/ark/datadir.ts
@@ -20,12 +20,38 @@ export async function ensureArkDatadir(): Promise<string> {
  * Delete the Ark datadir (VTXO state, SQLite, exit txs).
  *
  * DESTRUCTIVE: any funds in VTXOs not backed up externally are unrecoverable
- * after this. Intended for dev-only resets. The `ensured` latch is flipped
- * back so a subsequent `ensureArkDatadir()` recreates the folder cleanly.
+ * after this.
+ *
+ * NOT dev-only, despite what this said until 2026-09-08. Every caller is a
+ * shipping path: the orphan-datadir auto-clean in CreateArkScreen, "Delete
+ * vault" in Ark settings, and the re-key in ArkSeedPhraseScreen. This is the
+ * function that destroys funds, and it has form: the old
+ * `pendingExitsTotalSats == 0` auto-delete wiped a wallet mid-exit twice.
+ *
+ * THROWS IF THE DIRECTORY SURVIVES. `RNFS.unlink` does not only fail on a
+ * missing path; it also fails on open file descriptors, iOS file protection,
+ * and partial directory deletes, and in those cases the datadir is still there
+ * afterwards. Callers use the throw to decide whether it is safe to delete the
+ * seed, so "did it actually go" has to be answered rather than assumed.
+ *
+ * The `ensured` latch is reset in a `finally`. It used to sit after the awaited
+ * unlink, so a throw left it `true` and the next `ensureArkDatadir()` returned
+ * the path without checking the directory was there.
  */
 export async function deleteArkDatadir(): Promise<void> {
-    if (await RNFS.exists(ARK_DATADIR)) {
-        await RNFS.unlink(ARK_DATADIR);
+    try {
+        if (await RNFS.exists(ARK_DATADIR)) {
+            await RNFS.unlink(ARK_DATADIR);
+        }
+        // Verify rather than trust. A resolved unlink is not proof on every
+        // platform and failure mode, and the caller is about to decide whether
+        // to destroy the only key to whatever is still on disk.
+        if (await RNFS.exists(ARK_DATADIR)) {
+            throw new Error(
+                `Ark datadir still present after delete: ${ARK_DATADIR}`,
+            );
+        }
+    } finally {
+        ensured = false;
     }
-    ensured = false;
 }

--- a/src/services/ark/indeterminate.ts
+++ b/src/services/ark/indeterminate.ts
@@ -18,6 +18,27 @@
  * `exit.claimArkExitsToAddress`, and `recoverOnchainBoard`. Fixing a path
  * rather than a capability leaves the next call site to reintroduce it.
  *
+ * CALL SITES. Keep this list current; an audit found the Lightning ones missing
+ * from it, and the list being wrong is part of why they stayed unguarded. Six
+ * sites were enumerated here, all of them arkoor, on-chain or exit paths, so
+ * "the Lightning branch is not on the list" never looked like an omission.
+ *
+ *   exit.ts                 claimArkExitsToAddress
+ *   exitFunding.ts          convertToExitFees
+ *   recoverOnchainBoard.ts  recoverArkOnchainBoard
+ *   offboard.ts             offboardArkVtxos
+ *   send.ts                 sendArkoorPayment
+ *   send.ts                 sendOnchain
+ *   send.ts                 dispatchLnSend          <- added 2026-09-08
+ *
+ * `lightning.ts#cancelArkLightningReceive` uses `looksLikeConnectionLoss`
+ * directly rather than this wrapper, because it returns a discriminated result
+ * instead of throwing. Same rule, different shape.
+ *
+ * The test to apply when adding a call: does it hand something to the ASP or
+ * the chain that could still land after the connection dies? If yes, it belongs
+ * here, and it belongs on this list.
+ *
  * It imports nothing from the SDK on purpose, so any module can wrap a call
  * without dragging the native binding into a unit test.
  */

--- a/src/services/ark/lightning.ts
+++ b/src/services/ark/lightning.ts
@@ -1,6 +1,7 @@
 import bolt11 from 'bolt11';
 
 import { getArkWalletHandle } from './walletHandle';
+import { looksLikeConnectionLoss } from './networkFault';
 
 /**
  * Plain-JS view of a pending Lightning receive.
@@ -233,21 +234,41 @@ export async function cancelArkLightningReceive(
             return {
                 ok: false,
                 kind: 'preimage-revealed',
-                reason: 'Payment is already in flight — can\'t cancel.',
+                reason: 'Payment is already in flight, so it can\'t be cancelled.',
             };
         }
         if (/already finished/i.test(msg)) {
             return {
                 ok: false,
                 kind: 'already-finished',
-                reason: 'Receive already settled — nothing to cancel.',
+                reason: 'Receive already settled, so there is nothing to cancel.',
+            };
+        }
+        // A dropped connection is not a refusal. Without this branch anything
+        // the two guards above do not match fell through to `kind: 'unknown'`
+        // with the raw text as its reason, which reads to the user as a
+        // definite "it did not happen" for an outcome we cannot know: the ASP
+        // may have accepted the cancellation before the line died.
+        //
+        // Bounded, unlike the send paths: the UI leaves the row in place on
+        // failure, so the next 30s sync corrects the display either way. The
+        // fix is about not asserting something we cannot know.
+        if (looksLikeConnectionLoss(err)) {
+            return {
+                ok: false,
+                kind: 'unknown',
+                reason: 'The connection dropped, so this may or may not have been cancelled. Check again in a moment.',
             };
         }
         console.warn('[Ark cancel-ln-recv] failed:', err);
         return {
             ok: false,
             kind: 'unknown',
-            reason: msg || 'Cancel failed; try again or wait for the next sync.',
+            // Prefer the written sentence over bark's internal text. `msg ||`
+            // had it backwards: it showed the SDK's own vocabulary, unbounded
+            // in length and written for developers, and the human fallback only
+            // appeared when the SDK gave us nothing at all.
+            reason: 'Cancel failed; try again or wait for the next sync.',
         };
     }
 }

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -32,23 +32,47 @@ export type ArkNetworkFault =
     | 'ark-server'
     | 'unknown';
 
-/** Flatten a thrown value into searchable text. BarkError hides detail in `inner`. */
+/**
+ * Flatten a thrown value into searchable text. BarkError hides detail in `inner`.
+ *
+ * Follows `cause` as well, because an error wrapped once loses nothing but an
+ * error wrapped twice used to lose the signal entirely before any matcher saw
+ * it. Depth-limited and cycle-guarded: this runs on the error path, where
+ * throwing again would replace a useful message with a useless one.
+ *
+ * Measured on device 2026-09-08 (bark 0.6.1): a dropped ASP connection arrives
+ * as a BarkError whose own properties are exactly ["message","tag","stack"],
+ * with no `inner` and no `cause`, and the whole detail sits in `message`. The
+ * traversal below is therefore defensive rather than load-bearing today.
+ */
 export function arkErrorText(err: unknown): string {
-    if (err == null) return '';
-    if (typeof err === 'string') return err;
-    const e = err as {
-        tag?: unknown;
-        message?: unknown;
-        inner?: { errorMessage?: unknown; message?: unknown };
+    const parts: string[] = [];
+    const seen = new Set<unknown>();
+
+    const walk = (v: unknown, depth: number): void => {
+        if (v == null || depth > 4) return;
+        if (typeof v === 'string') {
+            parts.push(v);
+            return;
+        }
+        if (typeof v !== 'object' || seen.has(v)) return;
+        seen.add(v);
+        const e = v as {
+            tag?: unknown;
+            message?: unknown;
+            errorMessage?: unknown;
+            inner?: unknown;
+            cause?: unknown;
+        };
+        for (const p of [e.tag, e.message, e.errorMessage]) {
+            if (typeof p === 'string') parts.push(p);
+        }
+        walk(e.inner, depth + 1);
+        walk(e.cause, depth + 1);
     };
-    return [
-        e.tag,
-        e.message,
-        e.inner?.errorMessage,
-        e.inner?.message,
-    ]
-        .filter((p) => typeof p === 'string')
-        .join(' ');
+
+    walk(err, 0);
+    return parts.join(' ');
 }
 
 function hostOf(url: string): string | null {
@@ -190,11 +214,39 @@ export function describeArkFailure(
  * Deliberately biased toward returning true. A false "may have gone through"
  * costs a user one balance check. A false "your funds were not moved" costs
  * them their trust that the wallet knows where their money is.
+ *
+ * POLARITY: refusals are enumerated, everything else is unknown.
+ *
+ * This used to match transport failures positively and return false for
+ * anything it did not recognise, which put the unknown case on the dangerous
+ * side: an unmatched error was reported as a definite refusal, and the caller
+ * re-armed its send control on the strength of it. For an ln-address or
+ * ln-offer a retry mints a fresh invoice with a new payment hash, so it settles
+ * alongside the first and the recipient is paid twice.
+ *
+ * Refusals are a closed set we own: not enough funds, below dust, a bad
+ * address, a quota rejection. Transport failures are open ended, and the set
+ * grew every time the SDK reworded something. Enumerating the closed side puts
+ * the unknown case on the safe side, which is the same "fail closed" convention
+ * reset.ts documents.
+ *
+ * Measured on device 2026-09-08, bark 0.6.1, ~3 minutes fully offline: 79
+ * captured ASP failures, two distinct shapes, and BOTH would have matched the
+ * old positive regex (on "dns" and on "transport"). So this is not a live bug
+ * today. It is latent, and the reason is worth stating: they matched on words
+ * from tonic's verbose `source:` chain, not on the gRPC status. The status text
+ * alone, "The service is currently unavailable", matched nothing, because the
+ * old pattern carried `unreachable` and not `unavailable`. Any upstream change
+ * that trims that source chain would have flipped both shapes to "definite
+ * refusal" silently.
  */
+const DEFINITE_REFUSAL =
+    /insufficient|not enough|below dust|dust limit|too small|minimum|invalid address|bad user input|malformed|unparse|could not parse|\b429\b|too many requests|rate limit|exceeds the current limit|already spent|already finished|not found/i;
+
 export function looksLikeConnectionLoss(err: unknown): boolean {
     const tag = (err as { tag?: string })?.tag ?? '';
     const text = `${tag} ${arkErrorText(err)}`;
-    return /ServerConnection|connect|timed? ?out|network|unreachable|dns|socket|transport|aborted|reset by peer|broken pipe/i.test(
-        text,
-    );
+    // Nothing to read is not evidence of a refusal. Treat it as unknown.
+    if (!text.trim()) return true;
+    return !DEFINITE_REFUSAL.test(text);
 }

--- a/src/services/ark/reset.ts
+++ b/src/services/ark/reset.ts
@@ -20,10 +20,16 @@ export interface ResetArkWalletOptions {
      * biometric (Face/Touch ID) fast path so the user doesn't have to
      * re-type 12 words on the same device.
      *
-     * Defaults to false — i.e. the historic "nuke everything" behavior
-     * for reset paths that explicitly want a clean slate (DEV-only reset
-     * in CreateArkScreen, the auto-reset triggered after a successful
-     * unilateral exit in `useArkSync`).
+     * Defaults to false, i.e. the historic "nuke everything" behavior for
+     * reset paths that explicitly want a clean slate.
+     *
+     * This used to name "the auto-reset triggered after a successful unilateral
+     * exit in useArkSync" as a caller. There is no such caller, and grep finds
+     * no reference to one anywhere in the tree. Every caller is user-initiated:
+     * "Reset & wipe" and the orphan auto-clean in CreateArkScreen, the re-key in
+     * ArkSeedPhraseScreen, and "Delete vault" in Ark settings. Worth stating,
+     * because that phantom caller is what made this function look like it sat
+     * under the exit-fix freeze.
      */
     keepSeedInKeychain?: boolean;
 
@@ -81,11 +87,33 @@ export async function resetArkWalletState(
     // Scrub the in-memory PBKDF2 key so it doesn't carry over to a new wallet.
     clearArkKeyCache();
 
+    // DO NOT SWALLOW THIS.
+    //
+    // The old catch here reasoned "a missing datadir is the success state
+    // anyway", which is true for exactly one failure mode. `RNFS.unlink` also
+    // fails on open file descriptors, iOS file protection and partial directory
+    // deletes, and in those cases the datadir is still on disk. Reset then
+    // carried on and deleted the Keychain mnemonic and the background seed copy
+    // below, and `resetArkWalletState` resolved normally as though it had
+    // worked.
+    //
+    // End state: the wallet's data still on disk with the only key to it
+    // destroyed, and nobody told. That is the one outcome this function must
+    // never produce.
+    //
+    // So: bail before anything else is deleted. Nothing after this point runs,
+    // which also leaves the backup files alone, since they are the recovery
+    // path if the datadir really is stuck. The seed survives, so the wallet is
+    // still recoverable, and the caller gets a real error instead of silence.
     try {
         await deleteArkDatadir();
-    } catch (err) {
-        console.warn('[Ark] deleteArkDatadir failed:', err);
-        // Swallow — a missing datadir is the success state anyway.
+    } catch (err: any) {
+        console.warn('[Ark] deleteArkDatadir failed, aborting reset:', err);
+        throw new Error(
+            'Could not delete the Ark wallet data, so the seed was kept to avoid ' +
+            'leaving wallet data on this device with no way to open it. ' +
+            'Nothing was deleted. Close the app and try again.',
+        );
     }
 
     // Wallet-scoped backup deletion. Best-effort, swallow per-channel

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -451,7 +451,27 @@ export async function executeArkSend(
         // throws so the user checks Activity instead of being silently re-sent.
         let settled = false;
         for (let attempt = 1; attempt <= MAX_LN_SEND_ATTEMPTS; attempt++) {
-            const status = await dispatchLnSend(handle, dest, amount, comment);
+            // Wrapped, so a connection that dies mid-dispatch is reported as
+            // UNKNOWN rather than as a failure. This is the one send path that
+            // was not: runBroadcastCall guards sendArkoorPayment and sendOnchain
+            // below, and the four other ASP-facing calls across exit.ts,
+            // offboard.ts, exitFunding.ts and recoverOnchainBoard.ts, but the
+            // Lightning branch went straight to the SDK.
+            //
+            // It is also the path where being wrong costs the most. On a
+            // transport failure the ASP may already have begun the HTLC. If the
+            // caller is told "failed" it re-arms the send control, and for an
+            // ln-address or ln-offer a retry mints a FRESH invoice with a new
+            // payment hash, so it settles alongside the first one. The recipient
+            // is paid twice and the retry loop below cannot see it, because it
+            // only ever retries on a movement confirmed refunded.
+            //
+            // Throwing here leaves the loop entirely, which is correct: an
+            // indeterminate outcome must never be retried.
+            const status = await runBroadcastCall(
+                () => dispatchLnSend(handle, dest, amount, comment),
+                'payment',
+            );
 
             // Fast path: bark settled at dispatch and handed us the preimage.
             if (status.tag === LightningSendStatus_Tags.Paid) {

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -313,7 +313,47 @@ describe('telling a refusal apart from a dropped connection', () => {
         expect(loss(new Error('insufficient funds'))).toBe(false);
         expect(loss(new Error('bad user input: invalid address'))).toBe(false);
         expect(loss(new Error('amount below dust limit'))).toBe(false);
-        expect(loss({ tag: 'Internal', message: 'BarkError.Internal' })).toBe(false);
+        expect(loss(new Error('amount is below the minimum'))).toBe(false);
+    });
+
+    it('treats an unrecognised error as ambiguous, not as a refusal', () => {
+        // CHANGED DELIBERATELY. This case previously asserted `false`, back when
+        // the rule matched transport failures positively and returned false for
+        // everything it did not recognise.
+        //
+        // A bare "internal error" carries no evidence either way: the ASP may
+        // have signed and broadcast before whatever went wrong. Reporting it as
+        // a definite refusal re-arms the send control, and for an ln-address or
+        // ln-offer a retry mints a fresh invoice with a new payment hash, so it
+        // settles alongside the first and the recipient is paid twice.
+        //
+        // The unknown case now sits on the safe side. The cost is a balance
+        // check the user did not need; the cost of the old default was a
+        // double payment.
+        expect(loss({ tag: 'Internal', message: 'BarkError.Internal' })).toBe(true);
+        expect(loss(new Error('something nobody has seen before'))).toBe(true);
+    });
+
+    it('is not fooled by a gRPC status with the source chain trimmed', () => {
+        // Observed on device 2026-09-08 (bark 0.6.1): a dropped ASP connection
+        // arrives as tonic's verbose Display output, which happens to contain
+        // "dns" and "transport". The old positive regex matched on those, not on
+        // the gRPC status, and the status text on its own carries neither. It
+        // says "unavailable"; the old pattern knew "unreachable".
+        //
+        // So the old rule was correct only for as long as bark kept printing the
+        // source chain. These are the shapes that would have broken it.
+        expect(loss({ tag: 'Inner', message: "code: 'The service is currently unavailable'" })).toBe(true);
+        expect(loss({ tag: 'Inner', message: "code: 'DEADLINE_EXCEEDED'" })).toBe(true);
+        expect(loss({ tag: 'Inner', message: 'h2 protocol error' })).toBe(true);
+    });
+
+    it('reads a doubly wrapped error through its cause chain', () => {
+        // arkErrorText used to read tag/message/inner only, so a refusal wrapped
+        // twice lost its signal before any matcher saw it and fell to the
+        // default. Cheap to support and it fails in the right direction.
+        expect(loss({ message: 'send failed', cause: { message: 'insufficient funds' } })).toBe(false);
+        expect(loss({ message: 'outer', cause: { cause: { message: 'below dust limit' } } })).toBe(false);
     });
 
     it('does not throw on null, undefined or a non-error', () => {


### PR DESCRIPTION
Money-safety findings from the Ark L1 audit. They share a shape: code that could not know an outcome reported a definite one, in the direction that costs the user.

## The device verification came first, and it changed the framing

The audit set a gate: settle the classifier before wrapping anything, because "wrap it in `runBroadcastCall`" is a no-op if the classifier never fires. So I measured it before changing it.

Temporary in-code probe on a physical iPhone, bark 0.6.1, mainnet, ~3 minutes fully offline. Probe reverted, device storage cleared.

```
nextRoundStartTime: 96 ticks, 16 ok, 80 err     <- ASP, gRPC
arkInfo:            96 ticks, 96 ok,  0 err     <- never touches the network
```

79 captured failures, exactly two distinct shapes, and **both matched the old regex** (on `dns` and on `transport`).

So the classifier was **not** getting this wrong in production. That part of the finding does not reproduce, and the PR should not claim it did.

What is real is *why* it matched. It matched on words from tonic's verbose `source:` chain, not on the gRPC status. The status text on its own matches nothing:

```
full observed (dns shape)  -> MATCH on 'dns'
status word ONLY           -> NO MATCH   <- "The service is currently unavailable"
DEADLINE_EXCEEDED          -> NO MATCH
h2 protocol error          -> NO MATCH
```

`unavailable` was not in the pattern; `unreachable` was, and they are different words. The rule was correct only for as long as bark keeps printing the source chain. Any upstream trim flips both shapes to "definite refusal" silently.

**Filed as latent, not live.** The fix stands on the polarity argument, not on an active bug.

## Changes

**Classifier polarity** (`networkFault.ts`). Refusals are a closed set we own: not enough funds, below dust, a bad address, a quota rejection. Transport failures are open ended and get reworded by the SDK. Enumerating the closed side puts the unknown case on the safe side, which is the fail-closed convention `reset.ts` already documents. `arkErrorText` also follows `cause` chains now, though measurement shows these errors carry no cause and everything sits in `message`, so that half is defensive.

**Lightning dispatch** (`send.ts`). The Lightning branch called the SDK unwrapped while every other ASP-facing call went through `runBroadcastCall`. It is also where being wrong costs the most: on a transport failure the ASP may already have begun the HTLC, and for an ln-address or ln-offer a retry mints a fresh invoice with a **new payment hash**, so it settles alongside the first. The retry loop cannot catch that, because it only retries on a movement confirmed refunded. Now that the classifier is verified to fire on the real error shapes, this wrapper is not cosmetic.

**Cancel path** (`lightning.ts`). `cancelLightningReceive` had two substring branches and no connection-loss branch, so a dropped line became a definite "it did not happen". Bounded, since the UI leaves the row and the next 30s sync corrects it. Also stopped preferring bark's raw error text over the written sentence; the `||` had it backwards.

**Reset** (`reset.ts`, `datadir.ts`). The datadir delete failure was swallowed on the reasoning that a missing datadir is the success state. True for one failure mode. `unlink` also fails on open file descriptors, iOS file protection and partial deletes, and then the datadir survives while reset carries on to delete the Keychain mnemonic and the background seed copy, resolving normally. End state: wallet data on disk with the only key to it destroyed, and nobody told. Now it verifies the directory is actually gone, throws if not, and reset bails before deleting anything else, so the seed survives and the wallet stays recoverable. The `ensured` latch moved into a `finally`; it sat after the awaited unlink, so a throw left it `true`.

**Call-site list** (`indeterminate.ts`). It enumerated six sites, all arkoor, on-chain or exit, and omitted both Lightning ones, so "the Lightning branch is missing" never looked like an omission.

## A correction to the audit

`deleteArkDatadir` was labelled dev-only, and `reset.ts` named "the auto-reset triggered after a successful unilateral exit in `useArkSync`" as a caller.

**No such caller exists.** Grep finds no reference to one anywhere. Every caller is user-initiated and shipping: "Reset & wipe" and the orphan auto-clean in `CreateArkScreen`, the re-key in `ArkSeedPhraseScreen`, and "Delete vault" in Ark settings.

That phantom caller is precisely what made this finding look like it fell under the exit-fix freeze. It does not.

## Deviations from the suggested PR split

The audit puts these in PR 3. They are on lines this PR already rewrites, and splitting them would have meant leaving known defects inside a block being edited:

- **F10**, raw SDK text preferred over the written fallback: the exact line the cancel branch replaces.
- **F9**, two em-dashes in `cancelArkLightningReceive`: inside the same catch block. The house copy rule requires auditing user-visible strings in any change that touches them. The other four files in F9's table are untouched and remain for PR 3.
- **F2**, the dev-only mislabel: the docstring of the function F1 rewrites.

## Verification

- `tsc --noEmit`: **402**, identical to baseline. Zero new.
- Unit: **61 suites, 710 passed, 1 skipped.**
- One existing test changed deliberately: `{tag:'Internal'}` asserted `false` and now asserts `true`. That case *is* the polarity change, so it is encoded with its rationale rather than worked around. Four new tests cover the trimmed-status shapes and the cause chain.

## Not done

**No device exercise of the changed paths.** The classifier change is covered by tests built from real captured error text, but no send, cancel or reset was run against a live failure with this code in place. Testing the send path means real funds and a real dropped connection at the exact moment of dispatch.

The reset change is the one to watch: it converts a silent success into a thrown error. All four call sites handle failure, though `CreateArkScreen`'s "Reset & wipe" uses `try/finally` with no `catch`, so it will surface as an unhandled rejection rather than a message. Worth a follow-up, but it is strictly better than the current behaviour of quietly destroying the seed.

