### PR TITLE
fix: remove the neumorphic overlay that glows over button labels

### DIFF
--- a/src/components/GradientView/index.tsx
+++ b/src/components/GradientView/index.tsx
@@ -7,7 +7,6 @@ import {
     View,
 } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
-import { Shadow } from "react-native-neomorph-shadows";
 import styles from "./styles";
 
 interface Props extends TouchableOpacityProps {
@@ -21,6 +20,29 @@ interface Props extends TouchableOpacityProps {
     linearGradientStyleMain?: any;
     gradiantColors?: string[];
     isShadow?: boolean;
+}
+
+
+/**
+ * Strip shadow-only keys, keep everything else.
+ *
+ * The `topShadowStyle` / `bottomShadowStyle` props this component takes are not
+ * pure decoration: callers put the button's width, height, border radius and
+ * alignment in them too. Dropping the styles wholesale would resize every
+ * button in the app; keeping them wholesale would draw the very shadow being
+ * removed.
+ */
+function layoutOnly(input: any) {
+    const flat = StyleSheet.flatten(input) ?? {};
+    const {
+        shadowColor,
+        shadowOffset,
+        shadowOpacity,
+        shadowRadius,
+        elevation,
+        ...rest
+    } = flat as Record<string, unknown>;
+    return rest;
 }
 
 export default function GradientView({
@@ -52,26 +74,31 @@ export default function GradientView({
                     }
                     style={[styles.linearGradient, linearGradientStyleMain]}
                 >
-                    <Shadow
-                        inner // <- enable inner shadow
-                        useArt // <- set this prop to use non-native shadow on ios
-                        style={StyleSheet.flatten([styles.shadow, topShadowStyle])}
-                    >
-                        {/* Inner Shadow renders BEFORE children so the children
-                            paint on top. Under RN 0.77 Fabric the
-                            react-native-neomorph-shadows `useArt` fallback no
-                            longer renders a vector inset rim (ART module is
-                            gone in New Arch) — instead the Shadow paints a
-                            solid translucent overlay across its bounds.
-                            Painting it before children stops the colored tint
-                            from sitting on top of the button text (the
-                            blueish/greenish glow on the labels). */}
-                        <Shadow
-                            inner // <- enable inner shadow
-                            useArt // <- set this prop to use non-native shadow on ios
-                            style={StyleSheet.flatten([styles.innerShadow, bottomShadowStyle])} />
+                    {/* NO neumorphic rim. react-native-neomorph-shadows draws
+                        its inset rim through ART, which New Arch removed, so on
+                        RN 0.77 Fabric its `useArt` fallback paints a flat
+                        translucent overlay across its own bounds instead. That
+                        overlay is the green/blue haze reported over these
+                        button labels, and it was never the effect anyone asked
+                        for: it is the library failing.
+
+                        A previous pass moved the inner Shadow above {children}
+                        so the tint stopped covering the text. That helped but
+                        left the outer Shadow still painting, so the haze stayed,
+                        just behind the label rather than over it. Both are gone
+                        now.
+
+                        The wrapper survives as a plain View because these style
+                        objects carry LAYOUT as well as shadow (width, height,
+                        borderRadius, justifyContent), and 35 call sites depend
+                        on that sizing. `layoutOnly` keeps the geometry and drops
+                        the shadow keys, which also stops React Native drawing a
+                        real iOS shadow from them: several callers pass
+                        `shadowOpacity: 2`, which is outside the valid 0..1
+                        range and would render at full strength. */}
+                    <View style={layoutOnly([styles.shadow, topShadowStyle])}>
                         {children}
-                    </Shadow>
+                    </View>
                 </LinearGradient>
             </View>
         </TouchableOpacity>


### PR DESCRIPTION
Reported as a green/blue haze above the labels on the Hot and Cold Vault buttons. It is not styling gone wrong, it is a library failing.

## Cause

`react-native-neomorph-shadows` draws its inset rim through **ART**, which New Architecture removed. On RN 0.77 Fabric its `useArt` fallback therefore paints a **flat translucent overlay across its own bounds** instead of a rim. That overlay is the haze.

The device logs have been saying so all along, 36 times in one session:

```
(ADVICE) View #3054 of type BVLinearGradient has a shadow set but cannot
calculate shadow efficiently.
```

## A previous pass got half of it

There is already a comment in this file describing the same bug. It moved the inner `Shadow` above `{children}` so the tint stopped covering the text.

That fixed the half where the tint sat **on** the label, and left the **outer** `Shadow` still painting, so the haze remained, just behind the label rather than over it. Both are gone now.

## Blast radius, deliberately

`GradientView` has **35 call sites**. This is not only those two buttons.

Every one of them has been rendering the same broken overlay, so every one gets a clean gradient instead. **Nothing loses an effect it actually had**, because the effect has not rendered since the New Arch move.

## Why the wrapper stays

The `topShadowStyle` / `bottomShadowStyle` props are not pure decoration. Callers put `width`, `height`, `borderRadius` and `justifyContent` in them alongside the shadow keys, so dropping the styles wholesale would resize buttons across the app.

`layoutOnly` keeps the geometry and strips the shadow keys. That second half matters more than it looks: a plain `View` **would** paint a real iOS shadow from those keys, and several callers pass

```js
shadowOpacity: 2
```

which is outside the valid 0..1 range. I found 17 of those across the tree. They are not the cause of this bug, iOS clamps them, but they would have become a new one here.

## Verification

- `tsc --noEmit`: **402**, identical to baseline.
- Unit: **61 suites, 707 passed, 1 skipped.**

## Not done

**No device check, and this is purely visual across 35 surfaces.** Worth a look at the Hot Vault buttons first, then a general sweep of anything with a gradient button: home screen, send/receive sheets, Cold Storage. Expected result is the same buttons minus the haze, with identical size and position.

The dependency itself is now unused by this component but still in `package.json`. I have not touched that; removing a dependency is a separate decision.
