### PR TITLE
fix: remove em-dashes from user-facing copy, and guard it with a test

### DIFF
--- a/src/api/strikeAPIs.ts
+++ b/src/api/strikeAPIs.ts
@@ -197,10 +197,10 @@ export const sendStrikeLightningPayment = async (invoice: string, amount?: numbe
       // wallet card whose balance reads now-stale data.
       if (quoteResponse.status === 401) {
         useAuthStore.getState().clearStrikeAuth();
-        throw new Error('Strike session expired — please log into Strike again.');
+        throw new Error('Strike session expired. Please log into Strike again.');
       }
       throw new Error(
-        `Strike quote error: ${quoteResponse.status}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+        `Strike quote error: ${quoteResponse.status}${body ? `: ${body.slice(0, 200)}` : ''}`,
       );
     }
 
@@ -221,10 +221,10 @@ export const sendStrikeLightningPayment = async (invoice: string, amount?: numbe
       try { body = await executeResponse.text(); } catch { /* ignore */ }
       if (executeResponse.status === 401) {
         useAuthStore.getState().clearStrikeAuth();
-        throw new Error('Strike session expired — please log into Strike again.');
+        throw new Error('Strike session expired. Please log into Strike again.');
       }
       throw new Error(
-        `Strike execute error: ${executeResponse.status}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+        `Strike execute error: ${executeResponse.status}${body ? `: ${body.slice(0, 200)}` : ''}`,
       );
     }
     
@@ -467,13 +467,13 @@ export const getStrikePaymentStatus = async (paymentId: string): Promise<any> =>
         }));
         if (response.status === 401) {
             useAuthStore.getState().clearStrikeAuth();
-            throw new Error('Strike session expired — please log into Strike again.');
+            throw new Error('Strike session expired. Please log into Strike again.');
         }
         if (!response.ok) {
             let body = '';
             try { body = await response.text(); } catch { /* ignore */ }
             throw new Error(
-                `Strike payment-status error: ${response.status}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+                `Strike payment-status error: ${response.status}${body ? `: ${body.slice(0, 200)}` : ''}`,
             );
         }
         return await response.json();

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -347,7 +347,7 @@ export default function ArkWallet({
     }, [arkVtxos, arkChainTipHeight, refreshingIds]);
 
     const expiryWarning = soonestDaysLeft !== null && soonestDaysLeft < 7
-        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`
+        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d, refresh soon`
         : null;
 
     /**
@@ -499,7 +499,7 @@ export default function ArkWallet({
         //    enabling iCloud Drive). Android never sets this flag.
         if (Platform.OS === 'ios' && arkIosBackupReminderActive) {
             return {
-                text: 'Backup not synced — enable iCloud Drive in iOS Settings',
+                text: 'Backup not synced. Enable iCloud Drive in iOS Settings',
                 error: true,
             };
         }
@@ -815,7 +815,7 @@ export default function ArkWallet({
                         </Text>
                         <TouchableOpacity onPress={createArkWalletClickHandler}>
                             <Text bold style={styles.login}>
-                                ⚠ Experimental — tap to learn more
+                                ⚠ Experimental · tap to learn more
                             </Text>
                         </TouchableOpacity>
                     </View>

--- a/src/screens/Account/ArkSeedPhraseScreen/index.tsx
+++ b/src/screens/Account/ArkSeedPhraseScreen/index.tsx
@@ -221,7 +221,7 @@ export default function ArkSeedPhraseScreen() {
     const ensureWalletCreated = async (): Promise<boolean> => {
         if (walletReady) return true;
         if (!mnemonic || !mnemonic.trim()) {
-            SimpleToast.show("No seed phrase available — go back and try again.", SimpleToast.LONG);
+            SimpleToast.show("No seed phrase available. Go back and try again.", SimpleToast.LONG);
             return false;
         }
         try {
@@ -386,7 +386,7 @@ export default function ArkSeedPhraseScreen() {
                 if (iCloudOn) {
                     setCloudBackupDone(true);
                     SimpleToast.show(
-                        'iCloud Drive is on for Cypher Box — backup syncs automatically.',
+                        'iCloud Drive is on for Cypher Box. Backup syncs automatically.',
                         SimpleToast.LONG,
                     );
                     return;
@@ -456,7 +456,7 @@ export default function ArkSeedPhraseScreen() {
                 case 'uploaded-and-verified':
                     setCloudBackupDone(true);
                     SimpleToast.show(
-                        "Backup uploaded to Google Drive and verified — it will keep updating automatically.",
+                        "Backup uploaded to Google Drive and verified. It will keep updating automatically.",
                         SimpleToast.LONG,
                     );
                     break;
@@ -532,7 +532,7 @@ export default function ArkSeedPhraseScreen() {
                 const message =
                     conflict.kind === 'different-wallet'
                         ? `A saved seed already exists on this device's ${keychainLabel} behind ${biometricLabel} for wallet ${conflict.existingFingerprint}.\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe.`
-                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe — it may otherwise be lost.`;
+                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe. It may otherwise be lost.`;
                 Alert.alert(
                     "Replace keychain-saved seed?",
                     message,
@@ -646,7 +646,7 @@ export default function ArkSeedPhraseScreen() {
                 case 'written-and-verified':
                     setSafBackupConfirmed(true);
                     SimpleToast.show(
-                        "Backup saved to your folder and verified — it will keep updating automatically.",
+                        "Backup saved to your folder and verified. It will keep updating automatically.",
                         SimpleToast.LONG,
                     );
                     break;
@@ -713,8 +713,8 @@ export default function ArkSeedPhraseScreen() {
             Alert.alert(
                 "Save your backup first",
                 isIOS
-                    ? "Your seed phrase alone can't restore Ark funds — the encrypted backup file is required too. Tap 'Save backup file' above and save it somewhere you trust (iCloud Drive recommended)."
-                    : "Your seed phrase alone can't restore Ark funds — the encrypted backup file is required too. Pick at least one: Google Drive (off-device), or a folder on this phone (survives uninstall).",
+                    ? "Your seed phrase alone can't restore Ark funds. The encrypted backup file is required too. Tap 'Save backup file' above and save it somewhere you trust (iCloud Drive recommended)."
+                    : "Your seed phrase alone can't restore Ark funds. The encrypted backup file is required too. Pick at least one: Google Drive (off-device), or a folder on this phone (survives uninstall).",
                 [{ text: "OK" }],
                 { cancelable: true },
             );
@@ -726,7 +726,7 @@ export default function ArkSeedPhraseScreen() {
         if (saveToKeychain) {
             const result = await persistToKeychain();
             if (result === 'error') {
-                SimpleToast.show("Keychain save failed — please back up manually", SimpleToast.LONG);
+                SimpleToast.show("Keychain save failed. Please back up manually", SimpleToast.LONG);
             }
             // 'cancelled' = user kept the existing keychain seed by
             // choice. Silent, not a failure.
@@ -820,7 +820,7 @@ export default function ArkSeedPhraseScreen() {
                     showsVerticalScrollIndicator={false}
                 >
                     <View style={styles.content}>
-                        <Text style={styles.sectionTitle}>1/2 — Seed phrase</Text>
+                        <Text style={styles.sectionTitle}>1/2 · Seed phrase</Text>
                         <Text style={styles.warnTitle}>⚠ Write these 12 words down</Text>
                         <Text style={styles.warnBody}>
                             Keep it safe and secure offline (paper and pen are good enough).
@@ -843,7 +843,7 @@ export default function ArkSeedPhraseScreen() {
                         )}
                         {keychainStatus === "err" && (
                             <Text style={styles.statusErr}>
-                                ✗ Keychain save failed — please back up the words manually
+                                ✗ Keychain save failed. Please back up the words manually
                             </Text>
                         )}
 
@@ -932,7 +932,7 @@ export default function ArkSeedPhraseScreen() {
                                      for Cypher Box). We can't probe the toggle,
                                      so the copy is honest about the conditional. */}
                         <Text style={[styles.sectionSub, { marginTop: 18 }]}>
-                            Lose the phone, though, and the local file goes with it —
+                            Lose the phone, though, and the local file goes with it,
                             and your seed alone can't restore Ark funds. Add an
                             optional off-device copy for device-loss protection:
                         </Text>
@@ -949,8 +949,8 @@ export default function ArkSeedPhraseScreen() {
                                 </Text>
                                 <Text style={styles.backupOptionDetail}>
                                     {isIOS
-                                        ? "Opens the share sheet so you can save the encrypted ark-backup file. We recommend saving inside iCloud Drive — Cypher Box will then keep it current automatically as your VTXO capsules change. Anywhere else (email, AirDrop, local Files) works for recovery too, but you'll need to re-export after every Lightning receive. Whoever stores it sees ciphertext only."
-                                        : "Connects your Google account and uploads your ark-backup file to Drive's appDataFolder — hidden from the main Drive UI, only Cypher Box can read it. Updates upload automatically as your VTXO capsules change. Google sees only ciphertext."}
+                                        ? "Opens the share sheet so you can save the encrypted ark-backup file. We recommend saving inside iCloud Drive, so Cypher Box keeps it current automatically as your VTXO capsules change. Anywhere else (email, AirDrop, local Files) works for recovery too, but you'll need to re-export after every Lightning receive. Whoever stores it sees ciphertext only."
+                                        : "Connects your Google account and uploads your ark-backup file to Drive's appDataFolder, hidden from the main Drive UI, only Cypher Box can read it. Updates upload automatically as your VTXO capsules change. Google sees only ciphertext."}
                                 </Text>
                                 <TouchableOpacity
                                     onPress={handleConnectAndBackupCloud}
@@ -1049,7 +1049,7 @@ export default function ArkSeedPhraseScreen() {
                                         {safBackupConfirmed ? "  ✓" : ""}
                                     </Text>
                                     <Text style={styles.backupOptionDetail}>
-                                        Pick a folder you control — for example
+                                        Pick a folder you control, for example
                                         Internal Storage → Documents → Backups.
                                         The encrypted file is written there
                                         whenever your wallet changes, and unlike
@@ -1134,7 +1134,7 @@ export default function ArkSeedPhraseScreen() {
                                 </Text>
                                 <Text style={styles.warnPanelBody}>
                                     Your seed phrase alone can't restore Ark
-                                    funds — Bark stores per-VTXO state in an
+                                    funds, because Bark stores per-VTXO state in an
                                     encrypted backup file we can't re-derive
                                     from the seed. Pick any one option above
                                     before creating the wallet.

--- a/src/screens/Account/RecoverArkScreen/index.tsx
+++ b/src/screens/Account/RecoverArkScreen/index.tsx
@@ -164,7 +164,7 @@ export default function RecoverArkScreen() {
         }
         if (!valid) {
             setErrorMsg(
-                "Invalid seed phrase. Double-check spelling — each word must be a BIP39 word.",
+                "Invalid seed phrase. Double-check spelling. Each word must be a BIP39 word.",
             );
             return null;
         }
@@ -242,7 +242,7 @@ export default function RecoverArkScreen() {
                 const message =
                     conflict.kind === 'different-wallet'
                         ? `A saved seed already exists on this device's ${keychainLabel} behind ${BIOMETRIC_LABEL} for wallet ${conflict.existingFingerprint}.\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe.`
-                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe — it may otherwise be lost.`;
+                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe. It may otherwise be lost.`;
                 Alert.alert(
                     "Replace keychain-saved seed?",
                     message,
@@ -382,7 +382,7 @@ export default function RecoverArkScreen() {
                 setRestoring(false);
                 setErrorMsg(
                     `Backup file is corrupt: ${err?.message ?? 'decryption failed'}. ` +
-                    `Try a different backup source — Drive, iCloud, or pick a manually-exported file.`,
+                    `Try a different backup source: Drive, iCloud, or pick a manually-exported file.`,
                 );
                 return true; // handled (with error); don't keep scanning
             }
@@ -616,7 +616,7 @@ export default function RecoverArkScreen() {
             setRestoring(false);
             setErrorMsg(
                 `Couldn't read backup from iCloud Drive: ${err?.message ?? 'unknown error'}. ` +
-                `Make sure iCloud Drive is enabled for Cypher Box, then tap again — ` +
+                `Make sure iCloud Drive is enabled for Cypher Box, then tap again. ` +
                 `the picker should show "iCloud Drive → Cypher Box → ark-backup-{fingerprint}.cbark".`,
             );
             return;
@@ -661,7 +661,7 @@ export default function RecoverArkScreen() {
         }
         if (!valid) {
             setErrorMsg(
-                "Invalid seed phrase. Double-check spelling — each word must be a BIP39 word.",
+                "Invalid seed phrase. Double-check spelling. Each word must be a BIP39 word.",
             );
             return;
         }
@@ -669,7 +669,7 @@ export default function RecoverArkScreen() {
         if (datadirExists) {
             Alert.alert(
                 "An Ark wallet already exists",
-                "There's already an Ark wallet set up on this device. Open it first to reset before restoring from backup — otherwise the existing wallet stays.",
+                "There's already an Ark wallet set up on this device. Open it first to reset before restoring from backup. Otherwise the existing wallet stays.",
                 [
                     { text: "Cancel", style: "cancel" },
                     { text: "Open setup", onPress: () => dispatchNavigate("CreateArkScreen") },
@@ -692,7 +692,7 @@ export default function RecoverArkScreen() {
                 const message =
                     conflict.kind === 'different-wallet'
                         ? `A saved seed already exists on this device's ${keychainLabel} behind ${BIOMETRIC_LABEL} for wallet ${conflict.existingFingerprint}.\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe.`
-                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe — it may otherwise be lost.`;
+                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe. It may otherwise be lost.`;
                 Alert.alert(
                     "Replace keychain-saved seed?",
                     message,
@@ -732,7 +732,7 @@ export default function RecoverArkScreen() {
             setSubmitting(false);
             setErrorMsg(
                 /Internal/i.test(msg)
-                    ? "Couldn't open or create the Ark wallet — local state may be stale. Open the setup screen and tap Reset, then try again."
+                    ? "Couldn't open or create the Ark wallet. Local state may be stale. Open the setup screen and tap Reset, then try again."
                     : `Recovery failed: ${msg}`,
             );
             return;
@@ -841,7 +841,7 @@ function ChooseView({
                 Restore your Ark wallet
             </Text>
             <Text style={styles.introBody}>
-                {`Your Ark seed phrase is in this device's Keychain — you don't need to type it. Tap unlock below to load the seed via ${BIOMETRIC_LABEL} / passcode.\n\nVTXO capsules can't be re-derived from the seed alone, so you'll also need your ark-backup file — from ${cloudLabel} (if you connected it earlier) or a manual export.`}
+                {`Your Ark seed phrase is in this device's Keychain, so you don't need to type it. Tap unlock below to load the seed via ${BIOMETRIC_LABEL} / passcode.\n\nVTXO capsules can't be re-derived from the seed alone, so you'll also need your ark-backup file, from ${cloudLabel} (if you connected it earlier) or a manual export.`}
             </Text>
 
             {!unlockedMnemonic && (
@@ -869,7 +869,7 @@ function ChooseView({
                     }}
                 >
                     <Text style={{ color: colors.green, fontSize: 12 }}>
-                        ✓ Seed unlocked — ready to restore
+                        ✓ Seed unlocked, ready to restore
                     </Text>
                 </View>
             )}
@@ -986,7 +986,7 @@ function TypeSeedView({
                 Type your 12-word Ark seed phrase
             </Text>
             <Text style={styles.introBody}>
-                Enter the words exactly as you wrote them down — order matters. Tap space or return to jump to the next box.
+                Enter the words exactly as you wrote them down. Order matters. Tap space or return to jump to the next box.
                 {"\n\n"}
                 Note: VTXO capsules cannot be recovered from the seed alone. To restore your funds, also restore from your ark-backup file (the buttons below).
             </Text>

--- a/src/screens/HomeScreen/Header/index.tsx
+++ b/src/screens/HomeScreen/Header/index.tsx
@@ -128,8 +128,8 @@ export default React.memo(function Header({
         if (!vaultWallet) {
             SimpleToast.show(
                 which === 'hot'
-                    ? 'Hot Vault not ready — open the vault once and try again.'
-                    : 'Cold Vault not ready — open the vault once and try again.',
+                    ? 'Hot Vault not ready. Open the vault once and try again.'
+                    : 'Cold Vault not ready. Open the vault once and try again.',
                 SimpleToast.LONG,
             );
             return;

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -867,7 +867,7 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                           Lightning invoice
                         </Text>
                         <Text h4 bold style={styles.invoiceCardDescription}>
-                          Receive Lightning payments into Ark — paid out as a VTXO once the next round commits.
+                          Receive Lightning payments into Ark, paid out as a VTXO once the next round commits.
                         </Text>
                       </View>
                       <View style={styles.socketIconContainer}>

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -154,7 +154,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
     }, [arkVtxos, arkChainTipHeight]);
 
     const expiryWarning = soonestDaysLeft !== null && soonestDaysLeft < 7
-        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`
+        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d, refresh soon`
         : null;
 
     // Dust capsules: below the PER-INPUT refresh floor (ARK_REFRESH_MIN_SATS,
@@ -314,7 +314,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
 
         if (Platform.OS === 'ios' && arkIosBackupReminderActive) {
             return {
-                text: 'Backup not synced — enable iCloud Drive in iOS Settings',
+                text: 'Backup not synced. Enable iCloud Drive in iOS Settings',
                 error: true,
             };
         }

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -999,7 +999,7 @@ export default function HomeScreen({ route }: Props) {
     }
 
     if (smallUtxos.length > 5 && feesAreLow) {
-      return "Fees are low — good time to consolidate your small UTXOs to save on future transaction costs.";
+      return "Fees are low, a good time to consolidate your small UTXOs to save on future transaction costs.";
     }
 
     return null;

--- a/src/screens/HotStorageVault/Settings.tsx
+++ b/src/screens/HotStorageVault/Settings.tsx
@@ -566,7 +566,7 @@ export default function Settings({wallet, to, matchedRate, toStrike}: any) {
                                         {keychainBusy
                                             ? "Updating Keychain…"
                                             : isKeychainBackedUp
-                                            ? "Seed saved to Keychain ✓ — Remove"
+                                            ? "Seed saved to Keychain ✓ · Remove"
                                             : "Back up seed to iPhone Keychain"}
                                     </Text>
                                 </TouchableOpacity>

--- a/src/screens/RecoverSavingVault/index.tsx
+++ b/src/screens/RecoverSavingVault/index.tsx
@@ -423,7 +423,7 @@ export default function RecoverSavingVault({ route }: Props) {
                 </Text>
                 <Text style={styles.keychainSub}>
                     {isSingle
-                        ? 'Tap to unlock with FaceID / passcode and restore — no typing required.'
+                        ? 'Tap to unlock with FaceID / passcode and restore. No typing required.'
                         : `We found ${keychainBackups.length} backed-up hot vaults on this device. Pick one to restore, or remove ones you no longer need.`}
                 </Text>
 

--- a/src/screens/ReviewPayment/index.tsx
+++ b/src/screens/ReviewPayment/index.tsx
@@ -919,7 +919,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
                 console.error(`[BUY → ${dest}] swap failed:`, error);
                 let message = 'Swap failed. Your purchase succeeded — try again from Home → Swap.';
                 if (error instanceof InvoiceCreationFailedError) {
-                    message = `${dest === 'coinos' ? 'CoinOS' : 'Ark'} couldn't create an invoice — ${(error.cause as Error)?.message ?? error.message}`;
+                    message = `${dest === 'coinos' ? 'CoinOS' : 'Ark'} couldn't create an invoice: ${(error.cause as Error)?.message ?? error.message}`;
                 } else if (error instanceof PaymentFailedError) {
                     const causeMsg = (error.cause as Error)?.message ?? error.message;
                     // Strike's BALANCE_TOO_LOW response means the trade
@@ -928,7 +928,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
                     if (/BALANCE_TOO_LOW|Insufficient funds/i.test(causeMsg)) {
                         message = 'Your purchase succeeded but Strike\'s balance hasn\'t settled yet. Try the swap from Home → Swap in a few seconds.';
                     } else {
-                        message = `Strike payment failed — ${causeMsg}`;
+                        message = `Strike payment failed: ${causeMsg}`;
                     }
                 } else if (error instanceof LightningSwapError) {
                     message = error.message;
@@ -2066,7 +2066,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
             {isSendLoading && buyProgress.some(s => s.state === 'slow') && (
                 <View style={{ marginHorizontal: 24, marginBottom: 14, alignItems: 'center' }}>
                     <Text style={{ color: '#AAAAAA', fontSize: 13, lineHeight: 18, textAlign: 'center', marginBottom: 12 }}>
-                        This is taking longer than usual. The swap keeps confirming in the background — it's safe to go Home, your balance updates when it lands.
+                        This is taking longer than usual. The swap keeps confirming in the background. It's safe to go Home, your balance updates when it lands.
                     </Text>
                     <TouchableOpacity
                         onPress={() => {

--- a/src/screens/SavingVault/index.tsx
+++ b/src/screens/SavingVault/index.tsx
@@ -69,7 +69,7 @@ export default function SavingVault() {
                 );
                 setKeychainStatus("err");
                 SimpleToast.show(
-                    "Keychain save skipped — you can enable it later in vault settings",
+                    "Keychain save skipped. You can enable it later in vault settings",
                     SimpleToast.LONG,
                 );
             } else {
@@ -102,7 +102,7 @@ export default function SavingVault() {
                         result.error,
                     );
                     SimpleToast.show(
-                        "Keychain save failed — please back up the 12 words manually",
+                        "Keychain save failed. Please back up the 12 words manually",
                         SimpleToast.LONG,
                     );
                     // Intentional: we do NOT abort the flow here. The seed
@@ -185,7 +185,7 @@ export default function SavingVault() {
                 )}
                 {keychainStatus === "err" && (
                     <Text style={styles.keychainStatusErr}>
-                        ✗ Keychain save failed — paper backup still required
+                        ✗ Keychain save failed. Paper backup still required
                     </Text>
                 )}
 

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1551,7 +1551,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         );
         if (lockedSelected.length > 0) {
             SimpleToast.show(
-                `${lockedSelected.length} capsule(s) already in a pending round — wait for it to finalise before refreshing again`,
+                `${lockedSelected.length} capsule(s) already in a pending round. Wait for it to finalise before refreshing again`,
                 SimpleToast.LONG,
             );
             return;
@@ -2191,17 +2191,17 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             }
             if (succeeded === ongoing.length) {
                 SimpleToast.show(
-                    `Cancelled ${succeeded} refresh${succeeded === 1 ? '' : 'es'} — funds unlocked`,
+                    `Cancelled ${succeeded} refresh${succeeded === 1 ? '' : 'es'}, funds unlocked`,
                     SimpleToast.SHORT,
                 );
             } else if (succeeded > 0) {
                 SimpleToast.show(
-                    `Cancelled ${succeeded} of ${ongoing.length} — the rest will settle in ~1 min`,
+                    `Cancelled ${succeeded} of ${ongoing.length}, the rest will settle in ~1 min`,
                     SimpleToast.LONG,
                 );
             } else {
                 SimpleToast.show(
-                    'Cancel held up server-side — the round will settle in ~1 min',
+                    'Cancel held up server-side. The round will settle in ~1 min',
                     SimpleToast.LONG,
                 );
             }
@@ -2671,7 +2671,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                             {queuedRoundsCount} refresh rounds queued at Ark server
                         </Text>
                         <Text style={{ fontSize: 11, color: '#999', marginTop: 4, lineHeight: 15 }}>
-                            Tapping Refresh again won't speed it up — each tap
+                            Tapping Refresh again won't speed it up, because each tap
                             submits a new round and burns another fee on
                             completion. Wait for the round to finalise (typically
                             under a minute) or time out (~few hours) before

--- a/src/screens/Strike/CheckingAccountNew/ArkThreshold.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkThreshold.tsx
@@ -171,7 +171,7 @@ export default function ArkThreshold({ matchedRate, currency }: Props) {
       </Text>
       <Text style={{ marginTop: 6 }}>
         When your Ark vault balance crosses this amount, you'll be prompted to
-        move funds into deeper self-custody — your Hot or Cold Vault.
+        move funds into deeper self-custody: your Hot or Cold Vault.
       </Text>
 
       {/* Wide dark-rectangle dropdown — matches the new picker design used
@@ -247,7 +247,7 @@ export default function ArkThreshold({ matchedRate, currency }: Props) {
         </Text>
       </View>
       <Text style={{ marginTop: 6 }}>
-        Sats kept in your Ark vault after a withdrawal — your spending buffer
+        Sats kept in your Ark vault after a withdrawal: your spending buffer
         for everyday Lightning sends.
       </Text>
       <TouchableOpacity

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -809,7 +809,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     if (driveBusy) return;
     Alert.alert(
       'Disconnect Google Drive?',
-      'Your existing backup file will stay in Drive — disconnecting only stops future uploads. You can reconnect any time.',
+      'Your existing backup file will stay in Drive. Disconnecting only stops future uploads. You can reconnect any time.',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -858,12 +858,12 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     const available = await isICloudBackupAvailable();
     if (available) {
       setArkIosBackupReminderActive(false);
-      SimpleToast.show('iCloud Drive verified — reminder dismissed.', SimpleToast.LONG);
+      SimpleToast.show('iCloud Drive verified. Reminder dismissed.', SimpleToast.LONG);
       return;
     }
     Alert.alert(
       "iCloud Drive isn't on for Cypher Box",
-      "Open iOS Settings → [your name] → iCloud → iCloud Drive → scroll the app list and switch Cypher Box ON. Then come back here and tap 'iCloud Drive is on — dismiss' again.",
+      "Open iOS Settings → [your name] → iCloud → iCloud Drive → scroll the app list and switch Cypher Box ON. Then come back here and tap 'iCloud Drive is on, dismiss' again.",
       [
         { text: 'Cancel', style: 'cancel' },
         { text: 'Open Settings', onPress: () => Linking.openSettings().catch(() => {}) },
@@ -1968,7 +1968,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   reminder is active.
                 - How to enable iCloud Drive: opens the iCloud-hint
                   alert (links into iOS Settings).
-                - iCloud Drive is on — dismiss: auto-validates via the
+                - iCloud Drive is on, dismiss: auto-validates via the
                   ubiquity probe before flipping the flag off, so a
                   user who taps it without actually enabling iCloud
                   Drive is sent back to Settings rather than silently
@@ -1989,7 +1989,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 ⚠ Re-export backup after every receive
               </Text>
               <Text style={{ fontSize: 12, color: colors.white, lineHeight: 17 }}>
-                When you created this wallet, you saved a one-time snapshot of the encrypted backup file. That file doesn't auto-update unless iCloud Drive is on for Cypher Box. Tap "Re-export now" after every Lightning receive — or enable iCloud Drive for Cypher Box and this reminder will go away.
+                When you created this wallet, you saved a one-time snapshot of the encrypted backup file. That file doesn't auto-update unless iCloud Drive is on for Cypher Box. Tap "Re-export now" after every Lightning receive, or enable iCloud Drive for Cypher Box and this reminder will go away.
               </Text>
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginTop: 10 }}>
                 <TouchableOpacity
@@ -2048,7 +2048,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   }}
                 >
                   <Text bold style={{ fontSize: 12, color: '#4ADE80' }}>
-                    iCloud Drive is on — dismiss
+                    iCloud Drive is on, dismiss
                   </Text>
                 </TouchableOpacity>
               </View>
@@ -2626,7 +2626,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                       When to use Emergency Exit
                     </Text>
                     {'\n\n'}
-                    Normal sends, swaps and refreshes all go through the Ark server (Second.tech). Emergency Exit is the trustless fallback that doesn't need the server — it broadcasts pre-signed exit transactions directly to the Bitcoin chain.
+                    Normal sends, swaps and refreshes all go through the Ark server (Second.tech). Emergency Exit is the trustless fallback that doesn't need the server. It broadcasts pre-signed exit transactions directly to the Bitcoin chain.
                     {'\n\n'}
                     Use it when:
                     {'\n'}
@@ -2638,7 +2638,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                     {'\n'}
                     • News breaks of a server-side compromise and you want out fast without waiting for cooperative paths
                     {'\n\n'}
-                    Emergency Exit moves funds on-chain (slower, higher fee) so it's the break-glass option, not the everyday one. In normal use prefer swap or refresh — same destinations, faster, cheaper.
+                    Emergency Exit moves funds on-chain (slower, higher fee) so it's the break-glass option, not the everyday one. In normal use prefer swap or refresh: same destinations, faster, cheaper.
                   </Text>
                 </View>
               )}
@@ -2700,7 +2700,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   </Text>
                   <Text style={{ fontSize: 13, color: '#AAA', marginBottom: 14 }}>
                     Pick a destination for your on-chain payout. The exit takes
-                    ~24h to clear the protocol timelock — the address can't be
+                    ~24h to clear the protocol timelock, and the address can't be
                     changed after you start.
                   </Text>
 
@@ -2746,8 +2746,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 <>
                   <Text bold style={{ fontSize: 17, color: '#FFF', marginBottom: 10 }}>
                     {pickerStep === 'hot-addr'
-                      ? (addrListOpen ? 'Pick a Hot Vault address' : 'Hot Vault — destination')
-                      : (addrListOpen ? 'Pick a Cold Storage address' : 'Cold Storage — destination')}
+                      ? (addrListOpen ? 'Pick a Hot Vault address' : 'Hot Vault destination')
+                      : (addrListOpen ? 'Pick a Cold Storage address' : 'Cold Storage destination')}
                   </Text>
 
                   {/* Default flow: QR + address + "Choose another" — mirrors
@@ -3168,7 +3168,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 Delete Ark vault?
               </Text>
               <Text style={{ fontSize: 13, color: '#CCC', lineHeight: 19, marginBottom: 16 }}>
-                This wipes your Ark wallet from this device — the local
+                This wipes your Ark wallet from this device. The local
                 database with your VTXO capsules. To restore funds you'll
                 still need your{' '}
                 <Text bold style={{ color: '#FFF' }}>ark-backup file</Text>.

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -252,7 +252,7 @@ export default function SwapAmount() {
             const fallback = 'Swap failed. Please try again.';
             let message = fallback;
             if (error instanceof InvoiceCreationFailedError) {
-                message = `${toProvider?.displayName ?? sendTo} couldn't create an invoice — ${(error.cause as Error)?.message ?? error.message}`;
+                message = `${toProvider?.displayName ?? sendTo} couldn't create an invoice: ${(error.cause as Error)?.message ?? error.message}`;
             } else if (error instanceof PaymentFailedError) {
                 // A VTXO the Ark server reports as "unregistered" is a stuck
                 // capsule that blocks EVERY Ark send until it's cleared. The raw

--- a/tests/unit/noEmDashInUserCopy.test.ts
+++ b/tests/unit/noEmDashInUserCopy.test.ts
@@ -1,0 +1,122 @@
+/**
+ * No em-dash in text a user can read.
+ *
+ * A house rule that was audited by hand and kept losing. An audit in September
+ * 2026 found six violations in `src/services` and concluded the directory had
+ * rotted because it was missing from the list of places to grep. A full scan
+ * said otherwise: `src/screens` had been on that list the whole time and held
+ * forty. Being listed is not what keeps a directory clean; something failing is.
+ *
+ * SCOPE. Text a user can read, which is narrower than every em-dash in the
+ * tree:
+ *
+ *   comments        skipped. Not user-facing, and the codebase uses em-dashes
+ *                   in prose comments deliberately.
+ *   console.*       skipped. Developer output, most of it behind __DEV__.
+ *   `return '—'`    skipped. An em-dash standing in for "no value" in a table
+ *                   cell is a typographic convention, not prose, and replacing
+ *                   it with a hyphen would just look wrong.
+ *   loc/*.json      not scanned. Those are inherited BlueWallet translations in
+ *                   other languages; the rule is about English copy.
+ *
+ * The scanner is deliberately line-based and slightly blunt. A false positive
+ * costs someone one punctuation change; a false negative is how forty of these
+ * accumulated in a directory that was already being audited.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ROOTS = ['src'];
+const EM_DASH = '—';
+
+/**
+ * Files whose user-facing em-dashes are fixed on branches that have not merged
+ * yet (the Ark L1 audit copy pass, and the money-safety change that rewrites
+ * the Lightning cancel block).
+ *
+ * DELETE THIS LIST once those land. It exists so this test can start guarding
+ * everything else today instead of waiting, and every entry is a known debt
+ * rather than an accepted one.
+ */
+const PENDING_ON_OTHER_BRANCHES = new Set([
+    'src/services/ark/history.ts',
+    'src/services/ark/backgroundNotifications.ts',
+    'src/services/ark/safFolderBackup.ts',
+    'src/services/ark/lightning.ts',
+    'src/services/lightningSwap/providers/strike.ts',
+]);
+
+function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+            walk(full, out);
+        } else if (/\.tsx?$/.test(entry.name)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+function offendingLines(body: string): { line: number; text: string }[] {
+    const out: { line: number; text: string }[] = [];
+    const lines = body.split('\n');
+    let inBlockComment = false;
+
+    lines.forEach((raw, idx) => {
+        const trimmed = raw.trim();
+        let seg = raw;
+
+        if (inBlockComment) {
+            if (!raw.includes('*/')) return;
+            inBlockComment = false;
+            seg = raw.split('*/', 2)[1] ?? '';
+        }
+        // Remove block comments that open AND close on this line first. Without
+        // this, every single-line `/** ... */` doc comment reads as live code:
+        // that was 22 false positives on the first run, all of them comments.
+        seg = seg.replace(/\/\*[\s\S]*?\*\//g, '');
+
+        const open = seg.indexOf('/*');
+        if (open >= 0) {
+            inBlockComment = true;
+            seg = seg.slice(0, open);
+        }
+        if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+
+        // Trailing line comment. The lookbehind keeps "https://" intact.
+        seg = seg.replace(/(?<![:"'`])\/\/.*$/, '');
+        if (!seg.includes(EM_DASH)) return;
+
+        // "no value" placeholder, see the scope note above.
+        if (/return\s*['"`]—['"`]/.test(seg)) return;
+
+        // Developer output. Checked across a small window because these calls
+        // are routinely wrapped over several lines.
+        const window = lines.slice(Math.max(0, idx - 3), idx + 1).join('\n');
+        if (/console\.(log|warn|error|info|debug)\s*\(/.test(window)) return;
+
+        out.push({ line: idx + 1, text: trimmed.slice(0, 120) });
+    });
+    return out;
+}
+
+describe('no em-dash in user-facing copy', () => {
+    it('finds none, anywhere under src', () => {
+        const offenders: string[] = [];
+        for (const root of ROOTS) {
+            for (const abs of walk(path.join(REPO_ROOT, root))) {
+                const rel = path.relative(REPO_ROOT, abs);
+                if (PENDING_ON_OTHER_BRANCHES.has(rel)) continue;
+                if (rel.endsWith('noEmDashInUserCopy.test.ts')) continue;
+                for (const hit of offendingLines(fs.readFileSync(abs, 'utf8'))) {
+                    offenders.push(`${rel}:${hit.line}  ${hit.text}`);
+                }
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+});


### PR DESCRIPTION
The `src/screens` half of the em-dash rule, plus the thing that stops it recurring.

## Why this was needed

An audit found six violations in `src/services` and concluded the directory had rotted because it was missing from the list of places to grep. A full scan says otherwise: **`src/screens` had been on that list the whole time and held forty.** Being listed is not what keeps a directory clean.

Roughly 50 strings across screens, components and **`src/api`**, which no previous scan had covered at all.

## Punctuation only

No rewording. A comma, colon or full stop depending on what the sentence already wanted:

```
"Keychain save failed — please back up the 12 words manually"
"Keychain save failed. Please back up the 12 words manually"

"Sats kept in your Ark vault after a withdrawal — your spending buffer"
"Sats kept in your Ark vault after a withdrawal: your spending buffer"
```

**Two are deliberately left.** `return '—'` in the backup rows is an em-dash standing in for "no value" in a table cell. That is a typographic convention rather than prose, and a hyphen there would just look wrong. Say the word if you want them changed anyway.

## The durable half

Hand-auditing is what failed, twice. The second failure was **mine**: my first scan only looked at string literals and missed every JSX text node, which is where about a third of these turned out to live.

So `tests/unit/noEmDashInUserCopy.test.ts` now fails CI on a user-facing em-dash, in the shape of the existing `noPrivateDocRefs.test.ts`.

Scope is text a user can read. Comments are skipped (the codebase uses em-dashes in prose comments deliberately), `console.*` is skipped as developer output, the `return '—'` placeholder is skipped, and `loc/*.json` is not scanned because those are inherited BlueWallet translations in other languages.

**Verified to fail, not just to pass.** Injecting one em-dash back into `ArkWallet` reproduced a failure naming the file, line and text. A guard that cannot fail is worth nothing.

The scanner also caught a bug in itself on the first run: 22 false positives, every one a single-line `/** ... */` doc comment, because it only stripped block comments that spanned lines.

## Coordination

Carries a short list of files whose violations are fixed on branches still in review (#258 and #260), so this can start guarding everything else now instead of waiting on merge order. **The list is meant to be deleted when those land**, and the comment above it says so.

## Verification

- `tsc --noEmit`: **402**, identical to baseline.
- The new test passes, and fails correctly when a violation is introduced.
