### PR TITLE
fix(ark): small-amount warning boundary, and an unreadable invoice CTA

### DIFF
--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -50,7 +50,11 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
     // Small-amount warning: in sats mode the typed value is the sat amount; in
     // fiat mode CustomKeyboard mirrors the sat equivalent into `usd`.
     const currentSats = Math.round(isSats ? Number(sats) : Number(usd)) || 0;
-    const smallAmountWarn = currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
+    // Strictly below the floor. 700 is the amount the warning tells users to
+    // reach, so warning AT 700 contradicted its own advice: you typed the
+    // number it asked for and it still called the amount small. 699 warns,
+    // 700 does not.
+    const smallAmountWarn = currentSats > 0 && currentSats < SMALL_RECEIVE_SATS;
 
     const handleCreate = async () => {
         if (!sats) {
@@ -139,7 +143,7 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
             </View>
             {smallAmountWarn && (
                 <Text style={{ textAlign: 'center', marginHorizontal: 24, marginBottom: 6, fontSize: 12, color: '#FFD54F', lineHeight: 17 }}>
-                    Small amounts can leave un-refreshable dust that expires. Receiving above 700 sats keeps them refreshable.
+                    Small amounts can leave un-refreshable dust that expires. Receiving 700 sats or more keeps them refreshable.
                 </Text>
             )}
             <CustomKeyboard

--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -158,6 +158,14 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
                 currency={currency}
                 colors_={ARK_GRADIENT}
                 buttonColors_={smallAmountWarn ? WARN_YELLOW : undefined}
+                // The button's title defaults to white, and both gradients it
+                // can wear here are light: ARK_GRADIENT is #FFFFFF to #E6E6E6
+                // and WARN_YELLOW is #FFD54F to #FFB300. White on either is
+                // invisible, so once an amount was entered the CTA read as a
+                // blank slab. Disabled keeps white, because GradientButton
+                // swaps to a grey fill in that state. Same pattern as
+                // ArkSendScreen's CTA.
+                titleColor={sats.length && !isLoading ? colors.black.default : colors.whiteText}
                 // Invoices have no "max" semantics — the receiver picks
                 // any amount they want to be paid. MAX is a send-side
                 // affordance (drain the wallet); suppress it on receive.

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -442,7 +442,10 @@ export default function SwapAmount() {
     // leave un-refreshable dust that expires. Sats mode types the sat amount;
     // fiat mode mirrors the sat equivalent into `usd`.
     const currentSats = Math.round(isSats ? Number(sats) : Number(usd)) || 0;
-    const smallBarkSwapWarn = sendTo === 'ark' && currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
+    // Strictly below, matching ArkInvoiceScreen. 700 is the number the warning
+    // asks the user to reach, so warning at exactly 700 contradicted its own
+    // advice.
+    const smallBarkSwapWarn = sendTo === 'ark' && currentSats > 0 && currentSats < SMALL_RECEIVE_SATS;
 
     return (
         <ScreenLayout disableScroll showToolbar isBackButton title="Lightning Swap">
@@ -481,7 +484,7 @@ export default function SwapAmount() {
                 })()}
                 {smallBarkSwapWarn && (
                     <Text style={{ textAlign: 'center', marginTop: 8, marginHorizontal: 8, fontSize: 12, color: '#FFD54F', lineHeight: 17 }}>
-                        Small amounts can leave un-refreshable dust that expires. Swapping above 700 sats keeps them refreshable.
+                        Small amounts can leave un-refreshable dust that expires. Swapping 700 sats or more keeps them refreshable.
                     </Text>
                 )}
             </View>


### PR DESCRIPTION
The small-amount dust warning fired at exactly the amount it tells you to reach.

```js
// before
currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS   // 700 warns
// after
currentSats > 0 && currentSats < SMALL_RECEIVE_SATS    // 699 warns, 700 does not
```

Typing 700 warned, relabelled the CTA "Create anyways", and told you to receive above 700. You entered the number it asked for and it still called the amount small.

## Two screens, not one

The identical off-by-one was in the Bark swap flow (`SwapAmount`), same constant, same comparison, same copy. Fixed together, otherwise 700 sats would warn on one screen and not the other.

## Copy

"above 700 sats" excluded the value the code now accepts, so both strings read "700 sats or more". Punctuation and boundary only, nothing reworded. **Yours to adjust.**

`ArkCapsulesInfoScreen` already said "at least about 700 sats", which was consistent with the new boundary and is untouched.

## Not changed

The threshold itself. 700 stays the floor; only the comparison moved.

## Verification

- `tsc --noEmit`: **402**, identical to baseline.
- Unit: **61 suites, 707 passed, 1 skipped.**

## Not done

No device check. Worth one tap each: enter 700 on the Ark invoice screen and on a Bark swap, confirm no yellow note and the CTA reads "Create invoice" rather than "Create anyways", then 699 and confirm it comes back.


---

## Second commit: the CTA was unreadable

Separate bug on the same button, reported alongside the boundary.

`CustomKeyboard`'s title defaults to white, and **both** gradients this button can wear are light:

```
ARK_GRADIENT  #FFFFFF -> #E6E6E6
WARN_YELLOW   #FFD54F -> #FFB300
```

White on either is invisible, so once an amount was entered the CTA read as a blank slab.

The fix is the `titleColor` prop, which exists for exactly this and whose docstring already describes the failure: "The button defaults to white text, which is invisible on a light `colors_` gradient (the Ark surfaces use a white palette)." The screen simply never passed it.

Black while enabled, white while disabled, because `GradientButton` swaps to a grey fill when disabled. Same pattern `ArkSendScreen` already uses.

I checked every `CustomKeyboard` caller sitting on a light gradient. This screen was the only one missing it.
