### PR TITLE
fix(ark): remove em-dashes from user-facing service copy

### DIFF
--- a/src/services/ark/backgroundNotifications.ts
+++ b/src/services/ark/backgroundNotifications.ts
@@ -124,7 +124,7 @@ function fire(
 export function notifyConsecutiveFailures(): void {
     fire(
         'Auto-refresh trouble',
-        "Couldn't auto-refresh — tap to refresh manually.",
+        "Couldn't auto-refresh. Tap to refresh manually.",
         'low',
     );
 }
@@ -593,7 +593,7 @@ export function notifyDustUneconomic(
 ): void {
     fire(
         'Tiny capsules at risk',
-        `${vtxoCount} capsule${vtxoCount === 1 ? '' : 's'} totalling ${totalSats} sats will expire — refresh fee (${feeSats} sats) exceeds their value.`,
+        `${vtxoCount} capsule${vtxoCount === 1 ? '' : 's'} totalling ${totalSats} sats will expire. The refresh fee (${feeSats} sats) exceeds their value.`,
         'low',
         { feeSats, totalSats, vtxoCount },
     );

--- a/src/services/ark/history.ts
+++ b/src/services/ark/history.ts
@@ -173,9 +173,9 @@ function describe(
                 : direction;
 
     switch (status) {
-        case 'pending':   return `Pending — ${body.toLowerCase()}`;
-        case 'failed':    return `Failed — ${body.toLowerCase()}`;
-        case 'canceled':  return `Canceled — ${body.toLowerCase()}`;
+        case 'pending':   return `Pending: ${body.toLowerCase()}`;
+        case 'failed':    return `Failed: ${body.toLowerCase()}`;
+        case 'canceled':  return `Canceled: ${body.toLowerCase()}`;
         default:          return body;
     }
 }

--- a/src/services/ark/safFolderBackup.ts
+++ b/src/services/ark/safFolderBackup.ts
@@ -168,10 +168,10 @@ export function messageForSafError(cls: SafErrorClass): string {
         case 'folder-unreachable':
             return "The backup folder is no longer reachable (it may have been deleted, moved, or the storage was removed). Tap 'Pick folder' to choose a new one.";
         case 'create-failed':
-            return "Couldn't create the backup file in the chosen folder. The folder may be read-only — pick a different one.";
+            return "Couldn't create the backup file in the chosen folder. The folder may be read-only, so pick a different one.";
         case 'open-failed':
         case 'write-failed':
-            return "Couldn't write the backup to the chosen folder. The storage may be full or read-only — pick a different folder.";
+            return "Couldn't write the backup to the chosen folder. The storage may be full or read-only, so pick a different folder.";
         case 'native-not-loaded':
             return 'Local-folder backup is not available on this build.';
         case 'unknown':

--- a/src/services/lightningSwap/providers/strike.ts
+++ b/src/services/lightningSwap/providers/strike.ts
@@ -194,7 +194,7 @@ const strikeProvider: LightningSwapProvider = {
                 throw new PaymentPendingError(
                     'strike',
                     `Strike payment ${pidShort} is still settling on Lightning. ` +
-                    `Do NOT retry — open the Strike app to check. It will complete or refund automatically within a few hours.`,
+                    `Do NOT retry. Open the Strike app to check. It will complete or refund automatically within a few hours.`,
                     String(paymentId ?? ''),
                 );
             }


### PR DESCRIPTION
Six strings a user can read, across four files.

| File | What the user sees |
|---|---|
| `ark/backgroundNotifications.ts` | two push notification bodies |
| `ark/history.ts` | the `Pending` / `Failed` / `Canceled` history subtitles |
| `ark/safFolderBackup.ts` | two backup error messages |
| `lightningSwap/providers/strike.ts` | the do-not-retry sentence |

Push notification text and error messages are named explicitly in the house copy rule, so `backgroundNotifications.ts` is the worst of these.

Rewrites are minimal and keep the original wording. The em-dash becomes a colon where the string is a label plus detail, and a full stop where it joined two sentences. **The wording is yours to adjust**, nothing was reworded beyond the punctuation.

## Scope, deliberately narrow

**Only strings a user can read.** Twelve more em-dashes remain in `src/services` inside `console.log` / `console.warn`, most behind `__DEV__`. The rule covers user-facing English, not developer output, and rewriting log lines would be churn with no reader.

**`lightning.ts` is not touched here.** Its two cancel-toast strings are fixed in the money-safety branch, because they sit inside the catch block that change rewrites. Fixing them in both places would guarantee a conflict. Once both land, `src/services` has zero user-facing em-dashes.

## The finding underneath this one is bigger

The audit's proposed durable fix was to add `src/services/` to the copy rule's audit list, on the theory that the directory accumulated debt because it was not listed.

That theory does not survive a full scan. The directories the rule **already names explicitly** are in much worse shape:

```
src/screens       41 user-facing em-dashes
src/components     2
src/services       6  (this PR)  + 2 (money-safety branch)
src/custom-hooks   0  (13 hits, all console)
```

So being on the list is not what protects a directory. `src/screens` has been listed the whole time and carries roughly seven times this PR's count, including `"Fees are low — good time to consolidate…"`, `"Hot Vault not ready — open the vault once and try again."`, and `"Backup not synced — enable iCloud Drive in iOS Settings"`.

`loc/` also shows 35, but those are inherited BlueWallet translations in Ukrainian, Spanish and Malay. The rule is about English copy, so I read those as out of scope.

**I did not touch the 43 in `src/screens` and `src/components`.** That is your copy, a much larger review surface, and it deserves its own PR rather than riding along in an audit cleanup.

The real durable fix is probably not a doc line at all but a hygiene test, in the shape of the existing `noPrivateDocRefs.test.ts`, that fails CI on a user-facing em-dash. It cannot be added until the tree is clean, so it belongs after `src/screens` is dealt with.

## Verification

- `tsc --noEmit`: **402**, identical to baseline.
- Unit: **61 suites, 707 passed, 1 skipped.**
- Eight lines changed, punctuation only.

## Not done

No device check. These are static strings and two are push notification bodies, which only render when a real notification fires. The history subtitles are visible immediately in the Ark history list if you want to eyeball the colon form.
