### PR TITLE
fix(ark): tidy the Bark receive address panel

### DIFF
--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -1003,7 +1003,11 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         backgroundColor="white"
                       />
                     </View>
-                    <Text semibold style={styles.bitcoinAddressText}>
+                    {/* Its own style rather than the address one it used to
+                        borrow: at the address's 18pt this caption wrapped onto
+                        a second line and pushed the panel taller for no reason.
+                        It is a caption, so it is sized like one. */}
+                    <Text semibold style={styles.addressCaption} numberOfLines={1}>
                       Receive 0% fee payments from another Bark user
                     </Text>
                   </>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -712,7 +712,7 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
             {selectedItem === 5 && tab === 2 && (
               <Text
                 center
-                style={{ marginHorizontal: 24, marginTop: 8, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
+                style={{ marginHorizontal: 24, marginTop: 2, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
               >
                 To receive 700-sat or above capsule from another Bark user. Need to be present with the app being open when you receive to this address.
               </Text>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -995,17 +995,17 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         </Text>
                       </View>
                     )}
-                    {/* 120. It was 50, which was unscannable, and 150 was
-                        overcorrected and dominated the sheet. 120 sits just
-                        above the Bitcoin tab's 100 on purpose: an Ark address
-                        carries more data than an on-chain one, so the same
-                        square holds more modules and needs a little more room
-                        per module. The white quiet zone around it matters to a
-                        decoder as much as the size does, hence the padding. */}
+                    {/* 100, matching the Bitcoin tab in this same sheet. It
+                        was 50, which was unscannable because an Ark address
+                        packs more modules into the square than an on-chain one
+                        and each fell under a pixel. 150 and 120 were both too
+                        large for the panel. 100 is the floor I would not go
+                        below: the white quiet zone around it matters to a
+                        decoder as much as the size, hence the padding. */}
                     <View style={{ marginTop: 12, padding: 8, backgroundColor: 'white', borderRadius: 8 }}>
                       <QRCode
                         value={arkAddress}
-                        size={120}
+                        size={100}
                         color="black"
                         backgroundColor="white"
                       />

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -1012,8 +1012,9 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               // tab above uses, and for the same reason: a transform moves what
               // is drawn without shifting the layout flow beneath it, so the
               // sheet's own height and the content under it stay put.
-              // Landed by eye: 50 rode too high, 40 sits right.
-              <View style={[styles.liquidTabContent, { transform: [{ translateY: -40 }] }]}>
+              // Landed by eye on device: 50 rode too high, 40 still high, 25 sits
+              // right.
+              <View style={[styles.liquidTabContent, { transform: [{ translateY: -25 }] }]}>
                 {arkAddressError ? (
                   <AddressFetchFailed
                     message={arkAddressError}

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -30,6 +30,8 @@ import {
 import { dispatchNavigate } from "@Cypher/helpers";
 import { FEATURE_ARK_ENABLED, fetchArkMinBoardSats, getArkAddress, getArkOnchainAddress } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
+import { describeArkFailure } from "@Cypher/services/ark/networkFault";
+import { ARK_SERVER_URL, ESPLORA_URLS } from "@Cypher/services/ark";
 import { colors } from "@Cypher/style-guide";
 import Clipboard from "@react-native-clipboard/clipboard";
 import styles from "./styles";
@@ -54,6 +56,35 @@ interface Props {
   initialVaultType?: 'hot' | 'cold' | null;
 }
 
+
+
+/**
+ * Address fetch failed, say so instead of spinning.
+ *
+ * The retry is deliberate and deliberately plain. Some causes clear by
+ * themselves (a quota window rolling over), some need the user to act (switch
+ * networks, open the vault), and `message` already carries which. The button
+ * only re-runs the fetch; it does not claim the retry will work.
+ */
+function AddressFetchFailed({ message, onRetry }: { message: string; onRetry(): void }) {
+    return (
+        <View style={{ paddingHorizontal: 24, alignItems: 'center' }}>
+            <Text center style={{ fontSize: 13, lineHeight: 18, color: '#FFD54F' }}>
+                {message}
+            </Text>
+            <TouchableOpacity
+                onPress={onRetry}
+                accessibilityRole="button"
+                hitSlop={{ top: 10, bottom: 10, left: 16, right: 16 }}
+                style={{ marginTop: 12 }}
+            >
+                <Text bold style={{ fontSize: 14, color: '#FFFFFF', textDecorationLine: 'underline' }}>
+                    Try again
+                </Text>
+            </TouchableOpacity>
+        </View>
+    );
+}
 
 export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, receiveType, wallet, coldStorageWallet, matchedRate, currency, vaultAddress = '', coldStorageAddress = '', initialVaultType = null }: Props) {
   const { user, strikeMe, strikeUser, vaultTab, setVaultTab, isAuth, isStrikeAuth, isArkAuth, walletID, coldStorageWalletID, allBTCWallets } = useAuthStore();
@@ -86,6 +117,20 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
   // characters of opaque hex that would dominate the sheet.
 
   const [arkAddressExpanded, setArkAddressExpanded] = useState(false);
+  /**
+   * Why the address could not be fetched, or null.
+   *
+   * Exists because a rejected fetch used to leave the panel on its spinner
+   * forever: the address state stayed empty, nothing rendered the failure, and
+   * the only signal was a toast that had already gone. A hard failure looked
+   * exactly like "still loading", which is the reading that costs the most time
+   * (observed 2026-09-09: two separate sessions spent chasing a spinner that
+   * was a network refusal).
+   */
+  const [arkAddressError, setArkAddressError] = useState<string | null>(null);
+  const [arkOnchainAddressError, setArkOnchainAddressError] = useState<string | null>(null);
+  /** Bumped by "Try again" so the fetch effect re-runs. */
+  const [addressReloadTick, setAddressReloadTick] = useState(0);
   const [showSecondView, setShowSecondView] = useState(initialVaultType !== null || allBTCWallets.length == 1 ? true : false);
   const [hashLiquid, setHashLiquid] = useState('');
   const [hashBitcoin, setHashBitcoin] = useState('');
@@ -144,24 +189,36 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
           getArkOnchainAddress(),
         ]);
         if (!mounted) return;
-        if (arkRes.status === 'fulfilled') setArkAddress(arkRes.value);
-        if (onchainRes.status === 'fulfilled') setArkOnchainAddress(onchainRes.value);
+        if (arkRes.status === 'fulfilled') {
+          setArkAddress(arkRes.value);
+          setArkAddressError(null);
+        }
+        if (onchainRes.status === 'fulfilled') {
+          setArkOnchainAddress(onchainRes.value);
+          setArkOnchainAddressError(null);
+        }
 
-        if (arkRes.status === 'rejected' || onchainRes.status === 'rejected') {
-          const reason = (arkRes.status === 'rejected' ? arkRes.reason : null)
-            ?? (onchainRes.status === 'rejected' ? onchainRes.reason : null);
-          console.warn('[Receive] Ark address fetch failed:', reason);
-          // Name the actual cause. "Failed to fetch Ark addresses" next to a
-          // spinner that never stops tells the user nothing they can act on,
-          // and the usual cause is simply that the wallet is not open yet.
-          const locked = /not initialized|not ready|no wallet/i.test(
-            String((reason as Error)?.message ?? reason ?? ''),
+        // Each rail records its OWN failure. They fail independently (the Ark
+        // address needs an open wallet and a reachable chain source, the
+        // on-chain one is a local BDK call), so a shared error would blame one
+        // for the other's problem.
+        //
+        // describeArkFailure rather than a hand-written line: it already knows
+        // the difference between a provider that is unreachable and one that is
+        // refusing us on quota, and those need opposite advice. The old copy
+        // said "Pull to retry" for both, which is precisely wrong for a quota
+        // rejection, where retrying is what keeps it refused.
+        const endpoints = { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL };
+        if (arkRes.status === 'rejected') {
+          console.warn('[Receive] Ark address fetch failed:', arkRes.reason);
+          setArkAddressError(
+            describeArkFailure(arkRes.reason, "Couldn't get a Bark address", endpoints),
           );
-          SimpleToast.show(
-            locked
-              ? 'Bark vault is locked. Open the vault first, then try again.'
-              : 'Could not fetch an address. Pull to retry.',
-            SimpleToast.LONG,
+        }
+        if (onchainRes.status === 'rejected') {
+          console.warn('[Receive] on-chain address fetch failed:', onchainRes.reason);
+          setArkOnchainAddressError(
+            describeArkFailure(onchainRes.reason, "Couldn't get an on-chain address", endpoints),
           );
         }
       })();
@@ -174,7 +231,7 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
     } else if (tab == 2) {
       handleCreateInvoice('liquid');
     }
-  }, [tab, selectedItem])
+  }, [tab, selectedItem, addressReloadTick])
 
   useEffect(() => {
     if(initialVaultType !== null || (allBTCWallets.length == 1 && !coldStorageWalletID && !walletID)) {
@@ -913,7 +970,15 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                 <Text semibold style={{ color: '#FFD54F', textAlign: 'center', fontSize: 13, paddingHorizontal: 16 }}>
                   ⚠️ Do not receive less than {minBoardSats.toLocaleString('en-US')} sats to this on-chain address
                 </Text>
-                {!arkOnchainAddress ? (
+                {arkOnchainAddressError ? (
+                  <AddressFetchFailed
+                    message={arkOnchainAddressError}
+                    onRetry={() => {
+                      setArkOnchainAddressError(null);
+                      setAddressReloadTick((n) => n + 1);
+                    }}
+                  />
+                ) : !arkOnchainAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (
                   <>
@@ -949,7 +1014,15 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               // sheet's own height and the content under it stay put.
               // Landed by eye: 50 rode too high, 40 sits right.
               <View style={[styles.liquidTabContent, { transform: [{ translateY: -40 }] }]}>
-                {!arkAddress ? (
+                {arkAddressError ? (
+                  <AddressFetchFailed
+                    message={arkAddressError}
+                    onRetry={() => {
+                      setArkAddressError(null);
+                      setAddressReloadTick((n) => n + 1);
+                    }}
+                  />
+                ) : !arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (
                   <>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -995,10 +995,16 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         </Text>
                       </View>
                     )}
-                    <View style={{ marginTop: 10, padding: 2, backgroundColor: 'white', borderRadius: 2 }}>
+                    {/* 150, up from 50. At 50 the QR was smaller than the
+                        Bitcoin tab's and too dense to scan reliably: an Ark
+                        address is long, so it packs more modules into the same
+                        square than an on-chain address does, and each module
+                        was under a pixel on a phone screen. The white quiet
+                        zone matters for the same reason, hence the padding. */}
+                    <View style={{ marginTop: 12, padding: 10, backgroundColor: 'white', borderRadius: 8 }}>
                       <QRCode
                         value={arkAddress}
-                        size={50}
+                        size={150}
                         color="black"
                         backgroundColor="white"
                       />

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -942,7 +942,12 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
             )}
 
             {selectedItem === 5 && tab === 2 && (
-              <View style={styles.liquidTabContent}>
+              // Lift the whole Bark tab body (address row, expanded address,
+              // QR, caption) up 50pt. Same paint-only translateY the Bitcoin
+              // tab above uses, and for the same reason: a transform moves what
+              // is drawn without shifting the layout flow beneath it, so the
+              // sheet's own height and the content under it stay put.
+              <View style={[styles.liquidTabContent, { transform: [{ translateY: -50 }] }]}>
                 {!arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -995,16 +995,17 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         </Text>
                       </View>
                     )}
-                    {/* 150, up from 50. At 50 the QR was smaller than the
-                        Bitcoin tab's and too dense to scan reliably: an Ark
-                        address is long, so it packs more modules into the same
-                        square than an on-chain address does, and each module
-                        was under a pixel on a phone screen. The white quiet
-                        zone matters for the same reason, hence the padding. */}
-                    <View style={{ marginTop: 12, padding: 10, backgroundColor: 'white', borderRadius: 8 }}>
+                    {/* 120. It was 50, which was unscannable, and 150 was
+                        overcorrected and dominated the sheet. 120 sits just
+                        above the Bitcoin tab's 100 on purpose: an Ark address
+                        carries more data than an on-chain one, so the same
+                        square holds more modules and needs a little more room
+                        per module. The white quiet zone around it matters to a
+                        decoder as much as the size does, hence the padding. */}
+                    <View style={{ marginTop: 12, padding: 8, backgroundColor: 'white', borderRadius: 8 }}>
                       <QRCode
                         value={arkAddress}
-                        size={150}
+                        size={120}
                         color="black"
                         backgroundColor="white"
                       />

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -78,6 +78,14 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
   if (__DEV__) console.log("🚀 ~ ReceivedListNew ~ selectedItem:", selectedItem);
 
   const [tab, setTab] = useState(0);
+
+  // Whether the Bark address is shown in full. Collapsed by default: the
+
+  // short form is what a returning user needs, and the full string is 60+
+
+  // characters of opaque hex that would dominate the sheet.
+
+  const [arkAddressExpanded, setArkAddressExpanded] = useState(false);
   const [showSecondView, setShowSecondView] = useState(initialVaultType !== null || allBTCWallets.length == 1 ? true : false);
   const [hashLiquid, setHashLiquid] = useState('');
   const [hashBitcoin, setHashBitcoin] = useState('');
@@ -590,6 +598,11 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                     bold
                     style={{
                       fontSize: 22,
+                      // Explicit lineHeight: without one, iOS lays a bold 22pt
+                      // face out in a box shorter than its ascenders and clips
+                      // the tops of the capitals. Only shows up on this label
+                      // because it is the largest text in the header row.
+                      lineHeight: 28,
                       color: '#FFFFFF',
                       letterSpacing: 0.5,
                     }}
@@ -627,6 +640,18 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                 address while the app is closed has no reminder attached to it at
                 all. Sits with the tip above rather than under the QR so the
                 advice reads as one block. COPY: Bam finalizes. */}
+            {/* Tabs */}
+            {tabs.length > 0 && (
+              <CustomTabView
+                tabs={tabs}
+                selectedTab={tab}
+                onTabChange={setTab}
+              />
+            )}
+
+            {/* Below the tabs, not above: it describes the Bark tab's
+                address, so it read as a caption for the tab row itself
+                when it sat on top of it. */}
             {selectedItem === 5 && tab === 2 && (
               <Text
                 center
@@ -636,14 +661,6 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               </Text>
             )}
 
-            {/* Tabs */}
-            {tabs.length > 0 && (
-              <CustomTabView
-                tabs={tabs}
-                selectedTab={tab}
-                onTabChange={setTab}
-              />
-            )}
 
             {/* ---- Vault Sub-menu (Hot/Cold) ---- */}
             {(selectedItem === 3 || selectedItem === 4) && tab === 0 && (
@@ -926,25 +943,40 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
 
             {selectedItem === 5 && tab === 2 && (
               <View style={styles.liquidTabContent}>
-                <Text h2 bold>
-                  Bark Address
-                </Text>
                 {!arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (
                   <>
+                    {/* Label and address share one line. As two stacked blocks
+                        the heading took a full row to say something the address
+                        underneath already implied, and pushed the QR down. */}
                     <View style={styles.addressRow}>
-                      {/* Ark addresses are long opaque pubkey hex; the
-                          full string isn't human-verifiable anyway, so
-                          show first 6 + last 6 chars (e.g.
-                          "ark1ab…xyz999") to keep the row tidy. The
-                          tap-to-copy button below ships the full
-                          address to clipboard, unchanged. */}
-                      <Text semibold style={styles.bitcoinAddressText}>
-                        {arkAddress.length > 13
-                          ? `${arkAddress.slice(0, 6)}…${arkAddress.slice(-6)}`
-                          : arkAddress}
+                      <Text semibold style={styles.addressLabel}>
+                        Bark Address
                       </Text>
+                      {/* Ark addresses are long opaque pubkey hex and do not
+                          fit this row, so the row shows first 6 + last 6.
+                          Tapping expands the full string below rather than
+                          truncating it out of reach: the short form is fine for
+                          recognising an address you already have, and useless
+                          for reading one out. Copy still ships the full
+                          address, unchanged. */}
+                      <TouchableOpacity
+                        onPress={() => setArkAddressExpanded((v) => !v)}
+                        accessibilityRole="button"
+                        accessibilityLabel={
+                          arkAddressExpanded
+                            ? 'Hide the full Bark address'
+                            : 'Show the full Bark address'
+                        }
+                        style={styles.addressValueTap}
+                      >
+                        <Text semibold style={styles.bitcoinAddressText}>
+                          {arkAddress.length > 13
+                            ? `${arkAddress.slice(0, 6)}…${arkAddress.slice(-6)}`
+                            : arkAddress}
+                        </Text>
+                      </TouchableOpacity>
                       <TouchableOpacity onPress={() => {
                         Clipboard.setString(arkAddress);
                         SimpleToast.show('Copied to clipboard', SimpleToast.SHORT);
@@ -952,6 +984,17 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         <Image source={Copy} style={styles.copyIconImage} />
                       </TouchableOpacity>
                     </View>
+
+                    {/* Expanded form. Wrapped rather than side-scrolled: the
+                        whole point is seeing the address at once, and a
+                        horizontal scroller hides how much is left. */}
+                    {arkAddressExpanded && (
+                      <View style={styles.fullAddressBox}>
+                        <Text style={styles.fullAddressText}>
+                          {arkAddress}
+                        </Text>
+                      </View>
+                    )}
                     <View style={{ marginTop: 10, padding: 2, backgroundColor: 'white', borderRadius: 2 }}>
                       <QRCode
                         value={arkAddress}

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -943,11 +943,12 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
 
             {selectedItem === 5 && tab === 2 && (
               // Lift the whole Bark tab body (address row, expanded address,
-              // QR, caption) up 50pt. Same paint-only translateY the Bitcoin
+              // QR, caption) up 40pt. Same paint-only translateY the Bitcoin
               // tab above uses, and for the same reason: a transform moves what
               // is drawn without shifting the layout flow beneath it, so the
               // sheet's own height and the content under it stay put.
-              <View style={[styles.liquidTabContent, { transform: [{ translateY: -50 }] }]}>
+              // Landed by eye: 50 rode too high, 40 sits right.
+              <View style={[styles.liquidTabContent, { transform: [{ translateY: -40 }] }]}>
                 {!arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (

--- a/src/screens/HomeScreen/ReceivedListNew/styles.ts
+++ b/src/screens/HomeScreen/ReceivedListNew/styles.ts
@@ -37,6 +37,10 @@ interface Style {
   lightningTabContent: ViewStyle;
   bitcoinTabContent: ViewStyle;
   bitcoinAddressText: TextStyle;
+  addressLabel: TextStyle;
+  addressValueTap: ViewStyle;
+  fullAddressBox: ViewStyle;
+  fullAddressText: TextStyle;
   liquidTabContent: ViewStyle;
 }
 
@@ -257,11 +261,40 @@ export default StyleSheet.create<Style>({
   liquidTabContent: {
     paddingHorizontal: 16,
     paddingBottom: 16,
-    height: 220,
+    // minHeight, not height: the expanded address adds a block below the row,
+    // and a fixed height clipped it.
+    minHeight: 220,
     alignItems: 'center'
   },
   bitcoinAddressText: {
     fontSize: 18,
     marginTop: 10,
+  },
+  addressLabel: {
+    fontSize: 15,
+    color: '#AAAAAA',
+    marginTop: 10,
+    marginRight: 8,
+  },
+  // flexShrink so a long address gives way to the label and the copy icon
+  // instead of pushing them off the row.
+  addressValueTap: {
+    flexShrink: 1,
+  },
+  fullAddressBox: {
+    marginTop: 10,
+    marginHorizontal: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.14)',
+  },
+  fullAddressText: {
+    fontSize: 12,
+    lineHeight: 17,
+    color: '#FFFFFF',
+    textAlign: 'center',
   },
 });

--- a/src/screens/HomeScreen/ReceivedListNew/styles.ts
+++ b/src/screens/HomeScreen/ReceivedListNew/styles.ts
@@ -41,6 +41,7 @@ interface Style {
   addressValueTap: ViewStyle;
   fullAddressBox: ViewStyle;
   fullAddressText: TextStyle;
+  addressCaption: TextStyle;
   liquidTabContent: ViewStyle;
 }
 
@@ -296,5 +297,12 @@ export default StyleSheet.create<Style>({
     lineHeight: 17,
     color: '#FFFFFF',
     textAlign: 'center',
+  },
+  addressCaption: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#AAAAAA',
+    textAlign: 'center',
+    marginTop: 10,
   },
 });


### PR DESCRIPTION
Reported from the screen: the Bark receive panel was cramped and the address was unreachable.

## Four fixes

**The title was clipped.** "Bark Vault" lost the tops of its capitals. A bold 22pt face with no explicit `lineHeight` gets laid out in a box shorter than its ascenders on iOS, and this is the largest text in that header row, so it is the only one that showed it.

**The note sat above the tabs.** It describes the Bark tab's address, so sitting on top of the Lightning / Bitcoin / Bark row it read as a caption for the row itself. Moved below.

**Label and address now share a line.** As two stacked blocks the heading spent a full row saying what the address beneath it already implied, and pushed the QR down the sheet.

**The full address is reachable.** The row shows first 6 + last 6 because an Ark address does not fit, and until now that truncated form was the only one available anywhere in the UI. The short form is fine for recognising an address you already have and useless for reading one out. Tapping it expands the whole string below the row.

## One deliberate departure

The suggestion was a scrollable banner. I wrapped the address instead of side-scrolling it, because the point is seeing the whole thing at once and a horizontal scroller hides how much is left. Collapsed by default, since 60+ characters of opaque hex would otherwise dominate the sheet.

`liquidTabContent` also moves from a fixed `height` to `minHeight`, or the expanded block gets clipped.

## Verification

- `tsc --noEmit`: **402**, identical to baseline.
- Unit: **61 suites, 707 passed, 1 skipped.**

## Not done

**No device check, and this one is entirely layout**, so it wants eyes rather than a green tick. Worth confirming: the title renders whole, the note reads as belonging to the Bark tab, the label/address/copy row fits without the address shoving the copy icon off, and the expanded block does not overflow the sheet on a small screen.
