### PR TITLE
feat(ark): give dust that is too small to combine a way out

### DIFF
--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -2123,6 +2123,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                                 dispatchNavigate('SwapAmount', {
                                     swapFrom: 'ark',
                                     sendTo: 'coinos',
+                                    purpose: 'dust-exit',
                                     prefillSats: total,
                                     sourceBalance: total,
                                     // Cap at the dust total. Editing this up
@@ -2146,7 +2147,15 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                                 dispatchNavigate('SwapAmount', {
                                     swapFrom: 'coinos',
                                     sendTo: 'ark',
+                                    purpose: 'dust-topup',
                                     prefillSats: shortfall,
+                                    // Same ceiling the shortfall is computed
+                                    // against. Without it the user can edit
+                                    // the amount up, the top-up lands as a
+                                    // healthy capsule outside the dust set,
+                                    // and the sweep armed below refuses for a
+                                    // reason nothing on screen explains.
+                                    maxSats: ARK_REFRESH_MIN_SATS - 1,
                                 });
                             },
                         },

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -2051,7 +2051,25 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 SimpleToast.show('No dust capsules to refresh.', SimpleToast.SHORT);
                 return;
             }
-            if (total <= ARK_VTXO_DUST_SATS) {
+            // Gate on whether the sweep is WORTH anything, not on whether the
+            // ASP would take it.
+            //
+            // Two different limits were being confused. Below ARK_VTXO_DUST_SATS
+            // the server refuses the batch outright. Below ARK_REFRESH_MIN_SATS
+            // it accepts it and hands back another dust capsule, because the
+            // output is the total minus a fee and the total was already under
+            // the floor. The second case is the one users actually hit: 381
+            // sats of dust sweeps happily into 379 sats of dust, achieving
+            // nothing but a round fee and an hour of waiting.
+            //
+            // No fee estimate is needed to know this. If the total is under the
+            // floor then the output is under the floor even at zero fee, so the
+            // check is exact rather than a guess. That also keeps the decision
+            // ahead of estimateArkRefreshFee, which matters: that call reaches
+            // the chain source and dies on a 429, which would otherwise throw
+            // the user into a generic failure toast and they would never see
+            // this dialog at all.
+            if (total < ARK_REFRESH_MIN_SATS) {
                 // Below the dust limit the ASP will not take the batch at all,
                 // so the sweep is genuinely impossible rather than merely
                 // uneconomic. A toast saying "not enough" was true and useless:
@@ -2068,7 +2086,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 // honest answer.
                 if (!isCoinosConnected) {
                     SimpleToast.show(
-                        `Only ${total} sats of dust so far. It needs to total more than ${ARK_VTXO_DUST_SATS} sats before it can be swept into one capsule.`,
+                        `Only ${total} sats of dust so far. It needs to total at least ${ARK_REFRESH_MIN_SATS} sats before combining it is worth the fee.`,
                         SimpleToast.LONG,
                     );
                     return;
@@ -2094,9 +2112,10 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 );
                 // COPY: Bam finalizes.
                 Alert.alert(
-                    "These are too small to combine",
+                    "Combining these won't help yet",
                     `${total} sats of dust across ${ids.length} capsule${ids.length === 1 ? '' : 's'}. ` +
-                    `The Ark server won't accept a batch under ${ARK_VTXO_DUST_SATS} sats, so they can't be combined yet.`,
+                    `Combining them costs a fee and still leaves you under ${ARK_REFRESH_MIN_SATS} sats, ` +
+                    `so the result would be dust again.`,
                     [
                         {
                             text: 'Move them to CoinOS',

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1129,6 +1129,17 @@ function RefreshWaitBanner({
     );
 }
 
+/**
+ * What a dust top-up aims for, in sats.
+ *
+ * 700 rather than the 500 refresh floor: the batch has to clear the floor
+ * AFTER the round fee, and landing exactly on it would leave the swept capsule
+ * one sat of drift away from being dust again. It also matches the number the
+ * receive screens already tell users to aim for, so the two pieces of advice
+ * agree.
+ */
+const DUST_TOPUP_TARGET_SATS = 700;
+
 export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps) {
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
     const [refreshing, setRefreshing] = useState(false);
@@ -1164,6 +1175,13 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // so the user lands on this tab with refresh already running, without
     // having to find a button.
     const arkPendingTapRefresh = useAuthStore((s) => s.arkPendingTapRefresh);
+    // One-shot: sweep the dust once a top-up swap has landed. Set on the way
+    // out to the swap screen, consumed on the way back in.
+    const arkPendingDustSweep = useAuthStore((s) => s.arkPendingDustSweep);
+    const setArkPendingDustSweep = useAuthStore((s) => s.setArkPendingDustSweep);
+    // Both dust escape hatches are swaps with CoinOS, so neither is offered
+    // when it is not connected.
+    const isCoinosConnected = useAuthStore((s) => s.isAuth) === true;
     const setArkPendingTapRefresh = useAuthStore((s) => s.setArkPendingTapRefresh);
     const arkRefreshStuck = useAuthStore((s) => s.arkRefreshStuck);
     const setArkRefreshStuck = useAuthStore((s) => s.setArkRefreshStuck);
@@ -1361,6 +1379,34 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     //   3. Otherwise → fire the batch with skipConfirm so the refresh
     //      starts immediately. Selection + fee preview don't add safety
     //      here: the user already opted in by tapping the warning.
+    /**
+     * Follow-through for the dust top-up.
+     *
+     * The user chose "top up" on the too-small-to-combine dialog, swapped in
+     * from CoinOS, and has landed back here. Fire the sweep they were trying to
+     * run in the first place.
+     *
+     * Waits for `rows`, the same gate the tap-refresh effect below uses: an
+     * empty list means the wallet has not hydrated yet, and sweeping off a set
+     * we have not read would submit the wrong ids.
+     *
+     * The flag is cleared BEFORE the sweep, not after. handleDustRefresh is
+     * async and can fail, and a flag still set on failure would re-fire the
+     * round on the next mount, which is exactly the retry storm this codebase
+     * has been bitten by twice today.
+     *
+     * If the top-up has not landed as a capsule yet, or landed as one big
+     * enough not to count as dust, handleDustRefresh says so through its own
+     * guard. That is the honest outcome, and it is why this does not try to
+     * verify the balance itself.
+     */
+    useEffect(() => {
+        if (!arkPendingDustSweep) return;
+        if (rows.length === 0) return;
+        setArkPendingDustSweep(false);
+        handleDustRefresh();
+    }, [arkPendingDustSweep, rows, setArkPendingDustSweep]);
+
     useEffect(() => {
         if (!arkPendingTapRefresh) return;
         if (rows.length === 0) return;
@@ -2006,9 +2052,64 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 return;
             }
             if (total <= ARK_VTXO_DUST_SATS) {
-                SimpleToast.show(
-                    `Only ${total} sats of dust so far. It needs to total more than ${ARK_VTXO_DUST_SATS} sats before it can be swept into one capsule.`,
-                    SimpleToast.LONG,
+                // Below the dust limit the ASP will not take the batch at all,
+                // so the sweep is genuinely impossible rather than merely
+                // uneconomic. A toast saying "not enough" was true and useless:
+                // it named the obstacle and left the user holding sats they
+                // could not combine and had no obvious way to rescue.
+                //
+                // Two ways out, and they are opposites, so the user picks:
+                // take the value off Ark entirely, or add just enough to make
+                // the batch viable. Both go through the existing swap screen;
+                // neither is a new money path.
+                //
+                // Gated on CoinOS being connected, because both options are
+                // swaps with it. Without it, the old message is still the
+                // honest answer.
+                if (!isCoinosConnected) {
+                    SimpleToast.show(
+                        `Only ${total} sats of dust so far. It needs to total more than ${ARK_VTXO_DUST_SATS} sats before it can be swept into one capsule.`,
+                        SimpleToast.LONG,
+                    );
+                    return;
+                }
+                const shortfall = Math.max(1, DUST_TOPUP_TARGET_SATS - total);
+                // COPY: Bam finalizes.
+                Alert.alert(
+                    "These are too small to combine",
+                    `${total} sats of dust across ${ids.length} capsule${ids.length === 1 ? '' : 's'}. ` +
+                    `The Ark server won't accept a batch under ${ARK_VTXO_DUST_SATS} sats, so they can't be combined yet.`,
+                    [
+                        {
+                            text: 'Move them to CoinOS',
+                            onPress: () => {
+                                dispatchNavigate('SwapAmount', {
+                                    swapFrom: 'ark',
+                                    sendTo: 'coinos',
+                                    prefillSats: total,
+                                    sourceBalance: total,
+                                });
+                            },
+                        },
+                        {
+                            text: `Top up ${shortfall} sats`,
+                            onPress: () => {
+                                // Arm the follow-up sweep. The swap happens on
+                                // another screen, so the intent has to outlive
+                                // this one; ArkCapsules consumes the flag when
+                                // it is next mounted, by which time the topped
+                                // up sats have had a chance to land.
+                                setArkPendingDustSweep(true);
+                                dispatchNavigate('SwapAmount', {
+                                    swapFrom: 'coinos',
+                                    sendTo: 'ark',
+                                    prefillSats: shortfall,
+                                });
+                            },
+                        },
+                        { text: 'Not now', style: 'cancel' },
+                    ],
+                    { cancelable: true },
                 );
                 return;
             }

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -2073,7 +2073,25 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                     );
                     return;
                 }
-                const shortfall = Math.max(1, DUST_TOPUP_TARGET_SATS - total);
+                // The top-up has to arrive as DUST itself, or it will not join
+                // the batch it was meant to rescue.
+                //
+                // Aiming straight at 700 breaks for most of the range this
+                // dialog can appear in. The guard fires at a dust total of 330
+                // or less, so the shortfall to 700 is 370 or more, and any
+                // total at or below 200 asks for 500+, which lands as a healthy
+                // capsule and is excluded from the dust set. The user would
+                // swap in funds and the sweep would refuse again, for a reason
+                // no one could see.
+                //
+                // Capping one sat under the refresh floor keeps the incoming
+                // capsule inside the dust set. The batch then totals
+                // dust + up to 499, comfortably past the ASP's limit even
+                // though it may land short of 700.
+                const shortfall = Math.max(
+                    1,
+                    Math.min(DUST_TOPUP_TARGET_SATS - total, ARK_REFRESH_MIN_SATS - 1),
+                );
                 // COPY: Bam finalizes.
                 Alert.alert(
                     "These are too small to combine",
@@ -2088,6 +2106,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                                     sendTo: 'coinos',
                                     prefillSats: total,
                                     sourceBalance: total,
+                                    // Cap at the dust total. Editing this up
+                                    // would pull healthy capsules out of the
+                                    // vault, which is the opposite of what the
+                                    // user came here to do: this option exists
+                                    // to clear dust, not to move funds.
+                                    maxSats: total,
                                 });
                             },
                         },

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -22,6 +22,10 @@ import {
     type LightningSwapProvider,
     type LightningSwapProviderId,
 } from "@Cypher/services/lightningSwap";
+// From the defining module rather than the ark barrel, matching the direct
+// imports ArkCapsules already uses for constants the barrel has in-flight
+// edits around. Same value either way; this just avoids the churn.
+import { ARK_REFRESH_MIN_SATS } from "@Cypher/services/ark/config";
 import { getFiatRate } from "../../../models/fiatUnit";
 
 // Warning-yellow gradient for the small-amount "Swap anyways" CTA + dust note.
@@ -33,7 +37,7 @@ const SMALL_RECEIVE_SATS = 700;
 export default function SwapAmount() {
     const navigation = useNavigation();
     const route = useRoute();
-    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats, maxSats } = route.params as {
+    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats, maxSats, purpose } = route.params as {
         swapFrom: LightningSwapProviderId;
         sendTo: LightningSwapProviderId;
         fromAddress?: string;
@@ -63,6 +67,22 @@ export default function SwapAmount() {
          * poking at a dead input with no explanation.
          */
         maxSats?: number;
+        /**
+         * Why this screen was opened, when the answer changes what to say.
+         *
+         * Passed explicitly rather than inferred from `prefillSats` or from the
+         * rail pair. Inference was the tempting shortcut and it is wrong twice
+         * over: another caller prefilling an amount would silently inherit
+         * dust copy, and `swapFrom`/`sendTo` cannot tell a deliberate 319-sat
+         * top-up apart from a user typing 319 by hand, which is exactly the
+         * case the small-amount warning exists to catch.
+         *
+         * 'dust-topup'  covering a shortfall so a dust batch clears the
+         *               refresh floor. Small is the POINT here, so the generic
+         *               small-amount warning is suppressed.
+         * 'dust-exit'   taking dust off Ark entirely.
+         */
+        purpose?: 'dust-topup' | 'dust-exit';
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
     // Ark sats locked in an in-flight refresh. When the source is Ark and the
@@ -486,10 +506,24 @@ export default function SwapAmount() {
     // leave un-refreshable dust that expires. Sats mode types the sat amount;
     // fiat mode mirrors the sat equivalent into `usd`.
     const currentSats = Math.round(isSats ? Number(sats) : Number(usd)) || 0;
-    const smallBarkSwapWarn = sendTo === 'ark' && currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
+    // Suppressed for the dust top-up. That flow computes the amount itself,
+    // caps it under the refresh floor, and sent the user here precisely to
+    // deposit a small sum. Warning them off it would contradict the dialog
+    // that opened this screen, and the CTA it drives ("Swap anyways") frames
+    // the intended action as a mistake the user is overriding.
+    const isDustTopup = purpose === 'dust-topup';
+    const smallBarkSwapWarn =
+        !isDustTopup && sendTo === 'ark' && currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
 
     return (
-        <ScreenLayout disableScroll showToolbar isBackButton title="Lightning Swap">
+        <ScreenLayout
+            disableScroll
+            showToolbar
+            isBackButton
+            title={
+                isDustTopup ? 'Dust Top-up' : purpose === 'dust-exit' ? 'Move Dust Out' : 'Lightning Swap'
+            }
+        >
             <View style={styles.main}>
                 <GradientInput isSats={isSats} walletInfo={{ matchedRate, currency }} sats={sats} setSats={setSats} usd={usd} />
                 {swapFrom === 'ark' && pendingInRoundSats > 0 && (sourceBalance === 0 || (Number(sats) || 0) > sourceBalance) && (
@@ -526,6 +560,18 @@ export default function SwapAmount() {
                 {smallBarkSwapWarn && (
                     <Text style={{ textAlign: 'center', marginTop: 8, marginHorizontal: 8, fontSize: 12, color: '#FFD54F', lineHeight: 17 }}>
                         Small amounts can leave un-refreshable dust that expires. Swapping above 700 sats keeps them refreshable.
+                    </Text>
+                )}
+                {/* Replaces the warning above rather than sitting alongside it.
+                    The screen otherwise gives no reason for the odd prefilled
+                    number, and the ceiling is worth stating because the field
+                    is editable and overshooting it silently defeats the sweep
+                    the user is here to enable.
+                    COPY: Bam finalizes. */}
+                {isDustTopup && (
+                    <Text style={{ textAlign: 'center', marginTop: 8, marginHorizontal: 8, fontSize: 12, color: '#ddd', lineHeight: 17 }}>
+                        This is meant to be small. It has to stay under {ARK_REFRESH_MIN_SATS} sats to combine with
+                        the dust you already have.
                     </Text>
                 )}
             </View>

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -33,7 +33,7 @@ const SMALL_RECEIVE_SATS = 700;
 export default function SwapAmount() {
     const navigation = useNavigation();
     const route = useRoute();
-    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats } = route.params as {
+    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats, maxSats } = route.params as {
         swapFrom: LightningSwapProviderId;
         sendTo: LightningSwapProviderId;
         fromAddress?: string;
@@ -49,6 +49,20 @@ export default function SwapAmount() {
          * value, not a lock.
          */
         prefillSats?: number;
+        /**
+         * Hard ceiling on the amount, in sats.
+         *
+         * Set by the dust "move them to CoinOS" option. That path exists to
+         * clear dust, and editing the amount up would pull healthy capsules out
+         * of the vault instead, which is the opposite of what the user came for
+         * and defeats the point of the option.
+         *
+         * Enforced by clamping rather than by making the field read-only: the
+         * user can still type, still reduce it, and sees the value snap back if
+         * they overshoot. Locking the keyboard outright would leave them
+         * poking at a dead input with no explanation.
+         */
+        maxSats?: number;
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
     // Ark sats locked in an in-flight refresh. When the source is Ark and the
@@ -108,6 +122,16 @@ export default function SwapAmount() {
     // Seed the amount from `prefillSats` exactly once. Not a controlled sync:
     // re-applying it would fight the user every time they edited the field.
     const prefillApplied = React.useRef(false);
+    // Clamp to `maxSats` whenever the typed value goes over. Runs on the sats
+    // field only: fiat entry is mirrored into it by CustomKeyboard, so this
+    // catches both.
+    React.useEffect(() => {
+        if (!maxSats || !Number.isFinite(maxSats) || maxSats <= 0) return;
+        const typed = Number(sats);
+        if (Number.isFinite(typed) && typed > maxSats) {
+            setSats(String(maxSats));
+        }
+    }, [sats, maxSats]);
     React.useEffect(() => {
         if (prefillApplied.current) return;
         if (!prefillSats || !Number.isFinite(prefillSats) || prefillSats <= 0) return;

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -33,12 +33,22 @@ const SMALL_RECEIVE_SATS = 700;
 export default function SwapAmount() {
     const navigation = useNavigation();
     const route = useRoute();
-    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0 } = route.params as {
+    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats } = route.params as {
         swapFrom: LightningSwapProviderId;
         sendTo: LightningSwapProviderId;
         fromAddress?: string;
         toAddress?: string;
         sourceBalance?: number;
+        /**
+         * Amount to open the screen with, in sats.
+         *
+         * Set by callers that already know the number, currently the dust
+         * top-up: the user is not choosing an amount there, they are covering a
+         * specific shortfall, and making them work it out is asking them to do
+         * arithmetic the app already did. Still editable; it is a starting
+         * value, not a lock.
+         */
+        prefillSats?: number;
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
     // Ark sats locked in an in-flight refresh. When the source is Ark and the
@@ -95,6 +105,16 @@ export default function SwapAmount() {
         return () => clearTimeout(t);
     }, [loading]);
     const [success, setSuccess] = useState(false);
+    // Seed the amount from `prefillSats` exactly once. Not a controlled sync:
+    // re-applying it would fight the user every time they edited the field.
+    const prefillApplied = React.useRef(false);
+    React.useEffect(() => {
+        if (prefillApplied.current) return;
+        if (!prefillSats || !Number.isFinite(prefillSats) || prefillSats <= 0) return;
+        prefillApplied.current = true;
+        setIsSats(true);
+        setSats(String(Math.ceil(prefillSats)));
+    }, [prefillSats]);
     const [swappedSats, setSwappedSats] = useState('');
     const [swappedFiat, setSwappedFiat] = useState('');
     const [feeSats, setFeeSats] = useState<number | null>(null);

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -435,6 +435,18 @@ export type AuthStateType = {
      * next mount, which is the safer failure mode.
      */
     arkPendingTapRefresh: boolean;
+    /**
+     * One-shot: sweep the dust as soon as the Capsules tab is next mounted.
+     *
+     * Set when the user takes the "top up from CoinOS" way out of a dust set
+     * too small to sweep. The swap runs on another screen, so the intent has to
+     * outlive this one, and the sweep can only run once the topped-up sats have
+     * actually landed as a capsule.
+     *
+     * Not persisted. It describes an intent inside one session; restoring it
+     * from a previous run would fire a round the user never asked for.
+     */
+    arkPendingDustSweep: boolean;
 
     /**
      * One-shot flag: set when the homepage "stuck on-chain funds" banner is
@@ -532,6 +544,7 @@ export type AuthStateType = {
     setArkBgRefreshLastStuckWarnAt: (state: number | null) => void;
     setArkBgRefreshMaxFeeSats: (state: number) => void;
     setArkPendingTapRefresh: (state: boolean) => void;
+    setArkPendingDustSweep: (state: boolean) => void;
     setArkPendingOnchainRecoverOpen: (state: boolean) => void;
     setArkIosBackupReminderActive: (state: boolean) => void;
     setArkArkoorPromptState: (
@@ -628,6 +641,7 @@ const createAuthStore = (
     arkBgRefreshLastStuckWarnAt: null,
     arkBgRefreshMaxFeeSats: 5000,
     arkPendingTapRefresh: false,
+    arkPendingDustSweep: false,
     arkPendingOnchainRecoverOpen: false,
     arkIosBackupReminderActive: false,
     arkArkoorPromptState: {},
@@ -717,6 +731,7 @@ const createAuthStore = (
     setArkBgRefreshLastStuckWarnAt: (state: number | null) => set({ arkBgRefreshLastStuckWarnAt: state }),
     setArkBgRefreshMaxFeeSats: (state: number) => set({ arkBgRefreshMaxFeeSats: state }),
     setArkPendingTapRefresh: (state: boolean) => set({ arkPendingTapRefresh: state }),
+    setArkPendingDustSweep: (state: boolean) => set({ arkPendingDustSweep: state }),
     setArkPendingOnchainRecoverOpen: (state: boolean) => set({ arkPendingOnchainRecoverOpen: state }),
     setArkIosBackupReminderActive: (state: boolean) => set({ arkIosBackupReminderActive: state }),
     setArkArkoorPromptState: (state) => set({ arkArkoorPromptState: state }),


### PR DESCRIPTION
Dust that is too small to be worth combining had no way out. The old response was a toast naming the shortfall: true, and useless. It told the user the obstacle and left them holding sats they could not combine and had no obvious way to rescue.

## Which limit gates the dialog

Two different limits were being confused, and the first version of this PR used the wrong one.

- **`ARK_VTXO_DUST_SATS` (330)** is where the ASP refuses the batch outright.
- **`ARK_REFRESH_MIN_SATS` (500)** is where combining stops being *worth* anything. The batch is accepted and hands back another dust capsule, because the output is the total minus a round fee and the total was already under the floor.

The second case is the one users actually hit. Reported from device: a **381-sat** capsule is displayed as dust by the row UI, which marks dust at `< 500` (`ArkCapsules.tsx:412`), but the dialog was gated at `<= 330`, so it never appeared. The sweep proceeded, and 381 sats became ~379 sats. A legal batch, a paid fee, an hour of waiting, and nothing gained.

Gating on the refresh floor makes the two agree, and the check is **exact rather than estimated**: if the total is under the floor, the output is under the floor even at zero fee.

## This also fixes a silent failure

The old guard sat *after* the network call. Once it passed, the next statement was `estimateArkRefreshFee(ids)`, which reaches the chain source. Esplora answers `429` under load, that throw landed in the generic catch, and the user got no dialog and no explanation:

```
18:32:43  [Ark dust-refresh] failed tag= Inner inner= HttpResponse { status: 429 }
18:32:45  [Ark dust-refresh] failed ...
18:32:47  [Ark dust-refresh] failed ...
```

The repeat is the user tapping a dead button, not a loop. Each tap failed fast because a 429 returns immediately.

Deciding before the fee estimate removes the dependency entirely, so whether the user sees an explanation no longer depends on chain-source availability.

## The dialog

> **Combining these won't help yet**
> 381 sats of dust across 1 capsule. Combining them costs a fee and still leaves you under 500 sats, so the result would be dust again.
>
> `Move them to CoinOS` · `Top up 319 sats` · `Not now`

The two options are **opposites**, which is why the user picks rather than the app guessing: take the value off Ark entirely, or add just enough to make the batch viable. Both route through the existing swap screen with the amount prefilled. Neither is a new money path.

## Both amounts are bounded, in opposite directions

**The top-up must itself be dust**, or it will not join the batch it was meant to rescue. Aiming straight at 700 breaks across most of the range: a 200-sat total asks for 500, which lands as a healthy capsule, is excluded from the dust set, and the sweep refuses again for a reason nobody can see.

Capping one sat under the floor keeps the incoming capsule inside the dust set:

```
shortfall = max(1, min(700 - total, 499))
```

Verified over every total in `1..499`: the top-up is always `< 500` (stays dust) and the resulting batch is always `>= 500` (clears the floor). Zero failures.

**The swap-out is capped at the dust total** via `maxSats`. Editing it upward would pull healthy capsules out of the vault, which is the opposite of what the user came here to do. This option exists to clear dust, not to move funds.

## The follow-up sweep

A one-shot store flag, because the swap runs on another screen and the intent has to outlive this one.

**Cleared before the sweep, not after.** `handleDustRefresh` is async and can fail, and a flag still set on failure would re-fire the round on the next mount. That is precisely the retry-storm shape this codebase was bitten by twice on 2026-09-09.

**Not persisted.** It describes an intent inside one session; restoring it from a previous run would fire a round nobody asked for.

It waits on `rows` for the same reason the existing tap-refresh effect does: an empty list means the wallet has not hydrated, and sweeping off a set we have not read would submit the wrong ids.

## Gating

Both options are swaps with CoinOS, so the dialog only appears when CoinOS is connected. Without it the fallback toast is still the honest answer, and it now quotes the same floor as the guard that fired it rather than contradicting it.

## The swap screen has to know why it was opened

Reported from device: the top-up option opened a screen titled **"Lightning Swap"** that then warned the user off the amount it had just prefilled for them.

Anything under 700 sats into Ark trips `smallBarkSwapWarn`, which drives three signals at once: a yellow dust caution, a yellow CTA, and the CTA text **"Swap anyways"**. All three frame the action as a mistake being overridden. On the dust top-up they are all wrong, because the dialog computed that amount, capped it under the refresh floor, and sent the user here specifically to deposit a small sum.

Adds an explicit `purpose` route param (`'dust-topup' | 'dust-exit'`) rather than inferring the flow. Inference is wrong twice over: another caller passing `prefillSats` would silently inherit dust copy, and the rail pair cannot tell a deliberate 319-sat top-up from a user typing 319 by hand, which is exactly the case the warning exists to catch.

- **Title** is per flow: `Dust Top-up`, `Move Dust Out`, or the existing `Lightning Swap`.
- **Warning suppressed on the top-up path only.** Every other small-amount swap still gets it.
- **Replaced with the reason**, since the screen otherwise offered no explanation for the odd prefilled number:

> This is meant to be small. It has to stay under 500 sats to combine with the dust you already have.

## Known gap, now closed

The previous revision listed this as unfixed: if the topped-up sats land at or above the 500 floor, the capsule is not dust, will not join the batch, and the sweep still refuses.

The top-up now carries `maxSats: ARK_REFRESH_MIN_SATS - 1`, the same ceiling the shortfall is computed against. The field stays editable and the user can still reduce it, but overshooting snaps back rather than silently defeating the sweep armed on return.

## Merge note

Conflicts with #261 on the `smallBarkSwapWarn` line: that PR changes `<=` to `<`, this one prepends `!isDustTopup &&`. **Both are wanted.** Resolved form:

```ts
!isDustTopup && sendTo === 'ark' && currentSats > 0 && currentSats < SMALL_RECEIVE_SATS
```

## Verification

- `tsc --noEmit`: **402**, identical to baseline. Zero errors in the changed file.
- Top-up/batch arithmetic proven exhaustively over the full `1..499` range.
- Dialog threshold confirmed against the live device case that exposed it (381 sats).

## Not done

Nothing outstanding. The follow-through **has now run end to end on device** (2026-09-10), read back off the live store rather than inferred from the UI:

```
vtxos      = 319:Spendable, 381:Spendable, 698:Spendable
dust (<500)= 319 + 381 = 700
refreshing = 319 yes, 381 yes, 698 no
balance    = 1398 total / 1398 spendable
```

Reading that in order: the dialog fired on a lone 381-sat capsule, the 319-sat top-up **landed as dust** rather than as a healthy capsule (which is what the `maxSats` ceiling exists to guarantee, and the case the old known-gap warned about), the returning screen consumed the one-shot flag, and the sweep submitted against both dust capsules and nothing else. The 698 was correctly left alone.

The round itself still has to finalise, which takes about an hour and is the ASP's business, not this PR's.


