### PR TITLE
fix(ark): stop disclosing withdrawal txids to a third party

### DIFF
--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -536,52 +536,39 @@ export async function executeArkSend(
 
     console.log('[Ark send]', dest.kind, 'resolved id=', id.slice(0, 16) + '…');
 
-    // Slow-broadcast hint for `onchain` direction. The ASP sets the round's
-    // on-chain fee rate at construction; empirically it picks at-or-below
-    // mempool's economyFee floor to maximise its margin (the user paid Y
-    // sats but only ~45% of that hit miners; rest is server margin). This
-    // routinely lands withdrawals at ~2 sat/vb, meaning hours of mempool
-    // wait. Fire off a non-blocking mempool fee-rate fetch + warn-log if
-    // the resulting tx is well below current `fastestFee`. Pre-broadcast
-    // disclosure already exists on ArkWithdrawReviewScreen; this log is
-    // the breadcrumb a downstream auto-CPFP-prompt feature would key on.
+    // REMOVED 2026-09-08: a fire-and-forget slow-broadcast breadcrumb that
+    // fetched `https://mempool.space/api/tx/<txid>` after every on-chain
+    // withdrawal.
     //
-    // Fire-and-forget so we don't add latency to the send return path.
-    // 2-second budget on the mempool fetch; bail silently on error or
-    // timeout. Only runs for 'onchain' direction since LN sends route off
-    // chain and the rate concept doesn't apply.
-    if (dest.kind === 'onchain') {
-        const onchainTxid = id;
-        void (async () => {
-            try {
-                const controller = new AbortController();
-                const t = setTimeout(() => controller.abort(), 2000);
-                const [txRes, feeRes] = await Promise.all([
-                    fetch(`https://mempool.space/api/tx/${onchainTxid}`, { signal: controller.signal }),
-                    fetch('https://mempool.space/api/v1/fees/recommended', { signal: controller.signal }),
-                ]);
-                clearTimeout(t);
-                if (!txRes.ok || !feeRes.ok) return;
-                const tx = await txRes.json();
-                const feeRecs = await feeRes.json();
-                const vsize = (tx?.weight ?? 0) / 4;
-                const fee = tx?.fee ?? 0;
-                if (!vsize || !fee) return;
-                const broadcastRate = fee / vsize;
-                const fastest = Number(feeRecs?.fastestFee ?? 1);
-                if (broadcastRate < fastest / 2) {
-                    console.warn(
-                        '[Ark send] onchain broadcast at ' + broadcastRate.toFixed(1) +
-                        ' sat/vb (current fastestFee=' + fastest + ' sat/vb). ' +
-                        'Tx ' + onchainTxid.slice(0, 12) + '… may take hours to confirm. ' +
-                        'User can speed up via CPFP on the receiving wallet (see Hot Vault → tap pending → "Accelerate transaction").',
-                    );
-                }
-            } catch {
-                /* swallow — best-effort breadcrumb only */
-            }
-        })();
-    }
+    // It bound this device's IP to a specific withdrawal txid at a host the
+    // wallet otherwise never contacts. On a default install the chain source is
+    // blockstream.info, and esploraProviders states the invariant it broke: "A
+    // healthy wallet talks to exactly one provider." It was ungated: no setting,
+    // no consent, not even __DEV__.
+    //
+    // What it bought was a console.warn, and often not even that. There is no
+    // retry and no delay, so the lookup regularly ran before the tx had
+    // propagated, 404'd, and returned early. The disclosure was paid on every
+    // withdrawal; the breadcrumb was not always produced.
+    //
+    // NOT REPLACED, and the reason is worth recording. The plan was to keep the
+    // warning and derive it from the fee endpoint plus a local transaction size.
+    // There is no local transaction size. In a cooperative offboard the ASP
+    // builds and broadcasts the round transaction; this device never broadcasts
+    // anything, and that transaction's weight and fee are shared across everyone
+    // in the round, so `fee / vsize` was never a measure of this user's payment
+    // to begin with. `ArkSendFeeView` carries feeSats but no weight, and the SDK
+    // hands back only a txid.
+    //
+    // Nothing user-facing is lost. Pre-broadcast fee disclosure already exists
+    // on ArkWithdrawReviewScreen, and the remedy the warning pointed at (CPFP
+    // via Hot Vault, tap the pending row, Accelerate transaction) is a shipped
+    // flow the user reaches without it. The only consumer was a downstream
+    // auto-CPFP prompt that was never built.
+    //
+    // The fee-rate endpoint itself is fine and stays in use elsewhere
+    // (exitFunding.ts): it carries no user data. Only the per-txid lookup was
+    // the problem.
 
     // Re-read local state so the UI reflects the send before the 30s poll.
     //


### PR DESCRIPTION
Every on-chain withdrawal fired a fire-and-forget lookup of `https://mempool.space/api/tx/<txid>` to produce a slow-broadcast breadcrumb. This deletes it.

## The problem

```js
fetch(`https://mempool.space/api/tx/${onchainTxid}`, { signal: controller.signal })
```

It bound this device's IP to a specific withdrawal txid at a host the wallet otherwise never contacts. On a default install the chain source is blockstream.info, and `esploraProviders.ts` states the invariant this broke: "A healthy wallet talks to exactly one provider."

Ungated. No setting, no consent, not even `__DEV__`.

And it frequently bought nothing. There is no retry and no delay, so the lookup often ran before the transaction had propagated, 404'd, and returned early at the `!txRes.ok` guard. **The disclosure was paid on every withdrawal whether or not the breadcrumb was produced.**

## Being precise about the exposure

This does **not** prove the user originated the transaction. In a cooperative offboard the ASP builds and broadcasts the round transaction; the device never broadcasts anything.

What leaked is an IP-to-txid binding for a withdrawal that mempool.space would otherwise never have seen.

## Not replaced, and why

The plan was to keep the warning and derive it from the fee endpoint plus a local transaction size. **There is no local transaction size.**

That round transaction belongs to the ASP, and its weight and fee are shared across everyone in the round, so `fee / vsize` was never a measure of this user's payment in the first place. It described the round. `ArkSendFeeView` carries `feeSats` and no weight, and `sendOnchain` hands back only a txid. There is nothing on the device to compute a rate from.

So rather than reconstruct a metric that was measuring the wrong thing, the block goes.

## Nothing user-facing is lost

- Pre-broadcast fee disclosure already exists on `ArkWithdrawReviewScreen`, as the removed comment itself noted.
- The remedy the warning pointed at, CPFP from the Hot Vault pending row via "Accelerate transaction", is a shipped flow the user reaches on their own.
- The output was a `console.warn`. Its only intended consumer was a downstream auto-CPFP prompt that was never built.

## Scope

- The recommended-fees endpoint (`/api/v1/fees/recommended`) is **untouched** and still used in `exitFunding.ts`. It carries no user data and is precedented. Only the per-txid lookup was the problem.
- Confirmed by grep: this was the only `/api/tx/` fetch in the tree.
- `send.ts` now makes no network calls of its own.

## Verification

- `tsc --noEmit`: **402**, identical to baseline. Zero new.
- Unit: **61 suites, 707 passed, 1 skipped.**
- Net 45 lines removed, 32 added, and the additions are the comment recording why this must not come back.

## Not done

No device exercise. The change only removes a fire-and-forget side effect that never fed the return path, so a withdrawal behaves identically minus the outbound request. Worth confirming on the next real withdrawal that no request to mempool.space appears, which is the whole observable difference.
