### PR TITLE
feat: one success animation for every Lightning send

### DIFF
--- a/src/components/LightningSendSuccess/index.tsx
+++ b/src/components/LightningSendSuccess/index.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Easing, Image, TouchableOpacity, View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+import { Text } from '@Cypher/component-library';
+import { Electricity, GradientShock } from '@Cypher/assets/images';
+import { colors } from '@Cypher/style-guide';
+
+import styles from './styles';
+
+/**
+ * Success view for a completed LIGHTNING send.
+ *
+ * Extracted from SwapAmount, which is where this treatment was built and the
+ * only place it lived. Bam's call (2026-09-09): it is the one to keep, so the
+ * Lightning send surfaces adopt it rather than each carrying their own.
+ *
+ * LIGHTNING ONLY, deliberately. On-chain sends keep the screens they already
+ * have. An on-chain payment is not final when the screen appears, and this
+ * view is built to read as finished: a bolt, "Lightning Network", and no room
+ * for the "waiting to confirm" caveat that path needs. ArkSendSuccessScreen
+ * still owns the on-chain and exit-fee-top-up cases for exactly that reason.
+ *
+ * Two shapes of caption, because two things reach here:
+ *
+ *   a send   `paidTo` + `fromLabel` -> "Paid to satoshi@blink.me"
+ *                                      "from Bark Vault"
+ *   a swap   `detail` -> the caller's own node, e.g. the from/to provider
+ *            badges, since a swap's destination is another of the user's own
+ *            wallets and an address would be meaningless.
+ */
+interface Props {
+    /** Net sats actually sent. */
+    sats: string | number;
+    /** Fiat equivalent, already formatted to 2dp. */
+    fiat: string;
+    /** Currency symbol to prefix the fiat line with, e.g. "$". */
+    fiatSymbol?: string;
+    title?: string;
+    /** Realised network fee. Only rails that report one pass this. */
+    feeSats?: number | null;
+    /** Trailing note on the fee line, e.g. a provider caveat. */
+    feeNote?: string | null;
+    /** Payment destination, shown as "Paid to <x>". */
+    paidTo?: string;
+    /** Source wallet, shown as "from <x>". */
+    fromLabel?: string;
+    /** Caller-supplied caption, used instead of paidTo/fromLabel. */
+    detail?: React.ReactNode;
+    networkLabel?: string;
+    onHome(): void;
+    homeLabel?: string;
+}
+
+export default function LightningSendSuccess({
+    sats,
+    fiat,
+    fiatSymbol = '$',
+    title = 'Payment Sent ⚡',
+    feeSats = null,
+    feeNote = null,
+    paidTo,
+    fromLabel,
+    detail,
+    networkLabel = 'Lightning Network',
+    onHome,
+    homeLabel = 'Home',
+}: Props) {
+    const slideAnim = useRef(new Animated.Value(300)).current;
+    const fadeAnim = useRef(new Animated.Value(0)).current;
+    const ring1Scale = useRef(new Animated.Value(1)).current;
+    const ring1Opacity = useRef(new Animated.Value(0.8)).current;
+    const ring2Scale = useRef(new Animated.Value(1)).current;
+    const ring2Opacity = useRef(new Animated.Value(0.8)).current;
+
+    useEffect(() => {
+        Animated.parallel([
+            Animated.timing(slideAnim, {
+                toValue: 0,
+                duration: 600,
+                easing: Easing.out(Easing.cubic),
+                useNativeDriver: true,
+            }),
+            Animated.timing(fadeAnim, {
+                toValue: 1,
+                duration: 600,
+                easing: Easing.out(Easing.cubic),
+                useNativeDriver: true,
+            }),
+        ]).start();
+
+        // Each ring expands and fades, then snaps back to full size and
+        // opacity in a zero-duration step before repeating. The second ring is
+        // offset by 700ms so the two read as a pulse rather than one thick edge.
+        const createRingAnimation = (
+            scale: Animated.Value,
+            opacity: Animated.Value,
+            delay: number,
+        ) =>
+            Animated.loop(
+                Animated.sequence([
+                    Animated.delay(delay),
+                    Animated.parallel([
+                        Animated.timing(scale, {
+                            toValue: 1.8,
+                            duration: 2000,
+                            easing: Easing.out(Easing.ease),
+                            useNativeDriver: true,
+                        }),
+                        Animated.timing(opacity, {
+                            toValue: 0,
+                            duration: 2000,
+                            easing: Easing.out(Easing.ease),
+                            useNativeDriver: true,
+                        }),
+                    ]),
+                    Animated.parallel([
+                        Animated.timing(scale, { toValue: 1, duration: 0, useNativeDriver: true }),
+                        Animated.timing(opacity, { toValue: 0.8, duration: 0, useNativeDriver: true }),
+                    ]),
+                ]),
+            );
+
+        const a = createRingAnimation(ring1Scale, ring1Opacity, 0);
+        const b = createRingAnimation(ring2Scale, ring2Opacity, 700);
+        a.start();
+        b.start();
+        // Stop on unmount. The originals looped forever against a screen that
+        // was about to be reset away, which kept a native driver animation
+        // running behind Home.
+        return () => {
+            a.stop();
+            b.stop();
+        };
+    }, [slideAnim, fadeAnim, ring1Scale, ring1Opacity, ring2Scale, ring2Opacity]);
+
+    const satsNum = Number(sats) || 0;
+    const feeRow = (() => {
+        if (feeSats === null || feeSats === undefined || feeSats <= 0) return null;
+        // Percentage of the total debited, matching the pre-send preview and
+        // the ArkSendScreen fee row so the same number reads the same way
+        // across every surface.
+        const gross = satsNum + feeSats;
+        const pct = gross > 0 ? Math.min(999, (feeSats / gross) * 100) : null;
+        const pctStr =
+            pct === null ? '' : pct < 0.01 ? ' (< 0.01%)' : ` (${pct.toFixed(pct < 1 ? 2 : 1)}%)`;
+        return (
+            <Text style={styles.fee}>
+                Network fee: {feeSats} sats{pctStr}{feeNote ? ` · ${feeNote}` : ''}
+            </Text>
+        );
+    })();
+
+    return (
+        <Animated.View
+            style={[styles.container, { transform: [{ translateY: slideAnim }], opacity: fadeAnim }]}
+        >
+            <Text semibold style={styles.title}>{title}</Text>
+            <Text semibold style={styles.value}>{satsNum.toLocaleString()} sats</Text>
+            <Text semibold style={styles.fiat}>{fiatSymbol}{fiat}</Text>
+            {feeRow}
+            <View style={styles.animationContainer}>
+                <Animated.View
+                    style={[styles.ring, { transform: [{ scale: ring1Scale }], opacity: ring1Opacity }]}
+                >
+                    <Image source={GradientShock} style={styles.ringImage} />
+                </Animated.View>
+                <Animated.View
+                    style={[styles.ring, { transform: [{ scale: ring2Scale }], opacity: ring2Opacity }]}
+                >
+                    <Image source={GradientShock} style={styles.ringImage} />
+                </Animated.View>
+                <Image source={Electricity} style={styles.boltImage} />
+            </View>
+            {detail ?? (
+                <View style={styles.detail}>
+                    {!!paidTo && (
+                        <Text style={styles.paidTo}>Paid to {paidTo}</Text>
+                    )}
+                    {!!fromLabel && (
+                        <Text style={styles.fromWallet}>from {fromLabel}</Text>
+                    )}
+                </View>
+            )}
+            <Text semibold style={styles.network}>{networkLabel}</Text>
+            <TouchableOpacity onPress={onHome} style={styles.homeButton}>
+                <LinearGradient
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    colors={[colors.pink.extralight, colors.pink.default]}
+                    style={styles.homeButtonGradient}
+                >
+                    <Text bold style={styles.homeText}>{homeLabel}</Text>
+                </LinearGradient>
+            </TouchableOpacity>
+        </Animated.View>
+    );
+}

--- a/src/components/LightningSendSuccess/styles.ts
+++ b/src/components/LightningSendSuccess/styles.ts
@@ -1,0 +1,99 @@
+import { StyleSheet } from 'react-native';
+
+/**
+ * Lifted verbatim from SwapAmount's inline success view, which is where this
+ * treatment started. Kept byte-identical on purpose: the swap screen now
+ * renders through this component, so any drift here would silently restyle it.
+ */
+export default StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        marginHorizontal: 20,
+    },
+    title: {
+        fontSize: 40,
+        lineHeight: 50,
+        marginBottom: 30,
+    },
+    value: {
+        fontSize: 42,
+        lineHeight: 52,
+    },
+    fiat: {
+        fontSize: 30,
+        lineHeight: 40,
+        color: '#AAAAAA',
+    },
+    fee: {
+        marginTop: 6,
+        fontSize: 14,
+        color: '#AAAAAA',
+        textAlign: 'center',
+    },
+    animationContainer: {
+        width: 200,
+        height: 200,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginVertical: 20,
+    },
+    ring: {
+        position: 'absolute',
+        width: 150,
+        height: 150,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    ringImage: {
+        width: 150,
+        height: 150,
+    },
+    boltImage: {
+        width: 80,
+        height: 85,
+        zIndex: 10,
+    },
+    detail: {
+        alignItems: 'center',
+        marginVertical: 20,
+    },
+    /**
+     * "Paid to <address>". Wraps rather than truncates: a BOLT11 invoice is
+     * long, and an ellipsis in the middle of a payment destination is the one
+     * place a user might actually want to read every character.
+     */
+    paidTo: {
+        fontSize: 15,
+        lineHeight: 21,
+        color: '#FFFFFF',
+        textAlign: 'center',
+        marginHorizontal: 10,
+    },
+    fromWallet: {
+        fontSize: 15,
+        lineHeight: 21,
+        color: '#AAAAAA',
+        textAlign: 'center',
+        marginTop: 4,
+    },
+    network: {
+        fontSize: 22,
+        lineHeight: 30,
+        color: '#AAAAAA',
+    },
+    homeButton: {
+        marginTop: 40,
+        width: '80%',
+    },
+    homeButtonGradient: {
+        borderRadius: 25,
+        height: 50,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    homeText: {
+        fontSize: 18,
+        color: '#FFFFFF',
+    },
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,6 +14,7 @@ export { default as GradientTabNew } from './GradientTabNew';
 export { default as GradientInput } from './GradientInput';
 export { default as GradientInputNew } from './GradientInputNew';
 export { default as CustomKeyboard } from './CustomKeyboard';
+export { default as LightningSendSuccess } from './LightningSendSuccess';
 export { default as Blink } from './Blink';
 export { default as SwipeButton } from './SwipeButton';
 export { default as RingEffect } from './RingEffect';

--- a/src/screens/Ark/ArkSendReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkSendReviewScreen/index.tsx
@@ -171,10 +171,28 @@ export default function ArkSendReviewScreen({ route }: Props) {
             const result = await executeArkSend(destination, amountSats);
             const netSats = result.netAmountSats;
             const fiat = (netSats * matchedRate * btc(1)).toFixed(2);
+            // Only the Lightning rails take the shared success view. An
+            // Ark-to-Ark or on-chain send keeps the existing screen, which is
+            // the one that can say an on-chain payment still has to confirm.
+            const isLightning =
+                destination.kind === 'ln-invoice' ||
+                destination.kind === 'ln-offer' ||
+                destination.kind === 'ln-address';
             dispatchNavigate('ArkSendSuccessScreen', {
                 value: String(netSats),
                 valueUsd: fiat,
                 currency,
+                isLightning,
+                // An ln-address is short and worth reading in full. A BOLT11
+                // invoice is not, so show the shortened form for those; the
+                // user is confirming what they already reviewed, not auditing
+                // an address they have never seen.
+                paidTo: isLightning
+                    ? (destination.kind === 'ln-address'
+                        ? destination.value
+                        : `${destinationRaw.slice(0, 12)}…${destinationRaw.slice(-8)}`)
+                    : undefined,
+                fromLabel: isLightning ? 'Bark Vault' : undefined,
             });
         } catch (err: any) {
             console.error('[ArkSendReview] send failed:', err);

--- a/src/screens/Ark/ArkSendSuccessScreen/index.tsx
+++ b/src/screens/Ark/ArkSendSuccessScreen/index.tsx
@@ -8,7 +8,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { ScreenLayout, Text } from '@Cypher/component-library';
-import { GradientButton, GradientCard } from '@Cypher/components';
+import { GradientButton, GradientCard, LightningSendSuccess } from '@Cypher/components';
 import Ring from '@Cypher/components/RingEffect';
 import { Bitcoin, BitcoinTower, Electrik } from '@Cypher/assets/images';
 import { dispatchReset } from '@Cypher/helpers/navigation';
@@ -62,6 +62,17 @@ interface Props {
             networkLabel?: string;
             isOnchain?: boolean;
             note?: string;
+            /**
+             * True only for a Lightning rail (invoice, offer, ln-address).
+             * Opt-in rather than inferred: an Ark-to-Ark or on-chain send must
+             * not take the Lightning view, and defaulting this to true would
+             * hand it to every caller that has not been updated.
+             */
+            isLightning?: boolean;
+            /** Destination, for "Paid to <x>". */
+            paidTo?: string;
+            /** Source wallet, for "from <x>". */
+            fromLabel?: string;
         };
     };
 }
@@ -74,6 +85,9 @@ export default function ArkSendSuccessScreen({ route }: Props) {
     const networkLabel = route?.params?.networkLabel ?? 'Lightning Network';
     const isOnchain = route?.params?.isOnchain === true;
     const note = route?.params?.note;
+    const isLightning = route?.params?.isLightning === true;
+    const paidTo = route?.params?.paidTo;
+    const fromLabel = route?.params?.fromLabel;
 
     const [response, setResponse] = useState(false);
     const fadeInOpacity = useSharedValue(0);
@@ -98,6 +112,33 @@ export default function ArkSendSuccessScreen({ route }: Props) {
     }));
 
     const onHome = () => dispatchReset('HomeScreen');
+
+    // Lightning sends use the shared success view (Bam's call, 2026-09-09):
+    // one treatment across Strike, CoinOS and Bark instead of three.
+    //
+    // Everything else keeps the screen below, and that is the point of the
+    // gate rather than an oversight. The on-chain cases that land here, an
+    // on-chain send and the exit-fee top-up, are NOT final when this appears.
+    // The shared view is built to read as finished, carries a bolt and says
+    // "Lightning Network", and has nowhere to put the "has to confirm first"
+    // note those paths depend on. It already cost one user a screen that said
+    // "Payment Sent / 0 sats / Lightning Network" over an on-chain deposit.
+    if (isLightning && !isOnchain) {
+        return (
+            <ScreenLayout disableScroll showToolbar title="" isBackButton={false}>
+                <LightningSendSuccess
+                    title={title}
+                    sats={value}
+                    fiat={valueUsd}
+                    fiatSymbol={getStrikeCurrency(currency)}
+                    paidTo={paidTo}
+                    fromLabel={fromLabel}
+                    networkLabel={networkLabel}
+                    onHome={onHome}
+                />
+            </ScreenLayout>
+        );
+    }
 
     return (
         <ScreenLayout disableScroll showToolbar title="" isBackButton={false}>

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -3,8 +3,7 @@ import { View, Image, ActivityIndicator, TouchableOpacity, Animated, Easing, Ale
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { ScreenLayout, Text } from "@Cypher/component-library";
 import LinearGradient from "react-native-linear-gradient";
-import { CustomKeyboard, GradientInput } from "@Cypher/components";
-import { GradientShock, Electricity } from "@Cypher/assets/images";
+import { CustomKeyboard, GradientInput , LightningSendSuccess } from "@Cypher/components";
 import { dispatchNavigate, dispatchReset } from "@Cypher/helpers";
 import { colors } from "@Cypher/style-guide";
 import useAuthStore from "@Cypher/stores/authStore";
@@ -301,60 +300,6 @@ export default function SwapAmount() {
     };
 
     // Expanding ring animations
-    const slideAnim = React.useRef(new Animated.Value(300)).current;
-    const fadeAnim = React.useRef(new Animated.Value(0)).current;
-    const ring1Scale = React.useRef(new Animated.Value(1)).current;
-    const ring1Opacity = React.useRef(new Animated.Value(0.8)).current;
-    const ring2Scale = React.useRef(new Animated.Value(1)).current;
-    const ring2Opacity = React.useRef(new Animated.Value(0.8)).current;
-
-    React.useEffect(() => {
-        if (success) {
-            // Slide up + fade in
-            Animated.parallel([
-                Animated.timing(slideAnim, {
-                    toValue: 0,
-                    duration: 600,
-                    easing: Easing.out(Easing.cubic),
-                    useNativeDriver: true,
-                }),
-                Animated.timing(fadeAnim, {
-                    toValue: 1,
-                    duration: 600,
-                    easing: Easing.out(Easing.cubic),
-                    useNativeDriver: true,
-                }),
-            ]).start();
-
-            const createRingAnimation = (scale: Animated.Value, opacity: Animated.Value, delay: number) => {
-                return Animated.loop(
-                    Animated.sequence([
-                        Animated.delay(delay),
-                        Animated.parallel([
-                            Animated.timing(scale, {
-                                toValue: 1.8,
-                                duration: 2000,
-                                easing: Easing.out(Easing.ease),
-                                useNativeDriver: true,
-                            }),
-                            Animated.timing(opacity, {
-                                toValue: 0,
-                                duration: 2000,
-                                easing: Easing.out(Easing.ease),
-                                useNativeDriver: true,
-                            }),
-                        ]),
-                        Animated.parallel([
-                            Animated.timing(scale, { toValue: 1, duration: 0, useNativeDriver: true }),
-                            Animated.timing(opacity, { toValue: 0.8, duration: 0, useNativeDriver: true }),
-                        ]),
-                    ])
-                );
-            };
-            createRingAnimation(ring1Scale, ring1Opacity, 0).start();
-            createRingAnimation(ring2Scale, ring2Opacity, 700).start();
-        }
-    }, [success]);
 
     /**
      * Render a wallet badge in the from→to direction strip. Uses the
@@ -384,56 +329,25 @@ export default function SwapAmount() {
     if (success) {
         return (
             <ScreenLayout showToolbar isBackButton={false}>
-                <Animated.View style={[styles.successContainer, { transform: [{ translateY: slideAnim }], opacity: fadeAnim }]}>
-                    <Text semibold style={styles.successTitle}>Swap Sent ⚡</Text>
-                    <Text semibold style={styles.successValue}>{swappedSats} sats</Text>
-                    <Text semibold style={styles.successFiat}>{currency === 'EUR' ? '€' : '$'}{swappedFiat}</Text>
-                    {feeSats !== null && feeSats > 0 && (() => {
-                        // Surface the realised network fee under the fiat
-                        // line. Only providers that report it (Ark) reach
-                        // this branch — custodial swaps hide the row.
-                        // Percentage matches the pre-swap preview formula
-                        // and the ArkSendScreen Fee % row for consistency.
-                        const swappedSatsNum = Number(swappedSats) || 0;
-                        const gross = swappedSatsNum + feeSats;
-                        const feePct = gross > 0 ? Math.min(999, (feeSats / gross) * 100) : null;
-                        const pctStr = feePct === null
-                            ? ''
-                            : feePct < 0.01
-                                ? ' (< 0.01%)'
-                                : ` (${feePct.toFixed(feePct < 1 ? 2 : 1)}%)`;
-                        return (
-                            <Text style={styles.successFee}>
-                                Network fee: {feeSats} sats{pctStr}{feeNote ? ` · ${feeNote}` : ''}
-                            </Text>
-                        );
-                    })()}
-                    <View style={styles.animationContainer}>
-                        <Animated.View style={[styles.ring, { transform: [{ scale: ring1Scale }], opacity: ring1Opacity }]}>
-                            <Image source={GradientShock} style={styles.ringImage} />
-                        </Animated.View>
-                        <Animated.View style={[styles.ring, { transform: [{ scale: ring2Scale }], opacity: ring2Opacity }]}>
-                            <Image source={GradientShock} style={styles.ringImage} />
-                        </Animated.View>
-                        <Image source={Electricity} style={styles.boltImage} />
-                    </View>
-                    <View style={styles.successDirection}>
-                        {renderProviderBadge(fromProvider, swapFrom, 'success')}
-                        <Text style={styles.successArrow}>→</Text>
-                        {renderProviderBadge(toProvider, sendTo, 'success')}
-                    </View>
-                    <Text semibold style={styles.successNetwork}>Lightning Network</Text>
-                    <TouchableOpacity onPress={() => navigation.popToTop()} style={styles.homeButton}>
-                        <LinearGradient
-                            start={{ x: 0, y: 0 }}
-                            end={{ x: 1, y: 0 }}
-                            colors={[colors.pink.extralight, colors.pink.default]}
-                            style={styles.homeButtonGradient}
-                        >
-                            <Text bold style={styles.homeText}>Home</Text>
-                        </LinearGradient>
-                    </TouchableOpacity>
-                </Animated.View>
+                <LightningSendSuccess
+                    title="Swap Sent ⚡"
+                    sats={swappedSats}
+                    fiat={swappedFiat}
+                    fiatSymbol={currency === 'EUR' ? '€' : '$'}
+                    feeSats={feeSats}
+                    feeNote={feeNote}
+                    // A swap's destination is another of the user's own
+                    // wallets, so an address would be meaningless here. Keep
+                    // the from/to badges, which say the true thing.
+                    detail={
+                        <View style={styles.successDirection}>
+                            {renderProviderBadge(fromProvider, swapFrom, 'success')}
+                            <Text style={styles.successArrow}>→</Text>
+                            {renderProviderBadge(toProvider, sendTo, 'success')}
+                        </View>
+                    }
+                    onHome={() => navigation.popToTop()}
+                />
             </ScreenLayout>
         );
     }

--- a/src/screens/Transaction/index.tsx
+++ b/src/screens/Transaction/index.tsx
@@ -20,6 +20,7 @@ import { dispatchReset, resetAndNavigate } from "@Cypher/helpers/navigation";
 import { startsWithLn } from "../Send";
 import { getStrikeCurrency } from "@Cypher/helpers/coinosHelper";
 import CustomProgressBar from "@Cypher/components/CustomProgressBar";
+import { LightningSendSuccess } from "@Cypher/components";
 
 export default function Transaction({navigation, route}: any) {
     const {matchedRate, currency = 'USD', type, value, converted, isSats, to, item, swappedTo} = route?.params;
@@ -105,6 +106,49 @@ export default function Transaction({navigation, route}: any) {
     });
 
     console.log(type, amountUSD)
+
+    // Lightning payment sends take the shared success view (Bam's call,
+    // 2026-09-09), so Strike, CoinOS and Bark all end a Lightning send the
+    // same way.
+    //
+    // Everything else keeps the screen below, and the exclusions are the
+    // point. BUY and SELL are Strike fiat trades, not Lightning payments, and
+    // this screen carries their "Purchase Complete" / "Sale Complete" copy. A
+    // swap (`swappedTo`) passes a sentinel like 'Ark' or 'coinos' as `to`
+    // rather than a real address, so it must not be rendered as "Paid to Ark",
+    // and it has its own success view already.
+    const isLightningSend =
+        type !== 'BUY' &&
+        type !== 'SELL' &&
+        !swappedTo &&
+        !!to &&
+        (startsWithLn(to) || String(to).includes('@'));
+
+    if (isLightningSend && response) {
+        return (
+            <ScreenLayout disableScroll showToolbar title={""} isBackButton={false}>
+                <LightningSendSuccess
+                    sats={amountSat}
+                    fiat={String(amountUSD)}
+                    fiatSymbol={getStrikeCurrency(currency)}
+                    // An ln-address is short and worth reading in full; a
+                    // BOLT11 invoice is not, so it is shortened.
+                    paidTo={
+                        String(to).includes('@')
+                            ? String(to)
+                            : `${String(to).slice(0, 12)}…${String(to).slice(-8)}`
+                    }
+                    // No `fromLabel`: this screen is reached from several
+                    // Strike and CoinOS paths and none of them pass which
+                    // wallet paid. Naming the wrong wallet on a payment
+                    // receipt is worse than naming none, so it is left off
+                    // until the callers carry it. Bark sends do show it.
+                    onHome={onPressClickHandler}
+                />
+            </ScreenLayout>
+        );
+    }
+
     return (
         <ScreenLayout disableScroll showToolbar title={""} isBackButton={false}>
             <View style={styles.main}>


### PR DESCRIPTION
The swap success view was the nicest of the three and the only one nobody had copied. It is now shared, so Strike, CoinOS and Bark all end a Lightning send the same way.

## What changed

Extracted `SwapAmount`'s inline success view into `components/LightningSendSuccess`, **verbatim, styles included**, so the screen it came from looks identical. The slide still starts at 300 and the two rings keep their 0 and 700ms offsets.

Copy is payment-shaped on sends instead of swap-shaped:

```
1,250 sats
$1.04
Paid to satoshi@blink.me
from Bark Vault
```

An ln-address shows in full, since it is short and worth reading. A BOLT11 invoice is shortened: the user is confirming what they already reviewed, not auditing a string they have never seen.

The swap keeps its from/to provider badges. Its destination is another of the user's own wallets, so "Paid to <address>" would be meaningless there.

## Lightning only, and the exclusions are the risky part

| Path | Uses the new view? |
|---|---|
| Strike / CoinOS Lightning send | yes |
| Bark Lightning send (invoice, offer, ln-address) | yes |
| Swap | yes, with badges |
| **On-chain send, exit-fee top-up** | **no** |
| **Strike BUY / SELL** | **no** |
| **Ark-to-Ark (arkoor)** | **no** |

On-chain keeps `ArkSendSuccessScreen` deliberately. Those payments are **not final** when the screen appears, and the shared view reads as finished: a bolt, "Lightning Network", and nowhere to put the "has to confirm first" note. That path already once told a user "Payment Sent / 0 sats / Lightning Network" over an on-chain deposit.

`Transaction` excludes BUY and SELL, which are Strike fiat trades with their own "Purchase Complete" copy, and excludes swaps, which pass a sentinel like `'Ark'` as the destination and would otherwise render as "Paid to Ark".

**The rail is opt-in, not inferred.** A caller that has not been updated keeps its old screen rather than silently getting the wrong one.

## Also

Ring loops now stop on unmount. The originals looped forever against a screen about to be reset away.

## Not done

**"from <wallet>" only appears on Bark sends.** `Transaction` is reached from several Strike and CoinOS paths and none of them pass which wallet paid. Naming the wrong wallet on a payment receipt is worse than naming none, so it is omitted there until the callers carry it. That is the one part of the request this PR does not fully deliver.

**No device check.** This is animation and layout across three send surfaces, so it wants eyes: a Bark Lightning send, a Strike or CoinOS Lightning send, a swap, and one on-chain send to confirm it still gets the old screen.

## Verification

- `tsc --noEmit`: **402**, identical to baseline. The one error reported in `SwapAmount` is pre-existing (`navigation.popToTop`), confirmed by stashing.
- Unit: **61 suites, 707 passed, 1 skipped.**
