### PR TITLE
feat(ark): back up the refresh-complete notification with a scheduled one

### DIFF
--- a/src/services/ark/backgroundNotifications.ts
+++ b/src/services/ark/backgroundNotifications.ts
@@ -238,7 +238,8 @@ export function isArkCapsuleTapSource(s: unknown): boolean {
         isArkExpiryWarningSource(s) ||
         isArkExitReadySource(s) ||
         s === 'ark-received' ||
-        s === 'ark-refresh-complete'
+        s === 'ark-refresh-complete' ||
+        s === ARK_REFRESH_REMINDER_SOURCE
     );
 }
 
@@ -648,6 +649,85 @@ export function notifyArkRefreshComplete(capsuleCount?: number): void {
         'low',
         { source: 'ark-refresh-complete', capsuleCount },
     );
+}
+
+export const ARK_REFRESH_REMINDER_SOURCE = 'ark-refresh-reminder';
+
+/**
+ * One fixed id: only one round can be in flight per wallet at a time
+ * (refreshSubmissionInFlight and sweepInFlight both enforce that), so a
+ * per-round key would buy nothing and a stale one could never be cancelled.
+ * Scheduling again simply replaces the pending alarm.
+ */
+const REFRESH_REMINDER_ID = fnv1aNotificationId('ark-refresh-reminder');
+
+/** Rounds are documented as taking up to about an hour on mainnet. */
+const REFRESH_REMINDER_DELAY_MS = 60 * 60 * 1000;
+
+/**
+ * Backstop reminder for a refresh round, scheduled when the round is submitted.
+ *
+ * WHY THIS EXISTS ALONGSIDE notifyArkRefreshComplete. That one is better in
+ * every way except availability: it fires on the real completion event, with
+ * the real capsule count, and says the round is done because it saw it happen.
+ * But it runs inside movementWatcher, which only observes anything while the
+ * app process is alive. Once iOS suspends or kills the app, nothing is watching
+ * and no completion notification is ever produced. Observed on device
+ * 2026-09-10: a round finalised while the app was closed and the user learned
+ * about it by opening the app and looking.
+ *
+ * A scheduled local notification is handed to the OS at submit time, so it
+ * fires whether or not the app is still running. That is the entire point, and
+ * the only reason to accept a timer over an event.
+ *
+ * It is therefore deliberately CAUTIOUS about what it claims. It does not say
+ * the refresh finished, because it does not know: an hour is the documented
+ * upper bound, not a guarantee, and the round may have failed. It says the
+ * round should be done and invites the user to look.
+ *
+ * Cancelled by {@link cancelArkRefreshReminder} the moment a completion is
+ * actually observed, so a user whose app stayed alive gets the accurate
+ * "Refresh complete" and never sees this one.
+ */
+export function scheduleArkRefreshReminder(capsuleCount?: number): void {
+    // Same toggle that gates every other Ark alarm.
+    if (!useAuthStore.getState().arkBgRefreshEnabled) return;
+    ensureInit();
+    const subject =
+        typeof capsuleCount === 'number' && capsuleCount > 0
+            ? `${capsuleCount} capsule${capsuleCount === 1 ? '' : 's'}`
+            : 'Your capsules';
+    try {
+        // Cast as the permission check above does: this library's types are
+        // stale and omit the scheduling methods it ships. Casting only the new
+        // call sites, so the repo's error baseline does not move.
+        (PushNotification as any).localNotificationSchedule({
+            id: REFRESH_REMINDER_ID,
+            channelId: CHANNEL_ID,
+            title: 'Refresh should be done',
+            // Deliberately not "is done". See the docstring: this alarm was set
+            // an hour ago and has observed nothing since.
+            message: `${subject} were refreshing. Tap to check they went through.`,
+            date: new Date(Date.now() + REFRESH_REMINDER_DELAY_MS),
+            priority: 'low',
+            importance: 'low',
+            playSound: false,
+            userInfo: { source: ARK_REFRESH_REMINDER_SOURCE, capsuleCount },
+            allowWhileIdle: true,
+        });
+    } catch (err) {
+        // Never let a reminder break a submission that already succeeded.
+        console.warn('[Ark notifications] scheduleArkRefreshReminder:', err);
+    }
+}
+
+/** Drop the backstop, called as soon as a completion is actually observed. */
+export function cancelArkRefreshReminder(): void {
+    try {
+        (PushNotification as any).cancelLocalNotification(REFRESH_REMINDER_ID);
+    } catch (err) {
+        console.warn('[Ark notifications] cancelArkRefreshReminder:', err);
+    }
 }
 
 /**

--- a/src/services/ark/movementWatcher.ts
+++ b/src/services/ark/movementWatcher.ts
@@ -6,7 +6,11 @@ import {
 } from '@secondts/bark-react-native';
 
 import useAuthStore from '@Cypher/stores/authStore';
-import { notifyArkReceived, notifyArkRefreshComplete } from './backgroundNotifications';
+import {
+    cancelArkRefreshReminder,
+    notifyArkReceived,
+    notifyArkRefreshComplete,
+} from './backgroundNotifications';
 import { getArkWalletHandle } from './walletHandle';
 
 /**
@@ -217,6 +221,12 @@ function handleNotification(notif: { tag: string; inner?: any }): void {
     // completed round, ever, for this process. Backgrounded only: with
     // the app open the Capsules UI is the completion signal.
     if (subsystem === 'refresh' && status === 'successful') {
+        // Drop the backstop first, and OUTSIDE the dedupe guard. This runs on
+        // every re-emission of the movement, which is what we want: the alarm
+        // must die even if the notification itself was already handled, or
+        // suppressed because the app was in the foreground. Cancelling an id
+        // that is not queued is a no-op.
+        cancelArkRefreshReminder();
         if (!notifiedRefreshMovementIds.has(movement.id)) {
             notifiedRefreshMovementIds.add(movement.id);
             if (AppState.currentState !== 'active') {

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -4,6 +4,7 @@ import { assertNoActiveArkExitAsync } from './exit';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
 import { writeArkAutoBackup } from './backup';
+import { scheduleArkRefreshReminder } from './backgroundNotifications';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import useAuthStore from '@Cypher/stores/authStore';
 import type { FeeEstimate, RoundState } from '@secondts/bark-react-native';
@@ -369,6 +370,17 @@ export async function refreshArkVtxosDelegatedAndSync(
 ): Promise<ArkDelegatedRefreshResult> {
     const handle = await requireHandle();
     const result = await refreshArkVtxosDelegated(vtxoIds, totalSats);
+    // Backstop reminder, armed only once the ASP has accepted the round. Handed
+    // to the OS now so it survives the app being suspended or killed, which is
+    // the case movementWatcher's completion notification cannot cover: it only
+    // observes anything while the process is alive. Cancelled the moment a real
+    // completion is seen, so a user whose app stays up never sees it.
+    try {
+        scheduleArkRefreshReminder(vtxoIds.length);
+    } catch (err) {
+        // A reminder must never take down a submission that already succeeded.
+        console.warn('[Ark refresh] reminder schedule failed:', err);
+    }
     await handle.sync();
     await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
     // G2: eager backup so the just-refreshed state is captured now, not on


### PR DESCRIPTION
A scheduled backstop for the refresh-complete notification, so a round that finishes while the app is dead still reaches the user.

## The app already notifies on completion, and it is better

`movementWatcher` fires `notifyArkRefreshComplete` when a refresh round finalises. It beats this change in every way except one: it fires on the real event, carries the real capsule count, and says the round is done because it watched it happen.

```js
if (subsystem === 'refresh' && status === 'successful') {
    if (AppState.currentState !== 'active') { notifyArkRefreshComplete(...) }
}
```

**It only runs while the app process is alive.** Once iOS suspends or kills the app, nothing observes the completion and the user is told nothing. Seen on device 2026-09-10: a round finalised while the app was closed and the only way to find out was to open the app and look.

A local notification is handed to the OS at submit time, so it fires whether or not the app is still running. That is the only reason to prefer a timer over an event, and it is the entire justification for this change.

## It is careful about what it claims

> **Refresh should be done**
> N capsules were refreshing. Tap to check they went through.

Not "is done". An hour is the documented upper bound, not a guarantee, and the round may have failed. The alarm was set an hour earlier and has observed nothing since, so it says what it knows and invites the user to look.

The tap routes to the Capsules tab through the existing `isArkCapsuleTapSource` path, which already handled a `refresh-complete` source.

## Cancellation

Dropped as soon as a completion is actually observed, so a user whose app stays alive gets the accurate "Refresh complete" and never sees this one.

Cancelled **outside** the dedupe guard on purpose: it runs on every re-emission of the movement, so the alarm dies even when the notification itself was suppressed for being in the foreground. Cancelling an id that is not queued is a no-op.

## Details

- **One fixed notification id.** Only one round can be in flight per wallet, enforced by both `refreshSubmissionInFlight` and `sweepInFlight`, so a per-round key would buy nothing and a stale one could never be cancelled. Scheduling again replaces the pending alarm rather than stacking.
- **Gated on the same reminders toggle** as every other Ark alarm.
- **Cannot break a submission**: the schedule call is wrapped, because a reminder must never take down a round that already succeeded.
- Scheduled only after the ASP has accepted the round, not on attempt.

## Verification

- `tsc --noEmit`: **402**, identical to baseline. The two type errors the new calls produce come from this library's stale type definitions; I cast only the new call sites, the way the permission check in the same file already does, rather than move the repo's baseline.
- Unit: **61 suites, 707 passed, 1 skipped.**

## Not done

**No device verification, and shipping unadvertised at Bam's call.** Notifications fail silently in both directions, so the modes worth watching are: never fires, fires late, fires after the round already completed, or fires alongside the real completion notice if cancellation misses.

Also worth noting the reminder is per-process in one respect: if the app is killed before the ASP accepts, nothing is scheduled at all.
