### PR TITLE
release: 0.1.10 (vc38, iOS build 21) - integrate #254-#268

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,8 +99,8 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 37
-        versionName "0.1.9"
+        versionCode 38
+        versionName "0.1.10"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         missingDimensionStrategy 'react-native-camera', 'general' //add this line

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 				4B36CFF6FE55027DCA5CB6E1 /* Upload Bugsnag dSYM */,
 				9FF41DE89C69AED2AC3BAA92 /* [CP] Embed Pods Frameworks */,
 				98840B4C0BAF250AB1154EC4 /* [CP] Copy Pods Resources */,
+				D69E95167DDF706690AF1C07 /* Debug only: allow local networking */,
 			);
 			buildRules = (
 			);
@@ -1073,6 +1074,25 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		D69E95167DDF706690AF1C07 /* Debug only: allow local networking */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Debug only: allow local networking";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Debug builds only. Permits cleartext HTTP to private-range addresses so a\n# physical device can reach the Metro dev server over the LAN. Release and\n# archive builds ship Info.plist exactly as committed, with neither key.\nif [ \"${CONFIGURATION}\" != \"Debug\" ]; then\n  exit 0\nfi\n\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nPB=/usr/libexec/PlistBuddy\nDESC=\"Development builds connect to a Metro server on your local network.\"\n\nif [ ! -f \"${PLIST}\" ]; then\n  echo \"warning: no Info.plist at ${PLIST}, skipping local networking patch\"\n  exit 0\nfi\n\n\"${PB}\" -c \"Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool true\" \"${PLIST}\" 2>/dev/null \\\n  || \"${PB}\" -c \"Set :NSAppTransportSecurity:NSAllowsLocalNetworking true\" \"${PLIST}\"\n\n\"${PB}\" -c \"Add :NSLocalNetworkUsageDescription string ${DESC}\" \"${PLIST}\" 2>/dev/null \\\n  || \"${PB}\" -c \"Set :NSLocalNetworkUsageDescription ${DESC}\" \"${PLIST}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -1192,7 +1192,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWallet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;
@@ -1216,7 +1216,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.9;
+				MARKETING_VERSION = 0.1.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1247,7 +1247,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWalletRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;
@@ -1266,7 +1266,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.9;
+				MARKETING_VERSION = 0.1.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1424,7 +1424,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = ZJTFQCTLVX;
@@ -1475,7 +1475,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = ZJTFQCTLVX;
@@ -1515,7 +1515,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWallet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;
@@ -1570,7 +1570,7 @@
 				CODE_SIGN_ENTITLEMENTS = BlueWallet/BlueWalletRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8J926CQQU9;
 				ENABLE_BITCODE = NO;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypherbox",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypherbox",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypherbox",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/api/strikeAPIs.ts
+++ b/src/api/strikeAPIs.ts
@@ -197,10 +197,10 @@ export const sendStrikeLightningPayment = async (invoice: string, amount?: numbe
       // wallet card whose balance reads now-stale data.
       if (quoteResponse.status === 401) {
         useAuthStore.getState().clearStrikeAuth();
-        throw new Error('Strike session expired — please log into Strike again.');
+        throw new Error('Strike session expired. Please log into Strike again.');
       }
       throw new Error(
-        `Strike quote error: ${quoteResponse.status}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+        `Strike quote error: ${quoteResponse.status}${body ? `: ${body.slice(0, 200)}` : ''}`,
       );
     }
 
@@ -221,10 +221,10 @@ export const sendStrikeLightningPayment = async (invoice: string, amount?: numbe
       try { body = await executeResponse.text(); } catch { /* ignore */ }
       if (executeResponse.status === 401) {
         useAuthStore.getState().clearStrikeAuth();
-        throw new Error('Strike session expired — please log into Strike again.');
+        throw new Error('Strike session expired. Please log into Strike again.');
       }
       throw new Error(
-        `Strike execute error: ${executeResponse.status}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+        `Strike execute error: ${executeResponse.status}${body ? `: ${body.slice(0, 200)}` : ''}`,
       );
     }
     
@@ -467,13 +467,13 @@ export const getStrikePaymentStatus = async (paymentId: string): Promise<any> =>
         }));
         if (response.status === 401) {
             useAuthStore.getState().clearStrikeAuth();
-            throw new Error('Strike session expired — please log into Strike again.');
+            throw new Error('Strike session expired. Please log into Strike again.');
         }
         if (!response.ok) {
             let body = '';
             try { body = await response.text(); } catch { /* ignore */ }
             throw new Error(
-                `Strike payment-status error: ${response.status}${body ? ` — ${body.slice(0, 200)}` : ''}`,
+                `Strike payment-status error: ${response.status}${body ? `: ${body.slice(0, 200)}` : ''}`,
             );
         }
         return await response.json();

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -12,6 +12,7 @@ import {
     isVtxoMidRound,
     recoverArkOnchainBoard,
 } from "@Cypher/services/ark";
+import { deriveVaultConnectivity } from "@Cypher/services/ark/chainTipFreshness";
 import { getCapsuleColorBand } from "@Cypher/helpers/arkCapsuleColor";
 import { btc } from "@Cypher/helpers/bitcoinUnits";
 import useAuthStore from "@Cypher/stores/authStore";
@@ -65,6 +66,12 @@ export default function ArkWallet({
         reserveArkAmount,
         arkVtxos,
         arkChainTipHeight,
+        // Timestamps behind the card's connectivity dot. Both are only
+        // written on SUCCESS (tip on a good esplora read, sync at the end of
+        // a completed cycle), which is exactly what makes their AGE the
+        // signal: an outage stops updating them rather than recording itself.
+        arkChainTipHeightAt,
+        arkLastSyncedAt,
         arkRefreshingVtxoIds,
         arkBgRefreshEnabled,
         arkBgRefreshLastSuccessAt,
@@ -83,6 +90,35 @@ export default function ArkWallet({
     // which drains a stuck on-chain boarding deposit back to a fresh Hot
     // Vault change address. Same source HomeScreen uses to find the vault.
     const { wallets } = useContext(BlueStorageContext);
+
+    /**
+     * Slow clock for the connectivity dot.
+     *
+     * The dot has to be able to degrade with NO store activity at all. Both
+     * timestamps it reads are written only on success, so the exact failure it
+     * exists to report (sync loop wedged, esplora unreachable) is the one that
+     * produces no re-render. Without a tick of its own the card would hold its
+     * last green indefinitely while the vault sat dead, which is the failure
+     * direction that misleads.
+     *
+     * 30s matches the Capsules tab's tick. The thresholds are minutes wide, so
+     * anything faster is waste.
+     */
+    const [connTick, setConnTick] = useState(() => Date.now());
+    useEffect(() => {
+        const t = setInterval(() => setConnTick(Date.now()), 30_000);
+        return () => clearInterval(t);
+    }, []);
+
+    const vaultConnectivity = useMemo(
+        () =>
+            deriveVaultConnectivity({
+                tipFetchedAtMs: arkChainTipHeightAt,
+                lastSyncedAtMs: arkLastSyncedAt,
+                nowMs: connTick,
+            }),
+        [arkChainTipHeightAt, arkLastSyncedAt, connTick],
+    );
 
     // OS notification permission state for the bgRefreshStatus pill.
     // Drives the "Notifications off" branch that replaced the v0.1.1-dropped
@@ -617,6 +653,7 @@ export default function ArkWallet({
                             ? { count: pendingRoundCount, sats: pendingRoundSats }
                             : null}
                         arkCapsuleSlots={arkCapsuleSlots}
+                        vaultConnectivity={vaultConnectivity}
                     />
                     {/* When shared buttons are active (`hideActionButtons`),
                         skip this minHeight-40 reserve so the shared row can

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -72,6 +72,7 @@ export default function ArkWallet({
         // signal: an outage stops updating them rather than recording itself.
         arkChainTipHeightAt,
         arkLastSyncedAt,
+        arkSyncFailStreak,
         arkRefreshingVtxoIds,
         arkBgRefreshEnabled,
         arkBgRefreshLastSuccessAt,
@@ -116,8 +117,9 @@ export default function ArkWallet({
                 tipFetchedAtMs: arkChainTipHeightAt,
                 lastSyncedAtMs: arkLastSyncedAt,
                 nowMs: connTick,
+                syncFailStreak: arkSyncFailStreak,
             }),
-        [arkChainTipHeightAt, arkLastSyncedAt, connTick],
+        [arkChainTipHeightAt, arkLastSyncedAt, arkSyncFailStreak, connTick],
     );
 
     // OS notification permission state for the bgRefreshStatus pill.

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -347,7 +347,7 @@ export default function ArkWallet({
     }, [arkVtxos, arkChainTipHeight, refreshingIds]);
 
     const expiryWarning = soonestDaysLeft !== null && soonestDaysLeft < 7
-        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`
+        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d, refresh soon`
         : null;
 
     /**
@@ -499,7 +499,7 @@ export default function ArkWallet({
         //    enabling iCloud Drive). Android never sets this flag.
         if (Platform.OS === 'ios' && arkIosBackupReminderActive) {
             return {
-                text: 'Backup not synced — enable iCloud Drive in iOS Settings',
+                text: 'Backup not synced. Enable iCloud Drive in iOS Settings',
                 error: true,
             };
         }
@@ -815,7 +815,7 @@ export default function ArkWallet({
                         </Text>
                         <TouchableOpacity onPress={createArkWalletClickHandler}>
                             <Text bold style={styles.login}>
-                                ⚠ Experimental — tap to learn more
+                                ⚠ Experimental · tap to learn more
                             </Text>
                         </TouchableOpacity>
                     </View>

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -478,6 +478,27 @@ export default function ArkWallet({
      * subsumes it.
      */
     const bgRefreshStatus = useMemo(() => {
+        // 0. OFFLINE, ahead of everything below.
+        //
+        // Same branch and same copy as the shared-row version in WalletsView.
+        // It is here as well as there because the two layouts show different
+        // status rows, and a warning that exists in only one of them is
+        // invisible to whichever users are in the other. That is not
+        // hypothetical: the exit-fee reserve nudge lived in this file alone and
+        // no one in the default layout ever saw it.
+        //
+        // Everything below this point is derived from the cached chain tip, so
+        // when the vault is unreachable those numbers are projections rather
+        // than reads, and they keep counting down as if nothing were wrong.
+        if (vaultConnectivity.level === 'red') {
+            // COPY: Bam finalizes. Kept identical to WalletsView on purpose.
+            return {
+                text: 'Bark vault is offline. Capsule times shown are estimates until it reconnects.',
+                error: true,
+                tapTab: 0,
+            };
+        }
+
         // 1. Refresh / send / board in flight. Short-circuits the rest of
         //    the chain because the Card itself now renders a prominent
         //    pulsing "Refreshing N capsules · X sats" line inside the
@@ -554,6 +575,9 @@ export default function ArkWallet({
         arkIosBackupReminderActive,
         pendingRoundCount,
         pendingRoundSats,
+        // Or the offline branch never re-evaluates and the pill keeps showing
+        // whatever it said while the vault was last reachable.
+        vaultConnectivity,
     ]);
 
     // IMPORTANT: the parent's `convertedRate` prop is globally computed from

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -472,25 +472,37 @@ export default function Card({ onPress,
                     <Reanimated.View style={[styles.linearGradient2, { backgroundColor: colors.pink.dark, minWidth: 6 } as any, fillStyle]} />
                 </View>
             )}
-            {/* Vault connectivity, bottom-left. Last child of the card's
-                column, so it sits under the capsule slots without absolute
-                positioning that could ride over them on a narrow screen.
-                Deliberately small and quiet: on a healthy vault this is
-                reassurance the user should be able to ignore, and the loud
-                signal for an unhealthy one is the warning watermark behind
-                it rather than this line.
+            {/* Vault connectivity, bottom-right corner.
+                ABSOLUTE, not a flow child. `shadowTop` is a fixed 128pt box
+                (Card/styles.ts), so the card has no spare vertical room: an
+                appended row pushes past the border and gets clipped by it.
+                Anchoring to the container instead keeps the line inside the
+                card whatever the rows above it do. `right: 30` matches the
+                card's paddingHorizontal so it lines up with the brand mark
+                and the capsule slot row rather than the raw border edge,
+                since absolute children position against the padding box.
+
+                Quiet by design: on a healthy vault this is reassurance the
+                user can ignore, and the loud signal for an unhealthy one is
+                the warning watermark behind it rather than this line.
 
                 COPY: Bam finalizes. Same status vocabulary as the fuller
                 pill on the Capsules tab, shortened because the card is
                 already titled "Bark Vault" and repeating the noun here
                 reads as stutter. */}
             {vaultConnectivity && (
-                <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 10 }}>
+                <View style={{
+                    position: 'absolute',
+                    right: 30,
+                    bottom: 12,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                }}>
                     <View
                         style={{
-                            width: 7,
-                            height: 7,
-                            borderRadius: 3.5,
+                            width: 8,
+                            height: 8,
+                            borderRadius: 4,
                             marginRight: 6,
                             backgroundColor:
                                 vaultConnectivity.level === 'green'
@@ -502,7 +514,7 @@ export default function Card({ onPress,
                     />
                     <Text
                         style={{
-                            fontSize: 10,
+                            fontSize: 12,
                             fontWeight: '600',
                             color:
                                 vaultConnectivity.level === 'green'

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -11,6 +11,7 @@ import LinearGradient from "react-native-linear-gradient";
 import GradientButtonWithShadow from "../GradientButtonWithShadow";
 import styles from "./styles";
 import useAuthStore from "@Cypher/stores/authStore";
+import type { VaultConnectivity } from "@Cypher/services/ark/chainTipFreshness";
 import { CarouselPageVisibilityContext, useEasedProgress } from "@Cypher/custom-hooks";
 import { useIsFocused } from "@react-navigation/native";
 import Reanimated, { useAnimatedStyle } from "react-native-reanimated";
@@ -62,6 +63,17 @@ interface Props {
      * existing live caller renders the balance as before.
      */
     hideBalance?: boolean;
+    /**
+     * Vault connectivity for the Ark card's corner status line.
+     *
+     * Passed in rather than derived here because the derivation needs a slow
+     * clock of its own: if the sync loop is the thing that is wedged, no store
+     * write arrives to re-render us, so a component that only reacts to store
+     * changes would sit on a stale green forever. ArkWallet owns that tick.
+     *
+     * Null/undefined renders nothing, so every non-Ark caller is unaffected.
+     */
+    vaultConnectivity?: VaultConnectivity | null;
 }
 
 export default function Card({ onPress,
@@ -81,6 +93,7 @@ export default function Card({ onPress,
     refreshingInfo = null,
     arkCapsuleSlots,
     hideBalance = false,
+    vaultConnectivity = null,
 }: Props) {
     const {coldStorageWalletID, walletID, allBTCWallets} = useAuthStore();
 
@@ -212,26 +225,52 @@ export default function Card({ onPress,
 
     const cardChildren = (
         <>
-            {/* Translucent lightning watermark behind the card content —
-                mirrors the same treatment on the home "Unlock Lightning
-                Wallet" CTA so all Lightning surfaces share the visual
-                language. 12% alpha keeps it readable but lets the card's
-                pink (Strike/CoinOS) or grey (Ark) gradient show through. */}
-            <Image
-                source={Electricity}
-                style={{
-                    position: 'absolute',
-                    alignSelf: 'center',
-                    top: '50%',
-                    marginTop: -42,
-                    width: 60,
-                    height: 84,
-                    tintColor: '#FFFFFF',
-                    opacity: 0.10,
-                }}
-                resizeMode="contain"
-                pointerEvents="none"
-            />
+            {vaultConnectivity?.level === 'red' ? (
+                /* Offline vault: the watermark itself becomes the warning.
+                   A red dot in the corner is easy to miss on a card the user
+                   glances at, and the failure it reports is the one that reads
+                   most convincingly as normal — every expiry countdown keeps
+                   ticking off an estimated tip, so a stale card looks healthy.
+                   Swapping the lightning glyph for a warning sign changes the
+                   card's whole silhouette, which is noticeable without reading.
+                   Ionicons rather than a new asset: `warning` is already
+                   bundled and this needs no artwork. Carried at a higher alpha
+                   than the 0.10 lightning because it has to register, not
+                   recede. */
+                <View
+                    style={{
+                        position: 'absolute',
+                        alignSelf: 'center',
+                        top: '50%',
+                        marginTop: -42,
+                        opacity: 0.22,
+                    }}
+                    pointerEvents="none"
+                >
+                    <Ionicons name="warning" size={84} color="#FF7A68" />
+                </View>
+            ) : (
+                /* Translucent lightning watermark behind the card content —
+                    mirrors the same treatment on the home "Unlock Lightning
+                    Wallet" CTA so all Lightning surfaces share the visual
+                    language. 12% alpha keeps it readable but lets the card's
+                    pink (Strike/CoinOS) or grey (Ark) gradient show through. */
+                <Image
+                    source={Electricity}
+                    style={{
+                        position: 'absolute',
+                        alignSelf: 'center',
+                        top: '50%',
+                        marginTop: -42,
+                        width: 60,
+                        height: 84,
+                        tintColor: '#FFFFFF',
+                        opacity: 0.10,
+                    }}
+                    resizeMode="contain"
+                    pointerEvents="none"
+                />
+            )}
             <View style={styles.view}>
                 {wallet === 'ARK' ? (
                     // Boat-outline icon next to the "Ark Vault" title —
@@ -431,6 +470,54 @@ export default function Card({ onPress,
                         use a solid color and let the wrapper's percent
                         width control the fill. */}
                     <Reanimated.View style={[styles.linearGradient2, { backgroundColor: colors.pink.dark, minWidth: 6 } as any, fillStyle]} />
+                </View>
+            )}
+            {/* Vault connectivity, bottom-left. Last child of the card's
+                column, so it sits under the capsule slots without absolute
+                positioning that could ride over them on a narrow screen.
+                Deliberately small and quiet: on a healthy vault this is
+                reassurance the user should be able to ignore, and the loud
+                signal for an unhealthy one is the warning watermark behind
+                it rather than this line.
+
+                COPY: Bam finalizes. Same status vocabulary as the fuller
+                pill on the Capsules tab, shortened because the card is
+                already titled "Bark Vault" and repeating the noun here
+                reads as stutter. */}
+            {vaultConnectivity && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 10 }}>
+                    <View
+                        style={{
+                            width: 7,
+                            height: 7,
+                            borderRadius: 3.5,
+                            marginRight: 6,
+                            backgroundColor:
+                                vaultConnectivity.level === 'green'
+                                    ? '#4ADE80'
+                                    : vaultConnectivity.level === 'yellow'
+                                        ? colors.ark.light
+                                        : '#FF7A68',
+                        }}
+                    />
+                    <Text
+                        style={{
+                            fontSize: 10,
+                            fontWeight: '600',
+                            color:
+                                vaultConnectivity.level === 'green'
+                                    ? '#4ADE80'
+                                    : vaultConnectivity.level === 'yellow'
+                                        ? colors.ark.light
+                                        : '#FF7A68',
+                        }}
+                    >
+                        {vaultConnectivity.level === 'green'
+                            ? 'Connected'
+                            : vaultConnectivity.level === 'yellow'
+                                ? 'Connection slow'
+                                : 'Offline'}
+                    </Text>
                 </View>
             )}
         </>

--- a/src/components/GradientView/index.tsx
+++ b/src/components/GradientView/index.tsx
@@ -7,7 +7,6 @@ import {
     View,
 } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
-import { Shadow } from "react-native-neomorph-shadows";
 import styles from "./styles";
 
 interface Props extends TouchableOpacityProps {
@@ -21,6 +20,29 @@ interface Props extends TouchableOpacityProps {
     linearGradientStyleMain?: any;
     gradiantColors?: string[];
     isShadow?: boolean;
+}
+
+
+/**
+ * Strip shadow-only keys, keep everything else.
+ *
+ * The `topShadowStyle` / `bottomShadowStyle` props this component takes are not
+ * pure decoration: callers put the button's width, height, border radius and
+ * alignment in them too. Dropping the styles wholesale would resize every
+ * button in the app; keeping them wholesale would draw the very shadow being
+ * removed.
+ */
+function layoutOnly(input: any) {
+    const flat = StyleSheet.flatten(input) ?? {};
+    const {
+        shadowColor,
+        shadowOffset,
+        shadowOpacity,
+        shadowRadius,
+        elevation,
+        ...rest
+    } = flat as Record<string, unknown>;
+    return rest;
 }
 
 export default function GradientView({
@@ -52,26 +74,31 @@ export default function GradientView({
                     }
                     style={[styles.linearGradient, linearGradientStyleMain]}
                 >
-                    <Shadow
-                        inner // <- enable inner shadow
-                        useArt // <- set this prop to use non-native shadow on ios
-                        style={StyleSheet.flatten([styles.shadow, topShadowStyle])}
-                    >
-                        {/* Inner Shadow renders BEFORE children so the children
-                            paint on top. Under RN 0.77 Fabric the
-                            react-native-neomorph-shadows `useArt` fallback no
-                            longer renders a vector inset rim (ART module is
-                            gone in New Arch) — instead the Shadow paints a
-                            solid translucent overlay across its bounds.
-                            Painting it before children stops the colored tint
-                            from sitting on top of the button text (the
-                            blueish/greenish glow on the labels). */}
-                        <Shadow
-                            inner // <- enable inner shadow
-                            useArt // <- set this prop to use non-native shadow on ios
-                            style={StyleSheet.flatten([styles.innerShadow, bottomShadowStyle])} />
+                    {/* NO neumorphic rim. react-native-neomorph-shadows draws
+                        its inset rim through ART, which New Arch removed, so on
+                        RN 0.77 Fabric its `useArt` fallback paints a flat
+                        translucent overlay across its own bounds instead. That
+                        overlay is the green/blue haze reported over these
+                        button labels, and it was never the effect anyone asked
+                        for: it is the library failing.
+
+                        A previous pass moved the inner Shadow above {children}
+                        so the tint stopped covering the text. That helped but
+                        left the outer Shadow still painting, so the haze stayed,
+                        just behind the label rather than over it. Both are gone
+                        now.
+
+                        The wrapper survives as a plain View because these style
+                        objects carry LAYOUT as well as shadow (width, height,
+                        borderRadius, justifyContent), and 35 call sites depend
+                        on that sizing. `layoutOnly` keeps the geometry and drops
+                        the shadow keys, which also stops React Native drawing a
+                        real iOS shadow from them: several callers pass
+                        `shadowOpacity: 2`, which is outside the valid 0..1
+                        range and would render at full strength. */}
+                    <View style={layoutOnly([styles.shadow, topShadowStyle])}>
                         {children}
-                    </Shadow>
+                    </View>
                 </LinearGradient>
             </View>
         </TouchableOpacity>

--- a/src/components/LightningSendSuccess/index.tsx
+++ b/src/components/LightningSendSuccess/index.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Easing, Image, TouchableOpacity, View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+import { Text } from '@Cypher/component-library';
+import { Electricity, GradientShock } from '@Cypher/assets/images';
+import { colors } from '@Cypher/style-guide';
+
+import styles from './styles';
+
+/**
+ * Success view for a completed LIGHTNING send.
+ *
+ * Extracted from SwapAmount, which is where this treatment was built and the
+ * only place it lived. Bam's call (2026-09-09): it is the one to keep, so the
+ * Lightning send surfaces adopt it rather than each carrying their own.
+ *
+ * LIGHTNING ONLY, deliberately. On-chain sends keep the screens they already
+ * have. An on-chain payment is not final when the screen appears, and this
+ * view is built to read as finished: a bolt, "Lightning Network", and no room
+ * for the "waiting to confirm" caveat that path needs. ArkSendSuccessScreen
+ * still owns the on-chain and exit-fee-top-up cases for exactly that reason.
+ *
+ * Two shapes of caption, because two things reach here:
+ *
+ *   a send   `paidTo` + `fromLabel` -> "Paid to satoshi@blink.me"
+ *                                      "from Bark Vault"
+ *   a swap   `detail` -> the caller's own node, e.g. the from/to provider
+ *            badges, since a swap's destination is another of the user's own
+ *            wallets and an address would be meaningless.
+ */
+interface Props {
+    /** Net sats actually sent. */
+    sats: string | number;
+    /** Fiat equivalent, already formatted to 2dp. */
+    fiat: string;
+    /** Currency symbol to prefix the fiat line with, e.g. "$". */
+    fiatSymbol?: string;
+    title?: string;
+    /** Realised network fee. Only rails that report one pass this. */
+    feeSats?: number | null;
+    /** Trailing note on the fee line, e.g. a provider caveat. */
+    feeNote?: string | null;
+    /** Payment destination, shown as "Paid to <x>". */
+    paidTo?: string;
+    /** Source wallet, shown as "from <x>". */
+    fromLabel?: string;
+    /** Caller-supplied caption, used instead of paidTo/fromLabel. */
+    detail?: React.ReactNode;
+    networkLabel?: string;
+    onHome(): void;
+    homeLabel?: string;
+}
+
+export default function LightningSendSuccess({
+    sats,
+    fiat,
+    fiatSymbol = '$',
+    title = 'Payment Sent ⚡',
+    feeSats = null,
+    feeNote = null,
+    paidTo,
+    fromLabel,
+    detail,
+    networkLabel = 'Lightning Network',
+    onHome,
+    homeLabel = 'Home',
+}: Props) {
+    const slideAnim = useRef(new Animated.Value(300)).current;
+    const fadeAnim = useRef(new Animated.Value(0)).current;
+    const ring1Scale = useRef(new Animated.Value(1)).current;
+    const ring1Opacity = useRef(new Animated.Value(0.8)).current;
+    const ring2Scale = useRef(new Animated.Value(1)).current;
+    const ring2Opacity = useRef(new Animated.Value(0.8)).current;
+
+    useEffect(() => {
+        Animated.parallel([
+            Animated.timing(slideAnim, {
+                toValue: 0,
+                duration: 600,
+                easing: Easing.out(Easing.cubic),
+                useNativeDriver: true,
+            }),
+            Animated.timing(fadeAnim, {
+                toValue: 1,
+                duration: 600,
+                easing: Easing.out(Easing.cubic),
+                useNativeDriver: true,
+            }),
+        ]).start();
+
+        // Each ring expands and fades, then snaps back to full size and
+        // opacity in a zero-duration step before repeating. The second ring is
+        // offset by 700ms so the two read as a pulse rather than one thick edge.
+        const createRingAnimation = (
+            scale: Animated.Value,
+            opacity: Animated.Value,
+            delay: number,
+        ) =>
+            Animated.loop(
+                Animated.sequence([
+                    Animated.delay(delay),
+                    Animated.parallel([
+                        Animated.timing(scale, {
+                            toValue: 1.8,
+                            duration: 2000,
+                            easing: Easing.out(Easing.ease),
+                            useNativeDriver: true,
+                        }),
+                        Animated.timing(opacity, {
+                            toValue: 0,
+                            duration: 2000,
+                            easing: Easing.out(Easing.ease),
+                            useNativeDriver: true,
+                        }),
+                    ]),
+                    Animated.parallel([
+                        Animated.timing(scale, { toValue: 1, duration: 0, useNativeDriver: true }),
+                        Animated.timing(opacity, { toValue: 0.8, duration: 0, useNativeDriver: true }),
+                    ]),
+                ]),
+            );
+
+        const a = createRingAnimation(ring1Scale, ring1Opacity, 0);
+        const b = createRingAnimation(ring2Scale, ring2Opacity, 700);
+        a.start();
+        b.start();
+        // Stop on unmount. The originals looped forever against a screen that
+        // was about to be reset away, which kept a native driver animation
+        // running behind Home.
+        return () => {
+            a.stop();
+            b.stop();
+        };
+    }, [slideAnim, fadeAnim, ring1Scale, ring1Opacity, ring2Scale, ring2Opacity]);
+
+    const satsNum = Number(sats) || 0;
+    const feeRow = (() => {
+        if (feeSats === null || feeSats === undefined || feeSats <= 0) return null;
+        // Percentage of the total debited, matching the pre-send preview and
+        // the ArkSendScreen fee row so the same number reads the same way
+        // across every surface.
+        const gross = satsNum + feeSats;
+        const pct = gross > 0 ? Math.min(999, (feeSats / gross) * 100) : null;
+        const pctStr =
+            pct === null ? '' : pct < 0.01 ? ' (< 0.01%)' : ` (${pct.toFixed(pct < 1 ? 2 : 1)}%)`;
+        return (
+            <Text style={styles.fee}>
+                Network fee: {feeSats} sats{pctStr}{feeNote ? ` · ${feeNote}` : ''}
+            </Text>
+        );
+    })();
+
+    return (
+        <Animated.View
+            style={[styles.container, { transform: [{ translateY: slideAnim }], opacity: fadeAnim }]}
+        >
+            <Text semibold style={styles.title}>{title}</Text>
+            <Text semibold style={styles.value}>{satsNum.toLocaleString()} sats</Text>
+            <Text semibold style={styles.fiat}>{fiatSymbol}{fiat}</Text>
+            {feeRow}
+            <View style={styles.animationContainer}>
+                <Animated.View
+                    style={[styles.ring, { transform: [{ scale: ring1Scale }], opacity: ring1Opacity }]}
+                >
+                    <Image source={GradientShock} style={styles.ringImage} />
+                </Animated.View>
+                <Animated.View
+                    style={[styles.ring, { transform: [{ scale: ring2Scale }], opacity: ring2Opacity }]}
+                >
+                    <Image source={GradientShock} style={styles.ringImage} />
+                </Animated.View>
+                <Image source={Electricity} style={styles.boltImage} />
+            </View>
+            {detail ?? (
+                <View style={styles.detail}>
+                    {!!paidTo && (
+                        <Text style={styles.paidTo}>Paid to {paidTo}</Text>
+                    )}
+                    {!!fromLabel && (
+                        <Text style={styles.fromWallet}>from {fromLabel}</Text>
+                    )}
+                </View>
+            )}
+            <Text semibold style={styles.network}>{networkLabel}</Text>
+            <TouchableOpacity onPress={onHome} style={styles.homeButton}>
+                <LinearGradient
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    colors={[colors.pink.extralight, colors.pink.default]}
+                    style={styles.homeButtonGradient}
+                >
+                    <Text bold style={styles.homeText}>{homeLabel}</Text>
+                </LinearGradient>
+            </TouchableOpacity>
+        </Animated.View>
+    );
+}

--- a/src/components/LightningSendSuccess/styles.ts
+++ b/src/components/LightningSendSuccess/styles.ts
@@ -1,0 +1,99 @@
+import { StyleSheet } from 'react-native';
+
+/**
+ * Lifted verbatim from SwapAmount's inline success view, which is where this
+ * treatment started. Kept byte-identical on purpose: the swap screen now
+ * renders through this component, so any drift here would silently restyle it.
+ */
+export default StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        marginHorizontal: 20,
+    },
+    title: {
+        fontSize: 40,
+        lineHeight: 50,
+        marginBottom: 30,
+    },
+    value: {
+        fontSize: 42,
+        lineHeight: 52,
+    },
+    fiat: {
+        fontSize: 30,
+        lineHeight: 40,
+        color: '#AAAAAA',
+    },
+    fee: {
+        marginTop: 6,
+        fontSize: 14,
+        color: '#AAAAAA',
+        textAlign: 'center',
+    },
+    animationContainer: {
+        width: 200,
+        height: 200,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginVertical: 20,
+    },
+    ring: {
+        position: 'absolute',
+        width: 150,
+        height: 150,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    ringImage: {
+        width: 150,
+        height: 150,
+    },
+    boltImage: {
+        width: 80,
+        height: 85,
+        zIndex: 10,
+    },
+    detail: {
+        alignItems: 'center',
+        marginVertical: 20,
+    },
+    /**
+     * "Paid to <address>". Wraps rather than truncates: a BOLT11 invoice is
+     * long, and an ellipsis in the middle of a payment destination is the one
+     * place a user might actually want to read every character.
+     */
+    paidTo: {
+        fontSize: 15,
+        lineHeight: 21,
+        color: '#FFFFFF',
+        textAlign: 'center',
+        marginHorizontal: 10,
+    },
+    fromWallet: {
+        fontSize: 15,
+        lineHeight: 21,
+        color: '#AAAAAA',
+        textAlign: 'center',
+        marginTop: 4,
+    },
+    network: {
+        fontSize: 22,
+        lineHeight: 30,
+        color: '#AAAAAA',
+    },
+    homeButton: {
+        marginTop: 40,
+        width: '80%',
+    },
+    homeButtonGradient: {
+        borderRadius: 25,
+        height: 50,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    homeText: {
+        fontSize: 18,
+        color: '#FFFFFF',
+    },
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,6 +14,7 @@ export { default as GradientTabNew } from './GradientTabNew';
 export { default as GradientInput } from './GradientInput';
 export { default as GradientInputNew } from './GradientInputNew';
 export { default as CustomKeyboard } from './CustomKeyboard';
+export { default as LightningSendSuccess } from './LightningSendSuccess';
 export { default as Blink } from './Blink';
 export { default as SwipeButton } from './SwipeButton';
 export { default as RingEffect } from './RingEffect';

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -51,6 +51,8 @@ import { processArkMovementsForActivity } from '@Cypher/services/ark/movementsAc
 // Imported from the file path directly (not the @Cypher/services/ark
 // barrel) — the barrel doesn't re-export the expiry module.
 import { formatBlocksUntil } from '@Cypher/services/ark/expiry';
+// Also not re-exported through the barrel.
+import { shouldRescheduleExpiryWarning } from '@Cypher/services/ark/chainTipFreshness';
 import useAuthStore from '@Cypher/stores/authStore';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import {
@@ -1148,8 +1150,32 @@ export default function useArkSync(): UseArkSync {
                     const blocksLeft = v.expiryHeight - tip;
                     if (blocksLeft <= 0) continue;
                     const expiryAtMs = nowMs + blocksLeft * blockMs;
-                    nextScheduled[v.id] = expiryAtMs;
-                    if (needsScheduleMigration || prevScheduled[v.id] == null) {
+                    const previousAtMs = prevScheduled[v.id] ?? null;
+                    // Re-queue when our estimate of the deadline has moved.
+                    // Previously the guard was `prevScheduled[v.id] == null`
+                    // alone, which scheduled each VTXO exactly once and never
+                    // again: the estimate was recomputed every tick but the OS
+                    // alarms stayed pinned to the very first projection, and
+                    // the two were never compared. The 10-minute nominal block
+                    // interval means real expiry arrives EARLIER than that
+                    // first projection, so the drift always runs in the
+                    // direction that fires the warnings late. Re-queueing is
+                    // idempotent by id, so this replaces rather than stacks.
+                    const drifted = shouldRescheduleExpiryWarning({
+                        previousAtMs,
+                        currentAtMs: expiryAtMs,
+                    });
+                    const reschedule = needsScheduleMigration || drifted;
+                    // Carry the previous value forward when we are NOT
+                    // re-queueing. This map's documented contract is "the
+                    // expiry we scheduled FOR", and overwriting it with the
+                    // freshly recomputed estimate on every tick broke that in
+                    // two ways: drift became undetectable (each tick compared
+                    // against a value one tick old, never more than ~30s of
+                    // drift), and the map changed every tick, so the persisted
+                    // store took a write every 30s for no reason.
+                    nextScheduled[v.id] = reschedule ? expiryAtMs : (previousAtMs ?? expiryAtMs);
+                    if (reschedule) {
                         try {
                             // Pass per-VTXO sats so the notification title
                             // carries "{N} sats" instead of the generic

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -270,6 +270,7 @@ export default function useArkSync(): UseArkSync {
     const setArkPendingLnReceives = useAuthStore((s) => s.setArkPendingLnReceives);
     const setArkChainTipHeight = useAuthStore((s) => s.setArkChainTipHeight);
     const setArkLastSyncedAt = useAuthStore((s) => s.setArkLastSyncedAt);
+    const setArkSyncFailStreak = useAuthStore((s) => s.setArkSyncFailStreak);
     const setArkLastBackupAt = useAuthStore((s) => s.setArkLastBackupAt);
     const arkRoundIntervalSecs = useAuthStore((s) => s.arkRoundIntervalSecs);
     const setArkRoundIntervalSecs = useAuthStore((s) => s.setArkRoundIntervalSecs);
@@ -1567,6 +1568,10 @@ export default function useArkSync(): UseArkSync {
                 setArkChainTipHeight(tip);
             }
             setArkLastSyncedAt(Date.now());
+            // A completed tick is the only thing that clears the streak, so
+            // the connectivity dot recovers the moment the vault is reachable
+            // again rather than waiting for staleness to age out.
+            setArkSyncFailStreak(0);
             setLastError(null);
 
             // --- Soonest spendable expiry (feeds the failure escalation) ---
@@ -1698,6 +1703,12 @@ export default function useArkSync(): UseArkSync {
             }
         } catch (err) {
             console.warn('[Ark] sync failed:', err);
+            // Record the failure itself. Everything else here is written only
+            // on success, which left the UI inferring trouble from staleness
+            // and taking 20 minutes to admit a vault was offline. Read from
+            // the store rather than a closed-over value so the count is right
+            // even if this callback is stale.
+            setArkSyncFailStreak(useAuthStore.getState().arkSyncFailStreak + 1);
             setLastError(err instanceof Error ? err : new Error(String(err)));
         } finally {
             inFlight.current = false;
@@ -1710,6 +1721,7 @@ export default function useArkSync(): UseArkSync {
         setArkPendingLnReceives,
         setArkChainTipHeight,
         setArkLastSyncedAt,
+        setArkSyncFailStreak,
         setArkLastBackupAt,
         arkExitInProgress,
         arkExitDestinationAddress,

--- a/src/custom-hooks/useArkoorReceivePrompt.ts
+++ b/src/custom-hooks/useArkoorReceivePrompt.ts
@@ -9,8 +9,10 @@ import {
     ARK_REFRESH_MIN_SATS,
     ArkRefreshInFlightError,
     AVG_BLOCK_MINUTES,
+    buildDustSweepPlan,
     cancelVtxoExpiryWarnings,
     estimateArkRefreshFee,
+    maybeSweepDustArkVtxos,
     refreshArkVtxosDelegatedAndSync,
     scheduleVtxoExpiryWarnings,
 } from '@Cypher/services/ark';
@@ -421,6 +423,59 @@ export default function useArkoorReceivePrompt(): void {
                         })
                         .finally(release);
                     return;
+                }
+
+                // Before the notice: can the wallet fold this capsule in with
+                // the other dust instead? A Lightning receive is paid out of the
+                // ASP's VTXO pool and can arrive as several sub floor pieces (a
+                // 700 sat receive landed as a 300 and a 400), and each piece
+                // reaches this branch alone and unrefreshable. Together they are
+                // a dust only batch, which is the shape the ASP accepts. Telling
+                // the user to spend capsules the wallet is about to combine
+                // would be both alarming and wrong, so the sweep wins.
+                // Requires a known chain tip: without it a capsule that reports
+                // a real expiry height cannot be checked against the round
+                // window, and guessing there is what poisons a batch.
+                if (belowFloor && typeof tip === 'number') {
+                    const liveVtxos = useAuthStore.getState().arkVtxos ?? [];
+                    const refreshingIds = new Set(
+                        useAuthStore.getState().arkRefreshingVtxoIds ?? [],
+                    );
+                    const dustPlan = buildDustSweepPlan({
+                        vtxos: liveVtxos.map((v) => ({
+                            id: v.id,
+                            sats: v.sats,
+                            blocksUntilExpiry:
+                                v.expiryHeight > 0 ? v.expiryHeight - tip : null,
+                            stateTag: v.exiting ? 'exiting' : v.state,
+                            alreadyRefreshing: refreshingIds.has(v.id),
+                        })),
+                        exitInProgress: useAuthStore.getState().arkExitInProgress,
+                        minRefreshSats: ARK_REFRESH_MIN_SATS,
+                    });
+                    if (dustPlan.sweep && dustPlan.ids.includes(firstId)) {
+                        recordEvent({ kind: 'arkoor-prompt', outcome: 'auto-refresh', vtxoIdPrefix, sats: sats ?? undefined });
+                        // Optimistic, same as the single capsule path above: keep
+                        // it out of the next decision pass while the round runs.
+                        const curSweep = useAuthStore.getState().arkArkoorPromptState;
+                        const exSweep = curSweep[firstId];
+                        if (exSweep) {
+                            setArkArkoorPromptState({
+                                ...curSweep,
+                                [firstId]: { ...exSweep, status: 'refreshed' },
+                            });
+                        }
+                        SimpleToast.show(
+                            `Received ${amountPhrase}. Combining your small capsules to keep them longer.`,
+                            SimpleToast.SHORT,
+                        );
+                        // The sweep owns its own in-flight lock, pacing and
+                        // error reporting, so this is fire and forget. If it
+                        // cannot submit right now the foreground tick retries.
+                        void maybeSweepDustArkVtxos(liveVtxos, tip);
+                        release();
+                        return;
+                    }
                 }
 
                 // NOTICE path (too small to refresh, or the estimate would pull

--- a/src/screens/Account/ArkSeedPhraseScreen/index.tsx
+++ b/src/screens/Account/ArkSeedPhraseScreen/index.tsx
@@ -221,7 +221,7 @@ export default function ArkSeedPhraseScreen() {
     const ensureWalletCreated = async (): Promise<boolean> => {
         if (walletReady) return true;
         if (!mnemonic || !mnemonic.trim()) {
-            SimpleToast.show("No seed phrase available — go back and try again.", SimpleToast.LONG);
+            SimpleToast.show("No seed phrase available. Go back and try again.", SimpleToast.LONG);
             return false;
         }
         try {
@@ -386,7 +386,7 @@ export default function ArkSeedPhraseScreen() {
                 if (iCloudOn) {
                     setCloudBackupDone(true);
                     SimpleToast.show(
-                        'iCloud Drive is on for Cypher Box — backup syncs automatically.',
+                        'iCloud Drive is on for Cypher Box. Backup syncs automatically.',
                         SimpleToast.LONG,
                     );
                     return;
@@ -456,7 +456,7 @@ export default function ArkSeedPhraseScreen() {
                 case 'uploaded-and-verified':
                     setCloudBackupDone(true);
                     SimpleToast.show(
-                        "Backup uploaded to Google Drive and verified — it will keep updating automatically.",
+                        "Backup uploaded to Google Drive and verified. It will keep updating automatically.",
                         SimpleToast.LONG,
                     );
                     break;
@@ -532,7 +532,7 @@ export default function ArkSeedPhraseScreen() {
                 const message =
                     conflict.kind === 'different-wallet'
                         ? `A saved seed already exists on this device's ${keychainLabel} behind ${biometricLabel} for wallet ${conflict.existingFingerprint}.\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe.`
-                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe — it may otherwise be lost.`;
+                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe. It may otherwise be lost.`;
                 Alert.alert(
                     "Replace keychain-saved seed?",
                     message,
@@ -646,7 +646,7 @@ export default function ArkSeedPhraseScreen() {
                 case 'written-and-verified':
                     setSafBackupConfirmed(true);
                     SimpleToast.show(
-                        "Backup saved to your folder and verified — it will keep updating automatically.",
+                        "Backup saved to your folder and verified. It will keep updating automatically.",
                         SimpleToast.LONG,
                     );
                     break;
@@ -713,8 +713,8 @@ export default function ArkSeedPhraseScreen() {
             Alert.alert(
                 "Save your backup first",
                 isIOS
-                    ? "Your seed phrase alone can't restore Ark funds — the encrypted backup file is required too. Tap 'Save backup file' above and save it somewhere you trust (iCloud Drive recommended)."
-                    : "Your seed phrase alone can't restore Ark funds — the encrypted backup file is required too. Pick at least one: Google Drive (off-device), or a folder on this phone (survives uninstall).",
+                    ? "Your seed phrase alone can't restore Ark funds. The encrypted backup file is required too. Tap 'Save backup file' above and save it somewhere you trust (iCloud Drive recommended)."
+                    : "Your seed phrase alone can't restore Ark funds. The encrypted backup file is required too. Pick at least one: Google Drive (off-device), or a folder on this phone (survives uninstall).",
                 [{ text: "OK" }],
                 { cancelable: true },
             );
@@ -726,7 +726,7 @@ export default function ArkSeedPhraseScreen() {
         if (saveToKeychain) {
             const result = await persistToKeychain();
             if (result === 'error') {
-                SimpleToast.show("Keychain save failed — please back up manually", SimpleToast.LONG);
+                SimpleToast.show("Keychain save failed. Please back up manually", SimpleToast.LONG);
             }
             // 'cancelled' = user kept the existing keychain seed by
             // choice. Silent, not a failure.
@@ -820,7 +820,7 @@ export default function ArkSeedPhraseScreen() {
                     showsVerticalScrollIndicator={false}
                 >
                     <View style={styles.content}>
-                        <Text style={styles.sectionTitle}>1/2 — Seed phrase</Text>
+                        <Text style={styles.sectionTitle}>1/2 · Seed phrase</Text>
                         <Text style={styles.warnTitle}>⚠ Write these 12 words down</Text>
                         <Text style={styles.warnBody}>
                             Keep it safe and secure offline (paper and pen are good enough).
@@ -843,7 +843,7 @@ export default function ArkSeedPhraseScreen() {
                         )}
                         {keychainStatus === "err" && (
                             <Text style={styles.statusErr}>
-                                ✗ Keychain save failed — please back up the words manually
+                                ✗ Keychain save failed. Please back up the words manually
                             </Text>
                         )}
 
@@ -932,7 +932,7 @@ export default function ArkSeedPhraseScreen() {
                                      for Cypher Box). We can't probe the toggle,
                                      so the copy is honest about the conditional. */}
                         <Text style={[styles.sectionSub, { marginTop: 18 }]}>
-                            Lose the phone, though, and the local file goes with it —
+                            Lose the phone, though, and the local file goes with it,
                             and your seed alone can't restore Ark funds. Add an
                             optional off-device copy for device-loss protection:
                         </Text>
@@ -949,8 +949,8 @@ export default function ArkSeedPhraseScreen() {
                                 </Text>
                                 <Text style={styles.backupOptionDetail}>
                                     {isIOS
-                                        ? "Opens the share sheet so you can save the encrypted ark-backup file. We recommend saving inside iCloud Drive — Cypher Box will then keep it current automatically as your VTXO capsules change. Anywhere else (email, AirDrop, local Files) works for recovery too, but you'll need to re-export after every Lightning receive. Whoever stores it sees ciphertext only."
-                                        : "Connects your Google account and uploads your ark-backup file to Drive's appDataFolder — hidden from the main Drive UI, only Cypher Box can read it. Updates upload automatically as your VTXO capsules change. Google sees only ciphertext."}
+                                        ? "Opens the share sheet so you can save the encrypted ark-backup file. We recommend saving inside iCloud Drive, so Cypher Box keeps it current automatically as your VTXO capsules change. Anywhere else (email, AirDrop, local Files) works for recovery too, but you'll need to re-export after every Lightning receive. Whoever stores it sees ciphertext only."
+                                        : "Connects your Google account and uploads your ark-backup file to Drive's appDataFolder, hidden from the main Drive UI, only Cypher Box can read it. Updates upload automatically as your VTXO capsules change. Google sees only ciphertext."}
                                 </Text>
                                 <TouchableOpacity
                                     onPress={handleConnectAndBackupCloud}
@@ -1049,7 +1049,7 @@ export default function ArkSeedPhraseScreen() {
                                         {safBackupConfirmed ? "  ✓" : ""}
                                     </Text>
                                     <Text style={styles.backupOptionDetail}>
-                                        Pick a folder you control — for example
+                                        Pick a folder you control, for example
                                         Internal Storage → Documents → Backups.
                                         The encrypted file is written there
                                         whenever your wallet changes, and unlike
@@ -1134,7 +1134,7 @@ export default function ArkSeedPhraseScreen() {
                                 </Text>
                                 <Text style={styles.warnPanelBody}>
                                     Your seed phrase alone can't restore Ark
-                                    funds — Bark stores per-VTXO state in an
+                                    funds, because Bark stores per-VTXO state in an
                                     encrypted backup file we can't re-derive
                                     from the seed. Pick any one option above
                                     before creating the wallet.

--- a/src/screens/Account/RecoverArkScreen/index.tsx
+++ b/src/screens/Account/RecoverArkScreen/index.tsx
@@ -164,7 +164,7 @@ export default function RecoverArkScreen() {
         }
         if (!valid) {
             setErrorMsg(
-                "Invalid seed phrase. Double-check spelling — each word must be a BIP39 word.",
+                "Invalid seed phrase. Double-check spelling. Each word must be a BIP39 word.",
             );
             return null;
         }
@@ -242,7 +242,7 @@ export default function RecoverArkScreen() {
                 const message =
                     conflict.kind === 'different-wallet'
                         ? `A saved seed already exists on this device's ${keychainLabel} behind ${BIOMETRIC_LABEL} for wallet ${conflict.existingFingerprint}.\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe.`
-                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe — it may otherwise be lost.`;
+                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe. It may otherwise be lost.`;
                 Alert.alert(
                     "Replace keychain-saved seed?",
                     message,
@@ -382,7 +382,7 @@ export default function RecoverArkScreen() {
                 setRestoring(false);
                 setErrorMsg(
                     `Backup file is corrupt: ${err?.message ?? 'decryption failed'}. ` +
-                    `Try a different backup source — Drive, iCloud, or pick a manually-exported file.`,
+                    `Try a different backup source: Drive, iCloud, or pick a manually-exported file.`,
                 );
                 return true; // handled (with error); don't keep scanning
             }
@@ -616,7 +616,7 @@ export default function RecoverArkScreen() {
             setRestoring(false);
             setErrorMsg(
                 `Couldn't read backup from iCloud Drive: ${err?.message ?? 'unknown error'}. ` +
-                `Make sure iCloud Drive is enabled for Cypher Box, then tap again — ` +
+                `Make sure iCloud Drive is enabled for Cypher Box, then tap again. ` +
                 `the picker should show "iCloud Drive → Cypher Box → ark-backup-{fingerprint}.cbark".`,
             );
             return;
@@ -661,7 +661,7 @@ export default function RecoverArkScreen() {
         }
         if (!valid) {
             setErrorMsg(
-                "Invalid seed phrase. Double-check spelling — each word must be a BIP39 word.",
+                "Invalid seed phrase. Double-check spelling. Each word must be a BIP39 word.",
             );
             return;
         }
@@ -669,7 +669,7 @@ export default function RecoverArkScreen() {
         if (datadirExists) {
             Alert.alert(
                 "An Ark wallet already exists",
-                "There's already an Ark wallet set up on this device. Open it first to reset before restoring from backup — otherwise the existing wallet stays.",
+                "There's already an Ark wallet set up on this device. Open it first to reset before restoring from backup. Otherwise the existing wallet stays.",
                 [
                     { text: "Cancel", style: "cancel" },
                     { text: "Open setup", onPress: () => dispatchNavigate("CreateArkScreen") },
@@ -692,7 +692,7 @@ export default function RecoverArkScreen() {
                 const message =
                     conflict.kind === 'different-wallet'
                         ? `A saved seed already exists on this device's ${keychainLabel} behind ${BIOMETRIC_LABEL} for wallet ${conflict.existingFingerprint}.\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe.`
-                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe — it may otherwise be lost.`;
+                        : `A saved seed already exists on this device's ${keychainLabel} but couldn't be read to compare (${conflict.reason}).\n\nIf you want the new seed to take its place, make sure the old seed is written down somewhere safe. It may otherwise be lost.`;
                 Alert.alert(
                     "Replace keychain-saved seed?",
                     message,
@@ -732,7 +732,7 @@ export default function RecoverArkScreen() {
             setSubmitting(false);
             setErrorMsg(
                 /Internal/i.test(msg)
-                    ? "Couldn't open or create the Ark wallet — local state may be stale. Open the setup screen and tap Reset, then try again."
+                    ? "Couldn't open or create the Ark wallet. Local state may be stale. Open the setup screen and tap Reset, then try again."
                     : `Recovery failed: ${msg}`,
             );
             return;
@@ -841,7 +841,7 @@ function ChooseView({
                 Restore your Ark wallet
             </Text>
             <Text style={styles.introBody}>
-                {`Your Ark seed phrase is in this device's Keychain — you don't need to type it. Tap unlock below to load the seed via ${BIOMETRIC_LABEL} / passcode.\n\nVTXO capsules can't be re-derived from the seed alone, so you'll also need your ark-backup file — from ${cloudLabel} (if you connected it earlier) or a manual export.`}
+                {`Your Ark seed phrase is in this device's Keychain, so you don't need to type it. Tap unlock below to load the seed via ${BIOMETRIC_LABEL} / passcode.\n\nVTXO capsules can't be re-derived from the seed alone, so you'll also need your ark-backup file, from ${cloudLabel} (if you connected it earlier) or a manual export.`}
             </Text>
 
             {!unlockedMnemonic && (
@@ -869,7 +869,7 @@ function ChooseView({
                     }}
                 >
                     <Text style={{ color: colors.green, fontSize: 12 }}>
-                        ✓ Seed unlocked — ready to restore
+                        ✓ Seed unlocked, ready to restore
                     </Text>
                 </View>
             )}
@@ -986,7 +986,7 @@ function TypeSeedView({
                 Type your 12-word Ark seed phrase
             </Text>
             <Text style={styles.introBody}>
-                Enter the words exactly as you wrote them down — order matters. Tap space or return to jump to the next box.
+                Enter the words exactly as you wrote them down. Order matters. Tap space or return to jump to the next box.
                 {"\n\n"}
                 Note: VTXO capsules cannot be recovered from the seed alone. To restore your funds, also restore from your ark-backup file (the buttons below).
             </Text>

--- a/src/screens/Ark/ArkCapsulesInfoScreen/index.tsx
+++ b/src/screens/Ark/ArkCapsulesInfoScreen/index.tsx
@@ -158,7 +158,7 @@ export default function ArkCapsulesInfoScreen() {
                     </Body>
                     <Body>
                         Second.tech sets these fees, not Cypher Box, and can change them at
-                        any time. The figures below were checked in August 2026. For the
+                        any time. The figures below were checked in September 2026. For the
                         current schedule, see:
                     </Body>
                     <LinkRow label="second.tech/pricing" url={SECOND_FEES_URL} />
@@ -172,7 +172,7 @@ export default function ArkCapsulesInfoScreen() {
                     />
                     <FeeRow
                         title="Refreshing"
-                        body="Free within 2 days of expiry. 0.2% with under 7 days left, 0.4% with under 14 days left, 0.5% at 14 days or more. The reminders fire inside the cheapest part of that range, so following them costs little or nothing."
+                        body="0.2% with under 2 days left, 0.4% from 2 to 7 days, and 0.5% with more than 7 days left. Refreshing is free while a capsule is inside the short grace window just after expiry. Refreshing early costs the most, so waiting for a reminder is cheaper than refreshing on sight. Reminders fire inside the 0.2% band."
                     />
                     <FeeRow
                         title="Sending over Lightning"

--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -50,7 +50,11 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
     // Small-amount warning: in sats mode the typed value is the sat amount; in
     // fiat mode CustomKeyboard mirrors the sat equivalent into `usd`.
     const currentSats = Math.round(isSats ? Number(sats) : Number(usd)) || 0;
-    const smallAmountWarn = currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
+    // Strictly below the floor. 700 is the amount the warning tells users to
+    // reach, so warning AT 700 contradicted its own advice: you typed the
+    // number it asked for and it still called the amount small. 699 warns,
+    // 700 does not.
+    const smallAmountWarn = currentSats > 0 && currentSats < SMALL_RECEIVE_SATS;
 
     const handleCreate = async () => {
         if (!sats) {
@@ -139,7 +143,7 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
             </View>
             {smallAmountWarn && (
                 <Text style={{ textAlign: 'center', marginHorizontal: 24, marginBottom: 6, fontSize: 12, color: '#FFD54F', lineHeight: 17 }}>
-                    Small amounts can leave un-refreshable dust that expires. Receiving above 700 sats keeps them refreshable.
+                    Small amounts can leave un-refreshable dust that expires. Receiving 700 sats or more keeps them refreshable.
                 </Text>
             )}
             <CustomKeyboard

--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -158,6 +158,14 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
                 currency={currency}
                 colors_={ARK_GRADIENT}
                 buttonColors_={smallAmountWarn ? WARN_YELLOW : undefined}
+                // The button's title defaults to white, and both gradients it
+                // can wear here are light: ARK_GRADIENT is #FFFFFF to #E6E6E6
+                // and WARN_YELLOW is #FFD54F to #FFB300. White on either is
+                // invisible, so once an amount was entered the CTA read as a
+                // blank slab. Disabled keeps white, because GradientButton
+                // swaps to a grey fill in that state. Same pattern as
+                // ArkSendScreen's CTA.
+                titleColor={sats.length && !isLoading ? colors.black.default : colors.whiteText}
                 // Invoices have no "max" semantics — the receiver picks
                 // any amount they want to be paid. MAX is a send-side
                 // affordance (drain the wallet); suppress it on receive.

--- a/src/screens/Ark/ArkSendReviewScreen/index.tsx
+++ b/src/screens/Ark/ArkSendReviewScreen/index.tsx
@@ -171,10 +171,28 @@ export default function ArkSendReviewScreen({ route }: Props) {
             const result = await executeArkSend(destination, amountSats);
             const netSats = result.netAmountSats;
             const fiat = (netSats * matchedRate * btc(1)).toFixed(2);
+            // Only the Lightning rails take the shared success view. An
+            // Ark-to-Ark or on-chain send keeps the existing screen, which is
+            // the one that can say an on-chain payment still has to confirm.
+            const isLightning =
+                destination.kind === 'ln-invoice' ||
+                destination.kind === 'ln-offer' ||
+                destination.kind === 'ln-address';
             dispatchNavigate('ArkSendSuccessScreen', {
                 value: String(netSats),
                 valueUsd: fiat,
                 currency,
+                isLightning,
+                // An ln-address is short and worth reading in full. A BOLT11
+                // invoice is not, so show the shortened form for those; the
+                // user is confirming what they already reviewed, not auditing
+                // an address they have never seen.
+                paidTo: isLightning
+                    ? (destination.kind === 'ln-address'
+                        ? destination.value
+                        : `${destinationRaw.slice(0, 12)}…${destinationRaw.slice(-8)}`)
+                    : undefined,
+                fromLabel: isLightning ? 'Bark Vault' : undefined,
             });
         } catch (err: any) {
             console.error('[ArkSendReview] send failed:', err);

--- a/src/screens/Ark/ArkSendSuccessScreen/index.tsx
+++ b/src/screens/Ark/ArkSendSuccessScreen/index.tsx
@@ -8,7 +8,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { ScreenLayout, Text } from '@Cypher/component-library';
-import { GradientButton, GradientCard } from '@Cypher/components';
+import { GradientButton, GradientCard, LightningSendSuccess } from '@Cypher/components';
 import Ring from '@Cypher/components/RingEffect';
 import { Bitcoin, BitcoinTower, Electrik } from '@Cypher/assets/images';
 import { dispatchReset } from '@Cypher/helpers/navigation';
@@ -62,6 +62,17 @@ interface Props {
             networkLabel?: string;
             isOnchain?: boolean;
             note?: string;
+            /**
+             * True only for a Lightning rail (invoice, offer, ln-address).
+             * Opt-in rather than inferred: an Ark-to-Ark or on-chain send must
+             * not take the Lightning view, and defaulting this to true would
+             * hand it to every caller that has not been updated.
+             */
+            isLightning?: boolean;
+            /** Destination, for "Paid to <x>". */
+            paidTo?: string;
+            /** Source wallet, for "from <x>". */
+            fromLabel?: string;
         };
     };
 }
@@ -74,6 +85,9 @@ export default function ArkSendSuccessScreen({ route }: Props) {
     const networkLabel = route?.params?.networkLabel ?? 'Lightning Network';
     const isOnchain = route?.params?.isOnchain === true;
     const note = route?.params?.note;
+    const isLightning = route?.params?.isLightning === true;
+    const paidTo = route?.params?.paidTo;
+    const fromLabel = route?.params?.fromLabel;
 
     const [response, setResponse] = useState(false);
     const fadeInOpacity = useSharedValue(0);
@@ -98,6 +112,33 @@ export default function ArkSendSuccessScreen({ route }: Props) {
     }));
 
     const onHome = () => dispatchReset('HomeScreen');
+
+    // Lightning sends use the shared success view (Bam's call, 2026-09-09):
+    // one treatment across Strike, CoinOS and Bark instead of three.
+    //
+    // Everything else keeps the screen below, and that is the point of the
+    // gate rather than an oversight. The on-chain cases that land here, an
+    // on-chain send and the exit-fee top-up, are NOT final when this appears.
+    // The shared view is built to read as finished, carries a bolt and says
+    // "Lightning Network", and has nowhere to put the "has to confirm first"
+    // note those paths depend on. It already cost one user a screen that said
+    // "Payment Sent / 0 sats / Lightning Network" over an on-chain deposit.
+    if (isLightning && !isOnchain) {
+        return (
+            <ScreenLayout disableScroll showToolbar title="" isBackButton={false}>
+                <LightningSendSuccess
+                    title={title}
+                    sats={value}
+                    fiat={valueUsd}
+                    fiatSymbol={getStrikeCurrency(currency)}
+                    paidTo={paidTo}
+                    fromLabel={fromLabel}
+                    networkLabel={networkLabel}
+                    onHome={onHome}
+                />
+            </ScreenLayout>
+        );
+    }
 
     return (
         <ScreenLayout disableScroll showToolbar title="" isBackButton={false}>

--- a/src/screens/HomeScreen/Header/index.tsx
+++ b/src/screens/HomeScreen/Header/index.tsx
@@ -128,8 +128,8 @@ export default React.memo(function Header({
         if (!vaultWallet) {
             SimpleToast.show(
                 which === 'hot'
-                    ? 'Hot Vault not ready — open the vault once and try again.'
-                    : 'Cold Vault not ready — open the vault once and try again.',
+                    ? 'Hot Vault not ready. Open the vault once and try again.'
+                    : 'Cold Vault not ready. Open the vault once and try again.',
                 SimpleToast.LONG,
             );
             return;

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -1003,7 +1003,11 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         backgroundColor="white"
                       />
                     </View>
-                    <Text semibold style={styles.bitcoinAddressText}>
+                    {/* Its own style rather than the address one it used to
+                        borrow: at the address's 18pt this caption wrapped onto
+                        a second line and pushed the panel taller for no reason.
+                        It is a caption, so it is sized like one. */}
+                    <Text semibold style={styles.addressCaption} numberOfLines={1}>
                       Receive 0% fee payments from another Bark user
                     </Text>
                   </>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -712,7 +712,7 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
             {selectedItem === 5 && tab === 2 && (
               <Text
                 center
-                style={{ marginHorizontal: 24, marginTop: 8, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
+                style={{ marginHorizontal: 24, marginTop: 2, fontSize: 12, color: '#FFD54F', opacity: 0.95, lineHeight: 17 }}
               >
                 To receive 700-sat or above capsule from another Bark user. Need to be present with the app being open when you receive to this address.
               </Text>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -995,17 +995,17 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         </Text>
                       </View>
                     )}
-                    {/* 120. It was 50, which was unscannable, and 150 was
-                        overcorrected and dominated the sheet. 120 sits just
-                        above the Bitcoin tab's 100 on purpose: an Ark address
-                        carries more data than an on-chain one, so the same
-                        square holds more modules and needs a little more room
-                        per module. The white quiet zone around it matters to a
-                        decoder as much as the size does, hence the padding. */}
+                    {/* 100, matching the Bitcoin tab in this same sheet. It
+                        was 50, which was unscannable because an Ark address
+                        packs more modules into the square than an on-chain one
+                        and each fell under a pixel. 150 and 120 were both too
+                        large for the panel. 100 is the floor I would not go
+                        below: the white quiet zone around it matters to a
+                        decoder as much as the size, hence the padding. */}
                     <View style={{ marginTop: 12, padding: 8, backgroundColor: 'white', borderRadius: 8 }}>
                       <QRCode
                         value={arkAddress}
-                        size={120}
+                        size={100}
                         color="black"
                         backgroundColor="white"
                       />

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -1012,8 +1012,9 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               // tab above uses, and for the same reason: a transform moves what
               // is drawn without shifting the layout flow beneath it, so the
               // sheet's own height and the content under it stay put.
-              // Landed by eye: 50 rode too high, 40 sits right.
-              <View style={[styles.liquidTabContent, { transform: [{ translateY: -40 }] }]}>
+              // Landed by eye on device: 50 rode too high, 40 still high, 25 sits
+              // right.
+              <View style={[styles.liquidTabContent, { transform: [{ translateY: -25 }] }]}>
                 {arkAddressError ? (
                   <AddressFetchFailed
                     message={arkAddressError}

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -30,6 +30,8 @@ import {
 import { dispatchNavigate } from "@Cypher/helpers";
 import { FEATURE_ARK_ENABLED, fetchArkMinBoardSats, getArkAddress, getArkOnchainAddress } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
+import { describeArkFailure } from "@Cypher/services/ark/networkFault";
+import { ARK_SERVER_URL, ESPLORA_URLS } from "@Cypher/services/ark";
 import { colors } from "@Cypher/style-guide";
 import Clipboard from "@react-native-clipboard/clipboard";
 import styles from "./styles";
@@ -54,6 +56,35 @@ interface Props {
   initialVaultType?: 'hot' | 'cold' | null;
 }
 
+
+
+/**
+ * Address fetch failed, say so instead of spinning.
+ *
+ * The retry is deliberate and deliberately plain. Some causes clear by
+ * themselves (a quota window rolling over), some need the user to act (switch
+ * networks, open the vault), and `message` already carries which. The button
+ * only re-runs the fetch; it does not claim the retry will work.
+ */
+function AddressFetchFailed({ message, onRetry }: { message: string; onRetry(): void }) {
+    return (
+        <View style={{ paddingHorizontal: 24, alignItems: 'center' }}>
+            <Text center style={{ fontSize: 13, lineHeight: 18, color: '#FFD54F' }}>
+                {message}
+            </Text>
+            <TouchableOpacity
+                onPress={onRetry}
+                accessibilityRole="button"
+                hitSlop={{ top: 10, bottom: 10, left: 16, right: 16 }}
+                style={{ marginTop: 12 }}
+            >
+                <Text bold style={{ fontSize: 14, color: '#FFFFFF', textDecorationLine: 'underline' }}>
+                    Try again
+                </Text>
+            </TouchableOpacity>
+        </View>
+    );
+}
 
 export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, receiveType, wallet, coldStorageWallet, matchedRate, currency, vaultAddress = '', coldStorageAddress = '', initialVaultType = null }: Props) {
   const { user, strikeMe, strikeUser, vaultTab, setVaultTab, isAuth, isStrikeAuth, isArkAuth, walletID, coldStorageWalletID, allBTCWallets } = useAuthStore();
@@ -86,6 +117,20 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
   // characters of opaque hex that would dominate the sheet.
 
   const [arkAddressExpanded, setArkAddressExpanded] = useState(false);
+  /**
+   * Why the address could not be fetched, or null.
+   *
+   * Exists because a rejected fetch used to leave the panel on its spinner
+   * forever: the address state stayed empty, nothing rendered the failure, and
+   * the only signal was a toast that had already gone. A hard failure looked
+   * exactly like "still loading", which is the reading that costs the most time
+   * (observed 2026-09-09: two separate sessions spent chasing a spinner that
+   * was a network refusal).
+   */
+  const [arkAddressError, setArkAddressError] = useState<string | null>(null);
+  const [arkOnchainAddressError, setArkOnchainAddressError] = useState<string | null>(null);
+  /** Bumped by "Try again" so the fetch effect re-runs. */
+  const [addressReloadTick, setAddressReloadTick] = useState(0);
   const [showSecondView, setShowSecondView] = useState(initialVaultType !== null || allBTCWallets.length == 1 ? true : false);
   const [hashLiquid, setHashLiquid] = useState('');
   const [hashBitcoin, setHashBitcoin] = useState('');
@@ -144,24 +189,36 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
           getArkOnchainAddress(),
         ]);
         if (!mounted) return;
-        if (arkRes.status === 'fulfilled') setArkAddress(arkRes.value);
-        if (onchainRes.status === 'fulfilled') setArkOnchainAddress(onchainRes.value);
+        if (arkRes.status === 'fulfilled') {
+          setArkAddress(arkRes.value);
+          setArkAddressError(null);
+        }
+        if (onchainRes.status === 'fulfilled') {
+          setArkOnchainAddress(onchainRes.value);
+          setArkOnchainAddressError(null);
+        }
 
-        if (arkRes.status === 'rejected' || onchainRes.status === 'rejected') {
-          const reason = (arkRes.status === 'rejected' ? arkRes.reason : null)
-            ?? (onchainRes.status === 'rejected' ? onchainRes.reason : null);
-          console.warn('[Receive] Ark address fetch failed:', reason);
-          // Name the actual cause. "Failed to fetch Ark addresses" next to a
-          // spinner that never stops tells the user nothing they can act on,
-          // and the usual cause is simply that the wallet is not open yet.
-          const locked = /not initialized|not ready|no wallet/i.test(
-            String((reason as Error)?.message ?? reason ?? ''),
+        // Each rail records its OWN failure. They fail independently (the Ark
+        // address needs an open wallet and a reachable chain source, the
+        // on-chain one is a local BDK call), so a shared error would blame one
+        // for the other's problem.
+        //
+        // describeArkFailure rather than a hand-written line: it already knows
+        // the difference between a provider that is unreachable and one that is
+        // refusing us on quota, and those need opposite advice. The old copy
+        // said "Pull to retry" for both, which is precisely wrong for a quota
+        // rejection, where retrying is what keeps it refused.
+        const endpoints = { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL };
+        if (arkRes.status === 'rejected') {
+          console.warn('[Receive] Ark address fetch failed:', arkRes.reason);
+          setArkAddressError(
+            describeArkFailure(arkRes.reason, "Couldn't get a Bark address", endpoints),
           );
-          SimpleToast.show(
-            locked
-              ? 'Bark vault is locked. Open the vault first, then try again.'
-              : 'Could not fetch an address. Pull to retry.',
-            SimpleToast.LONG,
+        }
+        if (onchainRes.status === 'rejected') {
+          console.warn('[Receive] on-chain address fetch failed:', onchainRes.reason);
+          setArkOnchainAddressError(
+            describeArkFailure(onchainRes.reason, "Couldn't get an on-chain address", endpoints),
           );
         }
       })();
@@ -174,7 +231,7 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
     } else if (tab == 2) {
       handleCreateInvoice('liquid');
     }
-  }, [tab, selectedItem])
+  }, [tab, selectedItem, addressReloadTick])
 
   useEffect(() => {
     if(initialVaultType !== null || (allBTCWallets.length == 1 && !coldStorageWalletID && !walletID)) {
@@ -913,7 +970,15 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                 <Text semibold style={{ color: '#FFD54F', textAlign: 'center', fontSize: 13, paddingHorizontal: 16 }}>
                   ⚠️ Do not receive less than {minBoardSats.toLocaleString('en-US')} sats to this on-chain address
                 </Text>
-                {!arkOnchainAddress ? (
+                {arkOnchainAddressError ? (
+                  <AddressFetchFailed
+                    message={arkOnchainAddressError}
+                    onRetry={() => {
+                      setArkOnchainAddressError(null);
+                      setAddressReloadTick((n) => n + 1);
+                    }}
+                  />
+                ) : !arkOnchainAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (
                   <>
@@ -949,7 +1014,15 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               // sheet's own height and the content under it stay put.
               // Landed by eye: 50 rode too high, 40 sits right.
               <View style={[styles.liquidTabContent, { transform: [{ translateY: -40 }] }]}>
-                {!arkAddress ? (
+                {arkAddressError ? (
+                  <AddressFetchFailed
+                    message={arkAddressError}
+                    onRetry={() => {
+                      setArkAddressError(null);
+                      setAddressReloadTick((n) => n + 1);
+                    }}
+                  />
+                ) : !arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (
                   <>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -995,10 +995,16 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         </Text>
                       </View>
                     )}
-                    <View style={{ marginTop: 10, padding: 2, backgroundColor: 'white', borderRadius: 2 }}>
+                    {/* 150, up from 50. At 50 the QR was smaller than the
+                        Bitcoin tab's and too dense to scan reliably: an Ark
+                        address is long, so it packs more modules into the same
+                        square than an on-chain address does, and each module
+                        was under a pixel on a phone screen. The white quiet
+                        zone matters for the same reason, hence the padding. */}
+                    <View style={{ marginTop: 12, padding: 10, backgroundColor: 'white', borderRadius: 8 }}>
                       <QRCode
                         value={arkAddress}
-                        size={50}
+                        size={150}
                         color="black"
                         backgroundColor="white"
                       />

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -942,7 +942,12 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
             )}
 
             {selectedItem === 5 && tab === 2 && (
-              <View style={styles.liquidTabContent}>
+              // Lift the whole Bark tab body (address row, expanded address,
+              // QR, caption) up 50pt. Same paint-only translateY the Bitcoin
+              // tab above uses, and for the same reason: a transform moves what
+              // is drawn without shifting the layout flow beneath it, so the
+              // sheet's own height and the content under it stay put.
+              <View style={[styles.liquidTabContent, { transform: [{ translateY: -50 }] }]}>
                 {!arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -995,16 +995,17 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         </Text>
                       </View>
                     )}
-                    {/* 150, up from 50. At 50 the QR was smaller than the
-                        Bitcoin tab's and too dense to scan reliably: an Ark
-                        address is long, so it packs more modules into the same
-                        square than an on-chain address does, and each module
-                        was under a pixel on a phone screen. The white quiet
-                        zone matters for the same reason, hence the padding. */}
-                    <View style={{ marginTop: 12, padding: 10, backgroundColor: 'white', borderRadius: 8 }}>
+                    {/* 120. It was 50, which was unscannable, and 150 was
+                        overcorrected and dominated the sheet. 120 sits just
+                        above the Bitcoin tab's 100 on purpose: an Ark address
+                        carries more data than an on-chain one, so the same
+                        square holds more modules and needs a little more room
+                        per module. The white quiet zone around it matters to a
+                        decoder as much as the size does, hence the padding. */}
+                    <View style={{ marginTop: 12, padding: 8, backgroundColor: 'white', borderRadius: 8 }}>
                       <QRCode
                         value={arkAddress}
-                        size={150}
+                        size={120}
                         color="black"
                         backgroundColor="white"
                       />

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -78,6 +78,14 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
   if (__DEV__) console.log("🚀 ~ ReceivedListNew ~ selectedItem:", selectedItem);
 
   const [tab, setTab] = useState(0);
+
+  // Whether the Bark address is shown in full. Collapsed by default: the
+
+  // short form is what a returning user needs, and the full string is 60+
+
+  // characters of opaque hex that would dominate the sheet.
+
+  const [arkAddressExpanded, setArkAddressExpanded] = useState(false);
   const [showSecondView, setShowSecondView] = useState(initialVaultType !== null || allBTCWallets.length == 1 ? true : false);
   const [hashLiquid, setHashLiquid] = useState('');
   const [hashBitcoin, setHashBitcoin] = useState('');
@@ -590,6 +598,11 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                     bold
                     style={{
                       fontSize: 22,
+                      // Explicit lineHeight: without one, iOS lays a bold 22pt
+                      // face out in a box shorter than its ascenders and clips
+                      // the tops of the capitals. Only shows up on this label
+                      // because it is the largest text in the header row.
+                      lineHeight: 28,
                       color: '#FFFFFF',
                       letterSpacing: 0.5,
                     }}
@@ -627,6 +640,18 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                 address while the app is closed has no reminder attached to it at
                 all. Sits with the tip above rather than under the QR so the
                 advice reads as one block. COPY: Bam finalizes. */}
+            {/* Tabs */}
+            {tabs.length > 0 && (
+              <CustomTabView
+                tabs={tabs}
+                selectedTab={tab}
+                onTabChange={setTab}
+              />
+            )}
+
+            {/* Below the tabs, not above: it describes the Bark tab's
+                address, so it read as a caption for the tab row itself
+                when it sat on top of it. */}
             {selectedItem === 5 && tab === 2 && (
               <Text
                 center
@@ -636,14 +661,6 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
               </Text>
             )}
 
-            {/* Tabs */}
-            {tabs.length > 0 && (
-              <CustomTabView
-                tabs={tabs}
-                selectedTab={tab}
-                onTabChange={setTab}
-              />
-            )}
 
             {/* ---- Vault Sub-menu (Hot/Cold) ---- */}
             {(selectedItem === 3 || selectedItem === 4) && tab === 0 && (
@@ -926,25 +943,40 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
 
             {selectedItem === 5 && tab === 2 && (
               <View style={styles.liquidTabContent}>
-                <Text h2 bold>
-                  Bark Address
-                </Text>
                 {!arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (
                   <>
+                    {/* Label and address share one line. As two stacked blocks
+                        the heading took a full row to say something the address
+                        underneath already implied, and pushed the QR down. */}
                     <View style={styles.addressRow}>
-                      {/* Ark addresses are long opaque pubkey hex; the
-                          full string isn't human-verifiable anyway, so
-                          show first 6 + last 6 chars (e.g.
-                          "ark1ab…xyz999") to keep the row tidy. The
-                          tap-to-copy button below ships the full
-                          address to clipboard, unchanged. */}
-                      <Text semibold style={styles.bitcoinAddressText}>
-                        {arkAddress.length > 13
-                          ? `${arkAddress.slice(0, 6)}…${arkAddress.slice(-6)}`
-                          : arkAddress}
+                      <Text semibold style={styles.addressLabel}>
+                        Bark Address
                       </Text>
+                      {/* Ark addresses are long opaque pubkey hex and do not
+                          fit this row, so the row shows first 6 + last 6.
+                          Tapping expands the full string below rather than
+                          truncating it out of reach: the short form is fine for
+                          recognising an address you already have, and useless
+                          for reading one out. Copy still ships the full
+                          address, unchanged. */}
+                      <TouchableOpacity
+                        onPress={() => setArkAddressExpanded((v) => !v)}
+                        accessibilityRole="button"
+                        accessibilityLabel={
+                          arkAddressExpanded
+                            ? 'Hide the full Bark address'
+                            : 'Show the full Bark address'
+                        }
+                        style={styles.addressValueTap}
+                      >
+                        <Text semibold style={styles.bitcoinAddressText}>
+                          {arkAddress.length > 13
+                            ? `${arkAddress.slice(0, 6)}…${arkAddress.slice(-6)}`
+                            : arkAddress}
+                        </Text>
+                      </TouchableOpacity>
                       <TouchableOpacity onPress={() => {
                         Clipboard.setString(arkAddress);
                         SimpleToast.show('Copied to clipboard', SimpleToast.SHORT);
@@ -952,6 +984,17 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                         <Image source={Copy} style={styles.copyIconImage} />
                       </TouchableOpacity>
                     </View>
+
+                    {/* Expanded form. Wrapped rather than side-scrolled: the
+                        whole point is seeing the address at once, and a
+                        horizontal scroller hides how much is left. */}
+                    {arkAddressExpanded && (
+                      <View style={styles.fullAddressBox}>
+                        <Text style={styles.fullAddressText}>
+                          {arkAddress}
+                        </Text>
+                      </View>
+                    )}
                     <View style={{ marginTop: 10, padding: 2, backgroundColor: 'white', borderRadius: 2 }}>
                       <QRCode
                         value={arkAddress}

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -867,7 +867,7 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
                           Lightning invoice
                         </Text>
                         <Text h4 bold style={styles.invoiceCardDescription}>
-                          Receive Lightning payments into Ark — paid out as a VTXO once the next round commits.
+                          Receive Lightning payments into Ark, paid out as a VTXO once the next round commits.
                         </Text>
                       </View>
                       <View style={styles.socketIconContainer}>

--- a/src/screens/HomeScreen/ReceivedListNew/index.tsx
+++ b/src/screens/HomeScreen/ReceivedListNew/index.tsx
@@ -943,11 +943,12 @@ export default function ReceivedListNew({ setReceivedListSecondTab, refRBSheet, 
 
             {selectedItem === 5 && tab === 2 && (
               // Lift the whole Bark tab body (address row, expanded address,
-              // QR, caption) up 50pt. Same paint-only translateY the Bitcoin
+              // QR, caption) up 40pt. Same paint-only translateY the Bitcoin
               // tab above uses, and for the same reason: a transform moves what
               // is drawn without shifting the layout flow beneath it, so the
               // sheet's own height and the content under it stay put.
-              <View style={[styles.liquidTabContent, { transform: [{ translateY: -50 }] }]}>
+              // Landed by eye: 50 rode too high, 40 sits right.
+              <View style={[styles.liquidTabContent, { transform: [{ translateY: -40 }] }]}>
                 {!arkAddress ? (
                   <ActivityIndicator size="large" color="#ffffff" />
                 ) : (

--- a/src/screens/HomeScreen/ReceivedListNew/styles.ts
+++ b/src/screens/HomeScreen/ReceivedListNew/styles.ts
@@ -37,6 +37,10 @@ interface Style {
   lightningTabContent: ViewStyle;
   bitcoinTabContent: ViewStyle;
   bitcoinAddressText: TextStyle;
+  addressLabel: TextStyle;
+  addressValueTap: ViewStyle;
+  fullAddressBox: ViewStyle;
+  fullAddressText: TextStyle;
   liquidTabContent: ViewStyle;
 }
 
@@ -257,11 +261,40 @@ export default StyleSheet.create<Style>({
   liquidTabContent: {
     paddingHorizontal: 16,
     paddingBottom: 16,
-    height: 220,
+    // minHeight, not height: the expanded address adds a block below the row,
+    // and a fixed height clipped it.
+    minHeight: 220,
     alignItems: 'center'
   },
   bitcoinAddressText: {
     fontSize: 18,
     marginTop: 10,
+  },
+  addressLabel: {
+    fontSize: 15,
+    color: '#AAAAAA',
+    marginTop: 10,
+    marginRight: 8,
+  },
+  // flexShrink so a long address gives way to the label and the copy icon
+  // instead of pushing them off the row.
+  addressValueTap: {
+    flexShrink: 1,
+  },
+  fullAddressBox: {
+    marginTop: 10,
+    marginHorizontal: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.14)',
+  },
+  fullAddressText: {
+    fontSize: 12,
+    lineHeight: 17,
+    color: '#FFFFFF',
+    textAlign: 'center',
   },
 });

--- a/src/screens/HomeScreen/ReceivedListNew/styles.ts
+++ b/src/screens/HomeScreen/ReceivedListNew/styles.ts
@@ -41,6 +41,7 @@ interface Style {
   addressValueTap: ViewStyle;
   fullAddressBox: ViewStyle;
   fullAddressText: TextStyle;
+  addressCaption: TextStyle;
   liquidTabContent: ViewStyle;
 }
 
@@ -296,5 +297,12 @@ export default StyleSheet.create<Style>({
     lineHeight: 17,
     color: '#FFFFFF',
     textAlign: 'center',
+  },
+  addressCaption: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#AAAAAA',
+    textAlign: 'center',
+    marginTop: 10,
   },
 });

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -3,6 +3,7 @@ import { Text } from "@Cypher/component-library";
 import { Refresh } from "@Cypher/assets/images";
 import { ARK_REFRESH_MIN_SATS, FEATURE_ARK_ENABLED, areBgNotificationsEnabled, blocksToDays, cancelArkPendingRound, isVtxoMidRound, sumMidRoundVtxos } from "@Cypher/services/ark";
 import useAuthStore from "@Cypher/stores/authStore";
+import { deriveVaultConnectivity } from "@Cypher/services/ark/chainTipFreshness";
 import screenWidth from "@Cypher/style-guide/screenWidth";
 import { colors } from "@Cypher/style-guide";
 import { dispatchNavigate } from "@Cypher/helpers";
@@ -81,7 +82,38 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         arkRefreshStuck,
         setArkPendingOnchainRecoverOpen,
         arkExitFeeReserveSats,
+        // Behind the offline warning below. All three are written only on a
+        // SUCCESSFUL read, which is what makes their age the signal.
+        arkChainTipHeightAt,
+        arkLastSyncedAt,
+        arkSyncFailStreak,
     } = useAuthStore();
+
+    /**
+     * Slow clock for the offline warning.
+     *
+     * The warning has to be able to APPEAR with no store activity at all: the
+     * failure it reports is exactly the one that stops anything being written.
+     * Without a tick of its own the row would keep showing whatever it last
+     * said while the vault sat unreachable. 30s matches the Capsules tab and
+     * the home card, and the thresholds it feeds are minutes wide.
+     */
+    const [connTick, setConnTick] = useState(() => Date.now());
+    useEffect(() => {
+        const t = setInterval(() => setConnTick(Date.now()), 30_000);
+        return () => clearInterval(t);
+    }, []);
+
+    const vaultConnectivity = useMemo(
+        () =>
+            deriveVaultConnectivity({
+                tipFetchedAtMs: arkChainTipHeightAt,
+                lastSyncedAtMs: arkLastSyncedAt,
+                nowMs: connTick,
+                syncFailStreak: arkSyncFailStreak,
+            }),
+        [arkChainTipHeightAt, arkLastSyncedAt, arkSyncFailStreak, connTick],
+    );
 
     // Per-card vertical nudge for the Ark slide.
     //
@@ -239,6 +271,29 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
     }, []);
 
     const bgRefreshStatus = useMemo(() => {
+        // OFFLINE FIRST, ahead of everything below including an in-flight
+        // refresh.
+        //
+        // Every other line in this chain is derived from the cached chain tip:
+        // how many days a capsule has left, whether it is dust, whether a
+        // refresh is due. When the vault cannot be reached none of those
+        // numbers are reads, they are projections off a tip that stopped
+        // moving, and they keep counting down as if nothing were wrong. That
+        // is the failure that misleads in the expensive direction, so it
+        // outranks the advice built on top of it.
+        //
+        // The card's own status dot says the same thing quietly. This row says
+        // it in red, because the dot answers "is it connected" and this answers
+        // "should you trust the numbers you are looking at".
+        if (vaultConnectivity.level === 'red') {
+            return {
+                // COPY: Bam finalizes.
+                text: 'Bark vault is offline. Capsule times shown are estimates until it reconnects.',
+                error: true,
+                tapTab: 0,
+            };
+        }
+
         // Refresh in flight: short-circuit to all-clear. The Ark Card
         // itself surfaces the live "Refreshing N capsules · X sats" line
         // inside its balance area (see Card's `refreshingInfo` prop) so
@@ -327,6 +382,11 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         arkIosBackupReminderActive,
         pendingRound,
         arkBalanceDetail,
+        // Without this the offline branch never re-evaluates and the row keeps
+        // showing whatever it said when the vault was last reachable, which is
+        // the exact failure the branch exists to report.
+        vaultConnectivity,
+        arkExitFeeReserveSats,
     ]);
 
     const [indexStrike, setIndexStrike] = useState(0);

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -10,6 +10,7 @@ import { CarouselPageVisibilityContext } from "@Cypher/custom-hooks";
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { Animated, AppState, FlatList, Image, NativeScrollEvent, NativeSyntheticEvent, Platform, TouchableOpacity, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
+import SimpleToast from "react-native-simple-toast";
 
 interface Props {
     balance: any;
@@ -81,6 +82,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         arkRefreshStuck,
         setArkPendingOnchainRecoverOpen,
         arkExitFeeReserveSats,
+        setArkExitFeeReserveSats,
     } = useAuthStore();
 
     // Per-card vertical nudge for the Ark slide.
@@ -265,11 +267,19 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
             // and the recover section this deep-links to is hidden anyway.
             if (stuckSats > 0 && stuckSats < STUCK_BOARD_MIN_SATS && (arkExitFeeReserveSats ?? 0) <= 0) {
                 return {
-                    text: `You have ${stuckSats.toLocaleString()} sats failing to board your Bark vault. Recover here.`,
+                    text: `You have ${stuckSats.toLocaleString()} sats failing to board your Bark vault. Recover here, or use them for Emergency Exit fees.`,
                     linkText: 'here',
                     tapTab: 0, // Capsules tab
                     openOnchainRecover: true,
                     error: true,
+                    // Drives the second action under this banner. The in-card
+                    // path (ArkWallet) has offered this since the reserve
+                    // landed, but that whole block is gated behind
+                    // `!hideActionButtons`, so in shared-button mode (the
+                    // default home layout) the only option ever shown was
+                    // Recover. Same call and same wording as the in-card link
+                    // so the two surfaces stay one feature.
+                    reserveExitFeeSats: stuckSats,
                 };
             }
         }
@@ -1094,6 +1104,45 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                                 {body}
                             </Text>
                         </TouchableOpacity>
+                        {/* Second action: keep the un-boardable funds on-chain
+                            as the exit-fee reserve instead of recovering them.
+                            Arms arkExitFeeReserveSats, which tells sync.ts to
+                            stop trying to board them and suppresses this
+                            banner on the next tick.
+
+                            Separate TouchableOpacity rather than a second link
+                            inside `body`, because the banner's whole text is
+                            already one tap target routing to Recover, and
+                            nesting a differently-routed link inside it makes
+                            the hit areas ambiguous. */}
+                        {Number((bgRefreshStatus as any).reserveExitFeeSats ?? 0) > 0 && (
+                            <TouchableOpacity
+                                onPress={() => {
+                                    setArkExitFeeReserveSats(
+                                        Number((bgRefreshStatus as any).reserveExitFeeSats),
+                                    );
+                                    SimpleToast.show('Kept on-chain for exit fees.', SimpleToast.SHORT);
+                                }}
+                                activeOpacity={0.7}
+                                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                                accessibilityRole="button"
+                                accessibilityLabel="Leave on-chain funds as exit fees"
+                                style={{ marginTop: 6 }}
+                            >
+                                <Text
+                                    h4
+                                    bold
+                                    style={{
+                                        color: colors.gray.light,
+                                        textAlign: 'center',
+                                        textDecorationLine: 'underline',
+                                        paddingHorizontal: 12,
+                                    }}
+                                >
+                                    Leave on-chain funds as exit fees
+                                </Text>
+                            </TouchableOpacity>
+                        )}
                     </Animated.View>
                 );
             })()}

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -154,7 +154,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
     }, [arkVtxos, arkChainTipHeight]);
 
     const expiryWarning = soonestDaysLeft !== null && soonestDaysLeft < 7
-        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d — refresh soon`
+        ? `Oldest capsule expires in ${Math.round(soonestDaysLeft)}d, refresh soon`
         : null;
 
     // Dust capsules: below the PER-INPUT refresh floor (ARK_REFRESH_MIN_SATS,
@@ -314,7 +314,7 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
 
         if (Platform.OS === 'ios' && arkIosBackupReminderActive) {
             return {
-                text: 'Backup not synced — enable iCloud Drive in iOS Settings',
+                text: 'Backup not synced. Enable iCloud Drive in iOS Settings',
                 error: true,
             };
         }

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -999,7 +999,7 @@ export default function HomeScreen({ route }: Props) {
     }
 
     if (smallUtxos.length > 5 && feesAreLow) {
-      return "Fees are low — good time to consolidate your small UTXOs to save on future transaction costs.";
+      return "Fees are low, a good time to consolidate your small UTXOs to save on future transaction costs.";
     }
 
     return null;

--- a/src/screens/HotStorageVault/Settings.tsx
+++ b/src/screens/HotStorageVault/Settings.tsx
@@ -566,7 +566,7 @@ export default function Settings({wallet, to, matchedRate, toStrike}: any) {
                                         {keychainBusy
                                             ? "Updating Keychain…"
                                             : isKeychainBackedUp
-                                            ? "Seed saved to Keychain ✓ — Remove"
+                                            ? "Seed saved to Keychain ✓ · Remove"
                                             : "Back up seed to iPhone Keychain"}
                                     </Text>
                                 </TouchableOpacity>

--- a/src/screens/RecoverSavingVault/index.tsx
+++ b/src/screens/RecoverSavingVault/index.tsx
@@ -423,7 +423,7 @@ export default function RecoverSavingVault({ route }: Props) {
                 </Text>
                 <Text style={styles.keychainSub}>
                     {isSingle
-                        ? 'Tap to unlock with FaceID / passcode and restore — no typing required.'
+                        ? 'Tap to unlock with FaceID / passcode and restore. No typing required.'
                         : `We found ${keychainBackups.length} backed-up hot vaults on this device. Pick one to restore, or remove ones you no longer need.`}
                 </Text>
 

--- a/src/screens/ReviewPayment/index.tsx
+++ b/src/screens/ReviewPayment/index.tsx
@@ -919,7 +919,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
                 console.error(`[BUY → ${dest}] swap failed:`, error);
                 let message = 'Swap failed. Your purchase succeeded — try again from Home → Swap.';
                 if (error instanceof InvoiceCreationFailedError) {
-                    message = `${dest === 'coinos' ? 'CoinOS' : 'Ark'} couldn't create an invoice — ${(error.cause as Error)?.message ?? error.message}`;
+                    message = `${dest === 'coinos' ? 'CoinOS' : 'Ark'} couldn't create an invoice: ${(error.cause as Error)?.message ?? error.message}`;
                 } else if (error instanceof PaymentFailedError) {
                     const causeMsg = (error.cause as Error)?.message ?? error.message;
                     // Strike's BALANCE_TOO_LOW response means the trade
@@ -928,7 +928,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
                     if (/BALANCE_TOO_LOW|Insufficient funds/i.test(causeMsg)) {
                         message = 'Your purchase succeeded but Strike\'s balance hasn\'t settled yet. Try the swap from Home → Swap in a few seconds.';
                     } else {
-                        message = `Strike payment failed — ${causeMsg}`;
+                        message = `Strike payment failed: ${causeMsg}`;
                     }
                 } else if (error instanceof LightningSwapError) {
                     message = error.message;
@@ -2066,7 +2066,7 @@ export default function ReviewPayment({ navigation, route }: Props) {
             {isSendLoading && buyProgress.some(s => s.state === 'slow') && (
                 <View style={{ marginHorizontal: 24, marginBottom: 14, alignItems: 'center' }}>
                     <Text style={{ color: '#AAAAAA', fontSize: 13, lineHeight: 18, textAlign: 'center', marginBottom: 12 }}>
-                        This is taking longer than usual. The swap keeps confirming in the background — it's safe to go Home, your balance updates when it lands.
+                        This is taking longer than usual. The swap keeps confirming in the background. It's safe to go Home, your balance updates when it lands.
                     </Text>
                     <TouchableOpacity
                         onPress={() => {

--- a/src/screens/SavingVault/index.tsx
+++ b/src/screens/SavingVault/index.tsx
@@ -69,7 +69,7 @@ export default function SavingVault() {
                 );
                 setKeychainStatus("err");
                 SimpleToast.show(
-                    "Keychain save skipped — you can enable it later in vault settings",
+                    "Keychain save skipped. You can enable it later in vault settings",
                     SimpleToast.LONG,
                 );
             } else {
@@ -102,7 +102,7 @@ export default function SavingVault() {
                         result.error,
                     );
                     SimpleToast.show(
-                        "Keychain save failed — please back up the 12 words manually",
+                        "Keychain save failed. Please back up the 12 words manually",
                         SimpleToast.LONG,
                     );
                     // Intentional: we do NOT abort the flow here. The seed
@@ -185,7 +185,7 @@ export default function SavingVault() {
                 )}
                 {keychainStatus === "err" && (
                     <Text style={styles.keychainStatusErr}>
-                        ✗ Keychain save failed — paper backup still required
+                        ✗ Keychain save failed. Paper backup still required
                     </Text>
                 )}
 

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ActivityIndicator, Alert, Animated, Easing, FlatList, Image, ImageBackground, Text as RNText, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Alert, Animated, Easing, FlatList, Image, ImageBackground, RefreshControl, Text as RNText, TouchableOpacity, View } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
 import { Icon } from "react-native-elements";
 import Svg, { Circle } from "react-native-svg";
@@ -44,6 +44,12 @@ import {
     fetchArkNextRequiredRefreshHeight,
     formatBlocksUntil,
 } from "@Cypher/services/ark/expiry";
+// Same reason as the expiry import above: not re-exported through the barrel.
+import {
+    deriveVaultConnectivity,
+    effectiveChainTip,
+    type VaultConnectivity,
+} from "@Cypher/services/ark/chainTipFreshness";
 import { buildRefreshBatch } from "@Cypher/services/ark/refreshBatch";
 import { buildDeferredVtxoIds } from "@Cypher/services/ark/refreshDeferral";
 import useAuthStore from "@Cypher/stores/authStore";
@@ -1129,9 +1135,99 @@ function RefreshWaitBanner({
     );
 }
 
+/**
+ * Vault connectivity traffic light.
+ *
+ * Exists because the vault UI used to look IDENTICAL whether esplora was
+ * answering or had been unreachable for a day. Every expiry number on this
+ * screen is `expiryHeight - chainTip`, and the cached tip is only overwritten
+ * on a successful fetch, so an outage froze every countdown at its last value
+ * and there was nothing on screen to say so. A frozen "25 days left" read
+ * exactly like a true one, and it failed in the optimistic direction.
+ *
+ * Green is deliberately quiet (a dot and a word) so the only thing that draws
+ * the eye is a vault that has actually lost contact.
+ *
+ * COPY: Bam finalizes. Placeholder strings below are factual but unstyled for
+ * voice, and are the only new user-facing text in this change.
+ */
+function VaultConnectivityPill({ conn }: { conn: VaultConnectivity }) {
+    const { level } = conn;
+    // Reuses the palette already used by the depletion ring in this file so
+    // the status colors read as one system: green #4ADE80, amber via the ark
+    // token, red #FF7A68 (the same red as the stranded-dust warning).
+    const color =
+        level === 'green' ? '#4ADE80' : level === 'yellow' ? colors.ark.light : '#FF7A68';
+
+    // Age is quoted from whichever signal is actually the problem, so the
+    // number the user sees matches the reason given.
+    const ageMs =
+        level === 'green'
+            ? 0
+            : Math.max(conn.tip.ageMs ?? 0, conn.syncAgeMs ?? 0);
+    const ageLabel = formatAgo(ageMs);
+
+    const label =
+        level === 'green'
+            ? 'Vault connected'
+            : level === 'yellow'
+                ? `Vault connection slow (updated ${ageLabel})`
+                : `Vault offline (last updated ${ageLabel})`;
+
+    return (
+        <View style={{ marginBottom: 6 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <View
+                    style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: 4,
+                        backgroundColor: color,
+                        marginRight: 7,
+                    }}
+                />
+                <RNText style={{ fontSize: 12, color, fontWeight: '700' }}>{label}</RNText>
+            </View>
+            {/* Only once the tip is too old to vouch for. The countdowns are
+                still shown (and still tick down, because the tip is advanced
+                by elapsed time rather than frozen), but the user is told they
+                are projections rather than reads. */}
+            {!conn.tip.trusted && (
+                <RNText style={{ fontSize: 11, color: '#ddd', marginTop: 3 }}>
+                    Times below are estimates until the vault reconnects.
+                </RNText>
+            )}
+        </View>
+    );
+}
+
+/**
+ * Coarse "how long ago" for the connectivity pill. Minutes then hours then
+ * days; never seconds, because the pill only appears once the tip is already
+ * minutes old and a ticking seconds counter would read as more precision than
+ * the underlying estimate has.
+ */
+function formatAgo(ms: number): string {
+    const mins = Math.floor(ms / 60000);
+    if (mins < 60) return `${Math.max(1, mins)}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+}
+
 export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps) {
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
     const [refreshing, setRefreshing] = useState(false);
+    // Pull-to-refresh spinner. Deliberately NOT `refreshing` above: that one
+    // gates the round-submission path (dust sweep / per-row refresh), and
+    // reusing it would spin the list control whenever a round is being
+    // submitted and, worse, let a pull gesture read as a queued round.
+    const [pullRefreshing, setPullRefreshing] = useState(false);
+    // In-flight latch for the pull gesture. A ref, not the state above:
+    // setState is async, so two quick pulls can both pass a state check
+    // before either render lands. Same reason the round paths keep their
+    // own latches (see arkRefreshingVtxoIds, which is not a mutex).
+    const pullRefreshInFlight = useRef(false);
     // True between cancel-tap and the round actually clearing (NOT just
     // until our cancel call returns). bark's cancel can return failure
     // due to a transient internal-lock timeout while the round itself
@@ -1145,7 +1241,11 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     const arkRefreshingVtxoIds = useAuthStore((s) => s.arkRefreshingVtxoIds);
     const arkPendingLnReceives = useAuthStore((s) => s.arkPendingLnReceives);
     const setArkPendingLnReceives = useAuthStore((s) => s.setArkPendingLnReceives);
-    const chainTipHeight = useAuthStore((s) => s.arkChainTipHeight);
+    const rawChainTipHeight = useAuthStore((s) => s.arkChainTipHeight);
+    // Epoch ms the tip above was read. Already stamped by setArkChainTipHeight;
+    // until now its only consumer was the exit-funding triage, so the capsule
+    // countdowns trusted a tip of any age.
+    const arkChainTipHeightAt = useAuthStore((s) => s.arkChainTipHeightAt);
     const arkLastBackupAt = useAuthStore((s) => s.arkLastBackupAt);
     const arkRoundIntervalSecs = useAuthStore((s) => s.arkRoundIntervalSecs);
     // Read-only on this screen — the toggle lives on the Ark Settings
@@ -1177,6 +1277,116 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // Consecutive refresh failures, drives the per-row "N refresh attempts
     // failed" copy while a capsule is stuck mid-refresh.
     const arkRefreshFailStreak = useAuthStore((s) => s.arkRefreshFailStreak);
+
+    // Slow clock for the staleness derivations below. 30s rather than the 1s
+    // used by the in-flight round countdown: the thresholds it feeds are
+    // minutes wide, and re-deriving the row list every second would be pure
+    // waste on a wallet with many capsules. It exists at all because the
+    // connectivity pill has to degrade on its own: if the sync loop is the
+    // thing that is wedged, no store write will arrive to re-render us.
+    const [nowTick, setNowTick] = useState(() => Date.now());
+    useEffect(() => {
+        const t = setInterval(() => setNowTick(Date.now()), 30_000);
+        return () => clearInterval(t);
+    }, []);
+
+    /**
+     * The tip to actually compute expiry against.
+     *
+     * `arkChainTipHeight` is only written on a SUCCESSFUL esplora read, and
+     * the store is persisted with no partialize, so on an outage (or a cold
+     * launch with no connectivity) this screen used to render
+     * `expiryHeight - <last good tip>` and freeze every countdown at the value
+     * it had when contact was lost. That is the unsafe direction: it tells the
+     * user they have more runway than they do, and it survives the force-quit
+     * they would use to try to clear it.
+     *
+     * Advancing the cached tip by the elapsed block count is an estimate, but
+     * it is wrong in the direction that costs a round fee rather than the
+     * direction that costs the capsule. See services/ark/chainTipFreshness.
+     */
+    const chainTipHeight = useMemo(
+        () =>
+            effectiveChainTip({
+                tip: rawChainTipHeight,
+                fetchedAtMs: arkChainTipHeightAt,
+                nowMs: nowTick,
+            }),
+        [rawChainTipHeight, arkChainTipHeightAt, nowTick],
+    );
+
+    // Traffic light for the header. Folds in the sync stamp as well as the
+    // tip, because the two fail independently (esplora can answer while the
+    // wallet handle is wedged, and vice versa).
+    const connectivity = useMemo(
+        () =>
+            deriveVaultConnectivity({
+                tipFetchedAtMs: arkChainTipHeightAt,
+                lastSyncedAtMs: arkLastSyncedAt,
+                nowMs: nowTick,
+            }),
+        [arkChainTipHeightAt, arkLastSyncedAt, nowTick],
+    );
+
+    /**
+     * Pull-to-refresh: run the same read sequence the 30s `useArkSync` tick
+     * runs, on demand. Purely an affordance for "I am waiting on a Lightning
+     * receive to land" (and for on-device triage). It submits nothing.
+     *
+     * Same three calls, in the same order, as the pre-submit resync in
+     * `handleDustRefresh`: `syncArkWallet()` pulls round finalisations and
+     * incoming payments into the local datadir, then balance + vtxos read
+     * that datadir back into zustand, which is what re-renders this list.
+     *
+     * We do not touch `arkLastSyncedAt`, which is useArkSync's own cycle
+     * marker, and bumping it from here would fake a completed tick for every
+     * other screen keyed off it (ArkHistory reloads, the next-refresh-due
+     * effect below). The store writes inside fetchArkBalance/fetchArkVtxos
+     * are what this list actually renders from, so it updates regardless.
+     *
+     * Overlap with the tick is tolerable and already the norm on this screen
+     * (the dust resync and the stuck-round cancel both call `syncArkWallet`
+     * directly, and `syncArkWallet` carries its own exit-in-progress guard
+     * precisely because of that). The latch below only stops this gesture
+     * from stacking on itself.
+     */
+    const onPullRefresh = useCallback(() => {
+        if (pullRefreshInFlight.current) return;
+        pullRefreshInFlight.current = true;
+        setPullRefreshing(true);
+        void (async () => {
+            try {
+                await syncArkWallet();
+                await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+            } catch (err: any) {
+                console.warn(
+                    '[Ark pull-refresh] sync failed, keeping last-known state:',
+                    err?.message ?? err,
+                );
+                // Say so. A silent failure here is worse than no gesture at
+                // all: the user pulls, sees a spinner, sees the countdown not
+                // move, and reads that as "confirmed, still 25 days" when the
+                // truth is that we never reached the chain. The connectivity
+                // pill above is the persistent signal; this is the immediate
+                // one for the person who just asked.
+                //
+                // COPY: Bam finalizes the context prefix. Deliberately NOT
+                // "Refresh failed" (used below for a round submission) since
+                // this gesture submits nothing. The remedy text after the
+                // prefix is the existing shared network-fault copy.
+                SimpleToast.show(
+                    describeArkFailure(err, "Couldn't update", {
+                        chainUrls: ESPLORA_URLS,
+                        arkUrl: ARK_SERVER_URL,
+                    }),
+                    SimpleToast.LONG,
+                );
+            } finally {
+                pullRefreshInFlight.current = false;
+                setPullRefreshing(false);
+            }
+        })();
+    }, []);
 
     // Recover a stuck refresh from the Capsules tab. Mirrors the home-card
     // handler in ArkWallet — but that banner is invisible to a user sitting
@@ -2315,6 +2525,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 The on/off line is read-only — the actual toggle lives on
                 the Ark Settings tab. */}
             <View style={{ marginHorizontal: 20, marginTop: 14, marginBottom: 8, alignItems: 'flex-start' }}>
+                {/* Connectivity first: it qualifies every number below it.
+                    Every expiry figure on this screen is derived from the
+                    chain tip, so "can we currently see the chain" has to be
+                    readable before the countdowns are, not buried under
+                    them. */}
+                <VaultConnectivityPill conn={connectivity} />
                 <Text bold style={{ fontSize: 16, color: '#FFF', marginBottom: 6 }}>
                     Reminders:{' '}
                     <Text
@@ -2546,6 +2762,13 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 data={rows}
                 keyExtractor={(item) => item.id}
                 showsVerticalScrollIndicator={false}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={pullRefreshing}
+                        onRefresh={onPullRefresh}
+                        tintColor="white"
+                    />
+                }
                 renderItem={({ item }) => (
                     <VtxoRow
                         vtxo={item}

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1259,6 +1259,8 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // alongside the rest of the wallet's read state without spinning up a
     // separate poll.
     const arkLastSyncedAt = useAuthStore((s) => s.arkLastSyncedAt);
+    // Failed ticks, so the pill can degrade on evidence rather than on age.
+    const arkSyncFailStreak = useAuthStore((s) => s.arkSyncFailStreak);
     // One-shot flag set by the notification tap handler in
     // src/services/ark/scheduler.ts. Drives the auto-refresh effect below
     // so the user lands on this tab with refresh already running, without
@@ -1324,8 +1326,9 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 tipFetchedAtMs: arkChainTipHeightAt,
                 lastSyncedAtMs: arkLastSyncedAt,
                 nowMs: nowTick,
+                syncFailStreak: arkSyncFailStreak,
             }),
-        [arkChainTipHeightAt, arkLastSyncedAt, nowTick],
+        [arkChainTipHeightAt, arkLastSyncedAt, arkSyncFailStreak, nowTick],
     );
 
     /**

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1551,7 +1551,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         );
         if (lockedSelected.length > 0) {
             SimpleToast.show(
-                `${lockedSelected.length} capsule(s) already in a pending round — wait for it to finalise before refreshing again`,
+                `${lockedSelected.length} capsule(s) already in a pending round. Wait for it to finalise before refreshing again`,
                 SimpleToast.LONG,
             );
             return;
@@ -2191,17 +2191,17 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             }
             if (succeeded === ongoing.length) {
                 SimpleToast.show(
-                    `Cancelled ${succeeded} refresh${succeeded === 1 ? '' : 'es'} — funds unlocked`,
+                    `Cancelled ${succeeded} refresh${succeeded === 1 ? '' : 'es'}, funds unlocked`,
                     SimpleToast.SHORT,
                 );
             } else if (succeeded > 0) {
                 SimpleToast.show(
-                    `Cancelled ${succeeded} of ${ongoing.length} — the rest will settle in ~1 min`,
+                    `Cancelled ${succeeded} of ${ongoing.length}, the rest will settle in ~1 min`,
                     SimpleToast.LONG,
                 );
             } else {
                 SimpleToast.show(
-                    'Cancel held up server-side — the round will settle in ~1 min',
+                    'Cancel held up server-side. The round will settle in ~1 min',
                     SimpleToast.LONG,
                 );
             }
@@ -2671,7 +2671,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                             {queuedRoundsCount} refresh rounds queued at Ark server
                         </Text>
                         <Text style={{ fontSize: 11, color: '#999', marginTop: 4, lineHeight: 15 }}>
-                            Tapping Refresh again won't speed it up — each tap
+                            Tapping Refresh again won't speed it up, because each tap
                             submits a new round and burns another fee on
                             completion. Wait for the round to finalise (typically
                             under a minute) or time out (~few hours) before

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -2123,6 +2123,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                                 dispatchNavigate('SwapAmount', {
                                     swapFrom: 'ark',
                                     sendTo: 'coinos',
+                                    purpose: 'dust-exit',
                                     prefillSats: total,
                                     sourceBalance: total,
                                     // Cap at the dust total. Editing this up
@@ -2146,7 +2147,15 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                                 dispatchNavigate('SwapAmount', {
                                     swapFrom: 'coinos',
                                     sendTo: 'ark',
+                                    purpose: 'dust-topup',
                                     prefillSats: shortfall,
+                                    // Same ceiling the shortfall is computed
+                                    // against. Without it the user can edit
+                                    // the amount up, the top-up lands as a
+                                    // healthy capsule outside the dust set,
+                                    // and the sweep armed below refuses for a
+                                    // reason nothing on screen explains.
+                                    maxSats: ARK_REFRESH_MIN_SATS - 1,
                                 });
                             },
                         },

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -2051,7 +2051,25 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 SimpleToast.show('No dust capsules to refresh.', SimpleToast.SHORT);
                 return;
             }
-            if (total <= ARK_VTXO_DUST_SATS) {
+            // Gate on whether the sweep is WORTH anything, not on whether the
+            // ASP would take it.
+            //
+            // Two different limits were being confused. Below ARK_VTXO_DUST_SATS
+            // the server refuses the batch outright. Below ARK_REFRESH_MIN_SATS
+            // it accepts it and hands back another dust capsule, because the
+            // output is the total minus a fee and the total was already under
+            // the floor. The second case is the one users actually hit: 381
+            // sats of dust sweeps happily into 379 sats of dust, achieving
+            // nothing but a round fee and an hour of waiting.
+            //
+            // No fee estimate is needed to know this. If the total is under the
+            // floor then the output is under the floor even at zero fee, so the
+            // check is exact rather than a guess. That also keeps the decision
+            // ahead of estimateArkRefreshFee, which matters: that call reaches
+            // the chain source and dies on a 429, which would otherwise throw
+            // the user into a generic failure toast and they would never see
+            // this dialog at all.
+            if (total < ARK_REFRESH_MIN_SATS) {
                 // Below the dust limit the ASP will not take the batch at all,
                 // so the sweep is genuinely impossible rather than merely
                 // uneconomic. A toast saying "not enough" was true and useless:
@@ -2068,7 +2086,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 // honest answer.
                 if (!isCoinosConnected) {
                     SimpleToast.show(
-                        `Only ${total} sats of dust so far. It needs to total more than ${ARK_VTXO_DUST_SATS} sats before it can be swept into one capsule.`,
+                        `Only ${total} sats of dust so far. It needs to total at least ${ARK_REFRESH_MIN_SATS} sats before combining it is worth the fee.`,
                         SimpleToast.LONG,
                     );
                     return;
@@ -2094,9 +2112,10 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 );
                 // COPY: Bam finalizes.
                 Alert.alert(
-                    "These are too small to combine",
+                    "Combining these won't help yet",
                     `${total} sats of dust across ${ids.length} capsule${ids.length === 1 ? '' : 's'}. ` +
-                    `The Ark server won't accept a batch under ${ARK_VTXO_DUST_SATS} sats, so they can't be combined yet.`,
+                    `Combining them costs a fee and still leaves you under ${ARK_REFRESH_MIN_SATS} sats, ` +
+                    `so the result would be dust again.`,
                     [
                         {
                             text: 'Move them to CoinOS',

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1129,6 +1129,17 @@ function RefreshWaitBanner({
     );
 }
 
+/**
+ * What a dust top-up aims for, in sats.
+ *
+ * 700 rather than the 500 refresh floor: the batch has to clear the floor
+ * AFTER the round fee, and landing exactly on it would leave the swept capsule
+ * one sat of drift away from being dust again. It also matches the number the
+ * receive screens already tell users to aim for, so the two pieces of advice
+ * agree.
+ */
+const DUST_TOPUP_TARGET_SATS = 700;
+
 export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps) {
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
     const [refreshing, setRefreshing] = useState(false);
@@ -1164,6 +1175,13 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // so the user lands on this tab with refresh already running, without
     // having to find a button.
     const arkPendingTapRefresh = useAuthStore((s) => s.arkPendingTapRefresh);
+    // One-shot: sweep the dust once a top-up swap has landed. Set on the way
+    // out to the swap screen, consumed on the way back in.
+    const arkPendingDustSweep = useAuthStore((s) => s.arkPendingDustSweep);
+    const setArkPendingDustSweep = useAuthStore((s) => s.setArkPendingDustSweep);
+    // Both dust escape hatches are swaps with CoinOS, so neither is offered
+    // when it is not connected.
+    const isCoinosConnected = useAuthStore((s) => s.isAuth) === true;
     const setArkPendingTapRefresh = useAuthStore((s) => s.setArkPendingTapRefresh);
     const arkRefreshStuck = useAuthStore((s) => s.arkRefreshStuck);
     const setArkRefreshStuck = useAuthStore((s) => s.setArkRefreshStuck);
@@ -1361,6 +1379,34 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     //   3. Otherwise → fire the batch with skipConfirm so the refresh
     //      starts immediately. Selection + fee preview don't add safety
     //      here: the user already opted in by tapping the warning.
+    /**
+     * Follow-through for the dust top-up.
+     *
+     * The user chose "top up" on the too-small-to-combine dialog, swapped in
+     * from CoinOS, and has landed back here. Fire the sweep they were trying to
+     * run in the first place.
+     *
+     * Waits for `rows`, the same gate the tap-refresh effect below uses: an
+     * empty list means the wallet has not hydrated yet, and sweeping off a set
+     * we have not read would submit the wrong ids.
+     *
+     * The flag is cleared BEFORE the sweep, not after. handleDustRefresh is
+     * async and can fail, and a flag still set on failure would re-fire the
+     * round on the next mount, which is exactly the retry storm this codebase
+     * has been bitten by twice today.
+     *
+     * If the top-up has not landed as a capsule yet, or landed as one big
+     * enough not to count as dust, handleDustRefresh says so through its own
+     * guard. That is the honest outcome, and it is why this does not try to
+     * verify the balance itself.
+     */
+    useEffect(() => {
+        if (!arkPendingDustSweep) return;
+        if (rows.length === 0) return;
+        setArkPendingDustSweep(false);
+        handleDustRefresh();
+    }, [arkPendingDustSweep, rows, setArkPendingDustSweep]);
+
     useEffect(() => {
         if (!arkPendingTapRefresh) return;
         if (rows.length === 0) return;
@@ -2006,9 +2052,64 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 return;
             }
             if (total <= ARK_VTXO_DUST_SATS) {
-                SimpleToast.show(
-                    `Only ${total} sats of dust so far. It needs to total more than ${ARK_VTXO_DUST_SATS} sats before it can be swept into one capsule.`,
-                    SimpleToast.LONG,
+                // Below the dust limit the ASP will not take the batch at all,
+                // so the sweep is genuinely impossible rather than merely
+                // uneconomic. A toast saying "not enough" was true and useless:
+                // it named the obstacle and left the user holding sats they
+                // could not combine and had no obvious way to rescue.
+                //
+                // Two ways out, and they are opposites, so the user picks:
+                // take the value off Ark entirely, or add just enough to make
+                // the batch viable. Both go through the existing swap screen;
+                // neither is a new money path.
+                //
+                // Gated on CoinOS being connected, because both options are
+                // swaps with it. Without it, the old message is still the
+                // honest answer.
+                if (!isCoinosConnected) {
+                    SimpleToast.show(
+                        `Only ${total} sats of dust so far. It needs to total more than ${ARK_VTXO_DUST_SATS} sats before it can be swept into one capsule.`,
+                        SimpleToast.LONG,
+                    );
+                    return;
+                }
+                const shortfall = Math.max(1, DUST_TOPUP_TARGET_SATS - total);
+                // COPY: Bam finalizes.
+                Alert.alert(
+                    "These are too small to combine",
+                    `${total} sats of dust across ${ids.length} capsule${ids.length === 1 ? '' : 's'}. ` +
+                    `The Ark server won't accept a batch under ${ARK_VTXO_DUST_SATS} sats, so they can't be combined yet.`,
+                    [
+                        {
+                            text: 'Move them to CoinOS',
+                            onPress: () => {
+                                dispatchNavigate('SwapAmount', {
+                                    swapFrom: 'ark',
+                                    sendTo: 'coinos',
+                                    prefillSats: total,
+                                    sourceBalance: total,
+                                });
+                            },
+                        },
+                        {
+                            text: `Top up ${shortfall} sats`,
+                            onPress: () => {
+                                // Arm the follow-up sweep. The swap happens on
+                                // another screen, so the intent has to outlive
+                                // this one; ArkCapsules consumes the flag when
+                                // it is next mounted, by which time the topped
+                                // up sats have had a chance to land.
+                                setArkPendingDustSweep(true);
+                                dispatchNavigate('SwapAmount', {
+                                    swapFrom: 'coinos',
+                                    sendTo: 'ark',
+                                    prefillSats: shortfall,
+                                });
+                            },
+                        },
+                        { text: 'Not now', style: 'cancel' },
+                    ],
+                    { cancelable: true },
                 );
                 return;
             }

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -2073,7 +2073,25 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                     );
                     return;
                 }
-                const shortfall = Math.max(1, DUST_TOPUP_TARGET_SATS - total);
+                // The top-up has to arrive as DUST itself, or it will not join
+                // the batch it was meant to rescue.
+                //
+                // Aiming straight at 700 breaks for most of the range this
+                // dialog can appear in. The guard fires at a dust total of 330
+                // or less, so the shortfall to 700 is 370 or more, and any
+                // total at or below 200 asks for 500+, which lands as a healthy
+                // capsule and is excluded from the dust set. The user would
+                // swap in funds and the sweep would refuse again, for a reason
+                // no one could see.
+                //
+                // Capping one sat under the refresh floor keeps the incoming
+                // capsule inside the dust set. The batch then totals
+                // dust + up to 499, comfortably past the ASP's limit even
+                // though it may land short of 700.
+                const shortfall = Math.max(
+                    1,
+                    Math.min(DUST_TOPUP_TARGET_SATS - total, ARK_REFRESH_MIN_SATS - 1),
+                );
                 // COPY: Bam finalizes.
                 Alert.alert(
                     "These are too small to combine",
@@ -2088,6 +2106,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                                     sendTo: 'coinos',
                                     prefillSats: total,
                                     sourceBalance: total,
+                                    // Cap at the dust total. Editing this up
+                                    // would pull healthy capsules out of the
+                                    // vault, which is the opposite of what the
+                                    // user came here to do: this option exists
+                                    // to clear dust, not to move funds.
+                                    maxSats: total,
                                 });
                             },
                         },

--- a/src/screens/Strike/CheckingAccountNew/ArkThreshold.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkThreshold.tsx
@@ -171,7 +171,7 @@ export default function ArkThreshold({ matchedRate, currency }: Props) {
       </Text>
       <Text style={{ marginTop: 6 }}>
         When your Ark vault balance crosses this amount, you'll be prompted to
-        move funds into deeper self-custody — your Hot or Cold Vault.
+        move funds into deeper self-custody: your Hot or Cold Vault.
       </Text>
 
       {/* Wide dark-rectangle dropdown — matches the new picker design used
@@ -247,7 +247,7 @@ export default function ArkThreshold({ matchedRate, currency }: Props) {
         </Text>
       </View>
       <Text style={{ marginTop: 6 }}>
-        Sats kept in your Ark vault after a withdrawal — your spending buffer
+        Sats kept in your Ark vault after a withdrawal: your spending buffer
         for everyday Lightning sends.
       </Text>
       <TouchableOpacity

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -809,7 +809,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     if (driveBusy) return;
     Alert.alert(
       'Disconnect Google Drive?',
-      'Your existing backup file will stay in Drive — disconnecting only stops future uploads. You can reconnect any time.',
+      'Your existing backup file will stay in Drive. Disconnecting only stops future uploads. You can reconnect any time.',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -858,12 +858,12 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     const available = await isICloudBackupAvailable();
     if (available) {
       setArkIosBackupReminderActive(false);
-      SimpleToast.show('iCloud Drive verified — reminder dismissed.', SimpleToast.LONG);
+      SimpleToast.show('iCloud Drive verified. Reminder dismissed.', SimpleToast.LONG);
       return;
     }
     Alert.alert(
       "iCloud Drive isn't on for Cypher Box",
-      "Open iOS Settings → [your name] → iCloud → iCloud Drive → scroll the app list and switch Cypher Box ON. Then come back here and tap 'iCloud Drive is on — dismiss' again.",
+      "Open iOS Settings → [your name] → iCloud → iCloud Drive → scroll the app list and switch Cypher Box ON. Then come back here and tap 'iCloud Drive is on, dismiss' again.",
       [
         { text: 'Cancel', style: 'cancel' },
         { text: 'Open Settings', onPress: () => Linking.openSettings().catch(() => {}) },
@@ -1968,7 +1968,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   reminder is active.
                 - How to enable iCloud Drive: opens the iCloud-hint
                   alert (links into iOS Settings).
-                - iCloud Drive is on — dismiss: auto-validates via the
+                - iCloud Drive is on, dismiss: auto-validates via the
                   ubiquity probe before flipping the flag off, so a
                   user who taps it without actually enabling iCloud
                   Drive is sent back to Settings rather than silently
@@ -1989,7 +1989,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 ⚠ Re-export backup after every receive
               </Text>
               <Text style={{ fontSize: 12, color: colors.white, lineHeight: 17 }}>
-                When you created this wallet, you saved a one-time snapshot of the encrypted backup file. That file doesn't auto-update unless iCloud Drive is on for Cypher Box. Tap "Re-export now" after every Lightning receive — or enable iCloud Drive for Cypher Box and this reminder will go away.
+                When you created this wallet, you saved a one-time snapshot of the encrypted backup file. That file doesn't auto-update unless iCloud Drive is on for Cypher Box. Tap "Re-export now" after every Lightning receive, or enable iCloud Drive for Cypher Box and this reminder will go away.
               </Text>
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginTop: 10 }}>
                 <TouchableOpacity
@@ -2048,7 +2048,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   }}
                 >
                   <Text bold style={{ fontSize: 12, color: '#4ADE80' }}>
-                    iCloud Drive is on — dismiss
+                    iCloud Drive is on, dismiss
                   </Text>
                 </TouchableOpacity>
               </View>
@@ -2626,7 +2626,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                       When to use Emergency Exit
                     </Text>
                     {'\n\n'}
-                    Normal sends, swaps and refreshes all go through the Ark server (Second.tech). Emergency Exit is the trustless fallback that doesn't need the server — it broadcasts pre-signed exit transactions directly to the Bitcoin chain.
+                    Normal sends, swaps and refreshes all go through the Ark server (Second.tech). Emergency Exit is the trustless fallback that doesn't need the server. It broadcasts pre-signed exit transactions directly to the Bitcoin chain.
                     {'\n\n'}
                     Use it when:
                     {'\n'}
@@ -2638,7 +2638,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                     {'\n'}
                     • News breaks of a server-side compromise and you want out fast without waiting for cooperative paths
                     {'\n\n'}
-                    Emergency Exit moves funds on-chain (slower, higher fee) so it's the break-glass option, not the everyday one. In normal use prefer swap or refresh — same destinations, faster, cheaper.
+                    Emergency Exit moves funds on-chain (slower, higher fee) so it's the break-glass option, not the everyday one. In normal use prefer swap or refresh: same destinations, faster, cheaper.
                   </Text>
                 </View>
               )}
@@ -2700,7 +2700,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                   </Text>
                   <Text style={{ fontSize: 13, color: '#AAA', marginBottom: 14 }}>
                     Pick a destination for your on-chain payout. The exit takes
-                    ~24h to clear the protocol timelock — the address can't be
+                    ~24h to clear the protocol timelock, and the address can't be
                     changed after you start.
                   </Text>
 
@@ -2746,8 +2746,8 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 <>
                   <Text bold style={{ fontSize: 17, color: '#FFF', marginBottom: 10 }}>
                     {pickerStep === 'hot-addr'
-                      ? (addrListOpen ? 'Pick a Hot Vault address' : 'Hot Vault — destination')
-                      : (addrListOpen ? 'Pick a Cold Storage address' : 'Cold Storage — destination')}
+                      ? (addrListOpen ? 'Pick a Hot Vault address' : 'Hot Vault destination')
+                      : (addrListOpen ? 'Pick a Cold Storage address' : 'Cold Storage destination')}
                   </Text>
 
                   {/* Default flow: QR + address + "Choose another" — mirrors
@@ -3168,7 +3168,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 Delete Ark vault?
               </Text>
               <Text style={{ fontSize: 13, color: '#CCC', lineHeight: 19, marginBottom: 16 }}>
-                This wipes your Ark wallet from this device — the local
+                This wipes your Ark wallet from this device. The local
                 database with your VTXO capsules. To restore funds you'll
                 still need your{' '}
                 <Text bold style={{ color: '#FFF' }}>ark-backup file</Text>.

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -22,6 +22,10 @@ import {
     type LightningSwapProvider,
     type LightningSwapProviderId,
 } from "@Cypher/services/lightningSwap";
+// From the defining module rather than the ark barrel, matching the direct
+// imports ArkCapsules already uses for constants the barrel has in-flight
+// edits around. Same value either way; this just avoids the churn.
+import { ARK_REFRESH_MIN_SATS } from "@Cypher/services/ark/config";
 import { getFiatRate } from "../../../models/fiatUnit";
 
 // Warning-yellow gradient for the small-amount "Swap anyways" CTA + dust note.
@@ -33,7 +37,7 @@ const SMALL_RECEIVE_SATS = 700;
 export default function SwapAmount() {
     const navigation = useNavigation();
     const route = useRoute();
-    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats, maxSats } = route.params as {
+    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats, maxSats, purpose } = route.params as {
         swapFrom: LightningSwapProviderId;
         sendTo: LightningSwapProviderId;
         fromAddress?: string;
@@ -63,6 +67,22 @@ export default function SwapAmount() {
          * poking at a dead input with no explanation.
          */
         maxSats?: number;
+        /**
+         * Why this screen was opened, when the answer changes what to say.
+         *
+         * Passed explicitly rather than inferred from `prefillSats` or from the
+         * rail pair. Inference was the tempting shortcut and it is wrong twice
+         * over: another caller prefilling an amount would silently inherit
+         * dust copy, and `swapFrom`/`sendTo` cannot tell a deliberate 319-sat
+         * top-up apart from a user typing 319 by hand, which is exactly the
+         * case the small-amount warning exists to catch.
+         *
+         * 'dust-topup'  covering a shortfall so a dust batch clears the
+         *               refresh floor. Small is the POINT here, so the generic
+         *               small-amount warning is suppressed.
+         * 'dust-exit'   taking dust off Ark entirely.
+         */
+        purpose?: 'dust-topup' | 'dust-exit';
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
     // Ark sats locked in an in-flight refresh. When the source is Ark and the
@@ -486,10 +506,24 @@ export default function SwapAmount() {
     // leave un-refreshable dust that expires. Sats mode types the sat amount;
     // fiat mode mirrors the sat equivalent into `usd`.
     const currentSats = Math.round(isSats ? Number(sats) : Number(usd)) || 0;
-    const smallBarkSwapWarn = sendTo === 'ark' && currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
+    // Suppressed for the dust top-up. That flow computes the amount itself,
+    // caps it under the refresh floor, and sent the user here precisely to
+    // deposit a small sum. Warning them off it would contradict the dialog
+    // that opened this screen, and the CTA it drives ("Swap anyways") frames
+    // the intended action as a mistake the user is overriding.
+    const isDustTopup = purpose === 'dust-topup';
+    const smallBarkSwapWarn =
+        !isDustTopup && sendTo === 'ark' && currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
 
     return (
-        <ScreenLayout disableScroll showToolbar isBackButton title="Lightning Swap">
+        <ScreenLayout
+            disableScroll
+            showToolbar
+            isBackButton
+            title={
+                isDustTopup ? 'Dust Top-up' : purpose === 'dust-exit' ? 'Move Dust Out' : 'Lightning Swap'
+            }
+        >
             <View style={styles.main}>
                 <GradientInput isSats={isSats} walletInfo={{ matchedRate, currency }} sats={sats} setSats={setSats} usd={usd} />
                 {swapFrom === 'ark' && pendingInRoundSats > 0 && (sourceBalance === 0 || (Number(sats) || 0) > sourceBalance) && (
@@ -526,6 +560,18 @@ export default function SwapAmount() {
                 {smallBarkSwapWarn && (
                     <Text style={{ textAlign: 'center', marginTop: 8, marginHorizontal: 8, fontSize: 12, color: '#FFD54F', lineHeight: 17 }}>
                         Small amounts can leave un-refreshable dust that expires. Swapping above 700 sats keeps them refreshable.
+                    </Text>
+                )}
+                {/* Replaces the warning above rather than sitting alongside it.
+                    The screen otherwise gives no reason for the odd prefilled
+                    number, and the ceiling is worth stating because the field
+                    is editable and overshooting it silently defeats the sweep
+                    the user is here to enable.
+                    COPY: Bam finalizes. */}
+                {isDustTopup && (
+                    <Text style={{ textAlign: 'center', marginTop: 8, marginHorizontal: 8, fontSize: 12, color: '#ddd', lineHeight: 17 }}>
+                        This is meant to be small. It has to stay under {ARK_REFRESH_MIN_SATS} sats to combine with
+                        the dust you already have.
                     </Text>
                 )}
             </View>

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -33,7 +33,7 @@ const SMALL_RECEIVE_SATS = 700;
 export default function SwapAmount() {
     const navigation = useNavigation();
     const route = useRoute();
-    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats } = route.params as {
+    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats, maxSats } = route.params as {
         swapFrom: LightningSwapProviderId;
         sendTo: LightningSwapProviderId;
         fromAddress?: string;
@@ -49,6 +49,20 @@ export default function SwapAmount() {
          * value, not a lock.
          */
         prefillSats?: number;
+        /**
+         * Hard ceiling on the amount, in sats.
+         *
+         * Set by the dust "move them to CoinOS" option. That path exists to
+         * clear dust, and editing the amount up would pull healthy capsules out
+         * of the vault instead, which is the opposite of what the user came for
+         * and defeats the point of the option.
+         *
+         * Enforced by clamping rather than by making the field read-only: the
+         * user can still type, still reduce it, and sees the value snap back if
+         * they overshoot. Locking the keyboard outright would leave them
+         * poking at a dead input with no explanation.
+         */
+        maxSats?: number;
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
     // Ark sats locked in an in-flight refresh. When the source is Ark and the
@@ -108,6 +122,16 @@ export default function SwapAmount() {
     // Seed the amount from `prefillSats` exactly once. Not a controlled sync:
     // re-applying it would fight the user every time they edited the field.
     const prefillApplied = React.useRef(false);
+    // Clamp to `maxSats` whenever the typed value goes over. Runs on the sats
+    // field only: fiat entry is mirrored into it by CustomKeyboard, so this
+    // catches both.
+    React.useEffect(() => {
+        if (!maxSats || !Number.isFinite(maxSats) || maxSats <= 0) return;
+        const typed = Number(sats);
+        if (Number.isFinite(typed) && typed > maxSats) {
+            setSats(String(maxSats));
+        }
+    }, [sats, maxSats]);
     React.useEffect(() => {
         if (prefillApplied.current) return;
         if (!prefillSats || !Number.isFinite(prefillSats) || prefillSats <= 0) return;

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -442,7 +442,10 @@ export default function SwapAmount() {
     // leave un-refreshable dust that expires. Sats mode types the sat amount;
     // fiat mode mirrors the sat equivalent into `usd`.
     const currentSats = Math.round(isSats ? Number(sats) : Number(usd)) || 0;
-    const smallBarkSwapWarn = sendTo === 'ark' && currentSats > 0 && currentSats <= SMALL_RECEIVE_SATS;
+    // Strictly below, matching ArkInvoiceScreen. 700 is the number the warning
+    // asks the user to reach, so warning at exactly 700 contradicted its own
+    // advice.
+    const smallBarkSwapWarn = sendTo === 'ark' && currentSats > 0 && currentSats < SMALL_RECEIVE_SATS;
 
     return (
         <ScreenLayout disableScroll showToolbar isBackButton title="Lightning Swap">
@@ -481,7 +484,7 @@ export default function SwapAmount() {
                 })()}
                 {smallBarkSwapWarn && (
                     <Text style={{ textAlign: 'center', marginTop: 8, marginHorizontal: 8, fontSize: 12, color: '#FFD54F', lineHeight: 17 }}>
-                        Small amounts can leave un-refreshable dust that expires. Swapping above 700 sats keeps them refreshable.
+                        Small amounts can leave un-refreshable dust that expires. Swapping 700 sats or more keeps them refreshable.
                     </Text>
                 )}
             </View>

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -252,7 +252,7 @@ export default function SwapAmount() {
             const fallback = 'Swap failed. Please try again.';
             let message = fallback;
             if (error instanceof InvoiceCreationFailedError) {
-                message = `${toProvider?.displayName ?? sendTo} couldn't create an invoice — ${(error.cause as Error)?.message ?? error.message}`;
+                message = `${toProvider?.displayName ?? sendTo} couldn't create an invoice: ${(error.cause as Error)?.message ?? error.message}`;
             } else if (error instanceof PaymentFailedError) {
                 // A VTXO the Ark server reports as "unregistered" is a stuck
                 // capsule that blocks EVERY Ark send until it's cleared. The raw

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -3,8 +3,7 @@ import { View, Image, ActivityIndicator, TouchableOpacity, Animated, Easing, Ale
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { ScreenLayout, Text } from "@Cypher/component-library";
 import LinearGradient from "react-native-linear-gradient";
-import { CustomKeyboard, GradientInput } from "@Cypher/components";
-import { GradientShock, Electricity } from "@Cypher/assets/images";
+import { CustomKeyboard, GradientInput , LightningSendSuccess } from "@Cypher/components";
 import { dispatchNavigate, dispatchReset } from "@Cypher/helpers";
 import { colors } from "@Cypher/style-guide";
 import useAuthStore from "@Cypher/stores/authStore";
@@ -301,60 +300,6 @@ export default function SwapAmount() {
     };
 
     // Expanding ring animations
-    const slideAnim = React.useRef(new Animated.Value(300)).current;
-    const fadeAnim = React.useRef(new Animated.Value(0)).current;
-    const ring1Scale = React.useRef(new Animated.Value(1)).current;
-    const ring1Opacity = React.useRef(new Animated.Value(0.8)).current;
-    const ring2Scale = React.useRef(new Animated.Value(1)).current;
-    const ring2Opacity = React.useRef(new Animated.Value(0.8)).current;
-
-    React.useEffect(() => {
-        if (success) {
-            // Slide up + fade in
-            Animated.parallel([
-                Animated.timing(slideAnim, {
-                    toValue: 0,
-                    duration: 600,
-                    easing: Easing.out(Easing.cubic),
-                    useNativeDriver: true,
-                }),
-                Animated.timing(fadeAnim, {
-                    toValue: 1,
-                    duration: 600,
-                    easing: Easing.out(Easing.cubic),
-                    useNativeDriver: true,
-                }),
-            ]).start();
-
-            const createRingAnimation = (scale: Animated.Value, opacity: Animated.Value, delay: number) => {
-                return Animated.loop(
-                    Animated.sequence([
-                        Animated.delay(delay),
-                        Animated.parallel([
-                            Animated.timing(scale, {
-                                toValue: 1.8,
-                                duration: 2000,
-                                easing: Easing.out(Easing.ease),
-                                useNativeDriver: true,
-                            }),
-                            Animated.timing(opacity, {
-                                toValue: 0,
-                                duration: 2000,
-                                easing: Easing.out(Easing.ease),
-                                useNativeDriver: true,
-                            }),
-                        ]),
-                        Animated.parallel([
-                            Animated.timing(scale, { toValue: 1, duration: 0, useNativeDriver: true }),
-                            Animated.timing(opacity, { toValue: 0.8, duration: 0, useNativeDriver: true }),
-                        ]),
-                    ])
-                );
-            };
-            createRingAnimation(ring1Scale, ring1Opacity, 0).start();
-            createRingAnimation(ring2Scale, ring2Opacity, 700).start();
-        }
-    }, [success]);
 
     /**
      * Render a wallet badge in the from→to direction strip. Uses the
@@ -384,56 +329,25 @@ export default function SwapAmount() {
     if (success) {
         return (
             <ScreenLayout showToolbar isBackButton={false}>
-                <Animated.View style={[styles.successContainer, { transform: [{ translateY: slideAnim }], opacity: fadeAnim }]}>
-                    <Text semibold style={styles.successTitle}>Swap Sent ⚡</Text>
-                    <Text semibold style={styles.successValue}>{swappedSats} sats</Text>
-                    <Text semibold style={styles.successFiat}>{currency === 'EUR' ? '€' : '$'}{swappedFiat}</Text>
-                    {feeSats !== null && feeSats > 0 && (() => {
-                        // Surface the realised network fee under the fiat
-                        // line. Only providers that report it (Ark) reach
-                        // this branch — custodial swaps hide the row.
-                        // Percentage matches the pre-swap preview formula
-                        // and the ArkSendScreen Fee % row for consistency.
-                        const swappedSatsNum = Number(swappedSats) || 0;
-                        const gross = swappedSatsNum + feeSats;
-                        const feePct = gross > 0 ? Math.min(999, (feeSats / gross) * 100) : null;
-                        const pctStr = feePct === null
-                            ? ''
-                            : feePct < 0.01
-                                ? ' (< 0.01%)'
-                                : ` (${feePct.toFixed(feePct < 1 ? 2 : 1)}%)`;
-                        return (
-                            <Text style={styles.successFee}>
-                                Network fee: {feeSats} sats{pctStr}{feeNote ? ` · ${feeNote}` : ''}
-                            </Text>
-                        );
-                    })()}
-                    <View style={styles.animationContainer}>
-                        <Animated.View style={[styles.ring, { transform: [{ scale: ring1Scale }], opacity: ring1Opacity }]}>
-                            <Image source={GradientShock} style={styles.ringImage} />
-                        </Animated.View>
-                        <Animated.View style={[styles.ring, { transform: [{ scale: ring2Scale }], opacity: ring2Opacity }]}>
-                            <Image source={GradientShock} style={styles.ringImage} />
-                        </Animated.View>
-                        <Image source={Electricity} style={styles.boltImage} />
-                    </View>
-                    <View style={styles.successDirection}>
-                        {renderProviderBadge(fromProvider, swapFrom, 'success')}
-                        <Text style={styles.successArrow}>→</Text>
-                        {renderProviderBadge(toProvider, sendTo, 'success')}
-                    </View>
-                    <Text semibold style={styles.successNetwork}>Lightning Network</Text>
-                    <TouchableOpacity onPress={() => navigation.popToTop()} style={styles.homeButton}>
-                        <LinearGradient
-                            start={{ x: 0, y: 0 }}
-                            end={{ x: 1, y: 0 }}
-                            colors={[colors.pink.extralight, colors.pink.default]}
-                            style={styles.homeButtonGradient}
-                        >
-                            <Text bold style={styles.homeText}>Home</Text>
-                        </LinearGradient>
-                    </TouchableOpacity>
-                </Animated.View>
+                <LightningSendSuccess
+                    title="Swap Sent ⚡"
+                    sats={swappedSats}
+                    fiat={swappedFiat}
+                    fiatSymbol={currency === 'EUR' ? '€' : '$'}
+                    feeSats={feeSats}
+                    feeNote={feeNote}
+                    // A swap's destination is another of the user's own
+                    // wallets, so an address would be meaningless here. Keep
+                    // the from/to badges, which say the true thing.
+                    detail={
+                        <View style={styles.successDirection}>
+                            {renderProviderBadge(fromProvider, swapFrom, 'success')}
+                            <Text style={styles.successArrow}>→</Text>
+                            {renderProviderBadge(toProvider, sendTo, 'success')}
+                        </View>
+                    }
+                    onHome={() => navigation.popToTop()}
+                />
             </ScreenLayout>
         );
     }

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -33,12 +33,22 @@ const SMALL_RECEIVE_SATS = 700;
 export default function SwapAmount() {
     const navigation = useNavigation();
     const route = useRoute();
-    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0 } = route.params as {
+    const { swapFrom, sendTo, fromAddress, toAddress, sourceBalance = 0, prefillSats } = route.params as {
         swapFrom: LightningSwapProviderId;
         sendTo: LightningSwapProviderId;
         fromAddress?: string;
         toAddress?: string;
         sourceBalance?: number;
+        /**
+         * Amount to open the screen with, in sats.
+         *
+         * Set by callers that already know the number, currently the dust
+         * top-up: the user is not choosing an amount there, they are covering a
+         * specific shortfall, and making them work it out is asking them to do
+         * arithmetic the app already did. Still editable; it is a starting
+         * value, not a lock.
+         */
+        prefillSats?: number;
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
     // Ark sats locked in an in-flight refresh. When the source is Ark and the
@@ -95,6 +105,16 @@ export default function SwapAmount() {
         return () => clearTimeout(t);
     }, [loading]);
     const [success, setSuccess] = useState(false);
+    // Seed the amount from `prefillSats` exactly once. Not a controlled sync:
+    // re-applying it would fight the user every time they edited the field.
+    const prefillApplied = React.useRef(false);
+    React.useEffect(() => {
+        if (prefillApplied.current) return;
+        if (!prefillSats || !Number.isFinite(prefillSats) || prefillSats <= 0) return;
+        prefillApplied.current = true;
+        setIsSats(true);
+        setSats(String(Math.ceil(prefillSats)));
+    }, [prefillSats]);
     const [swappedSats, setSwappedSats] = useState('');
     const [swappedFiat, setSwappedFiat] = useState('');
     const [feeSats, setFeeSats] = useState<number | null>(null);

--- a/src/screens/Transaction/index.tsx
+++ b/src/screens/Transaction/index.tsx
@@ -20,6 +20,7 @@ import { dispatchReset, resetAndNavigate } from "@Cypher/helpers/navigation";
 import { startsWithLn } from "../Send";
 import { getStrikeCurrency } from "@Cypher/helpers/coinosHelper";
 import CustomProgressBar from "@Cypher/components/CustomProgressBar";
+import { LightningSendSuccess } from "@Cypher/components";
 
 export default function Transaction({navigation, route}: any) {
     const {matchedRate, currency = 'USD', type, value, converted, isSats, to, item, swappedTo} = route?.params;
@@ -105,6 +106,49 @@ export default function Transaction({navigation, route}: any) {
     });
 
     console.log(type, amountUSD)
+
+    // Lightning payment sends take the shared success view (Bam's call,
+    // 2026-09-09), so Strike, CoinOS and Bark all end a Lightning send the
+    // same way.
+    //
+    // Everything else keeps the screen below, and the exclusions are the
+    // point. BUY and SELL are Strike fiat trades, not Lightning payments, and
+    // this screen carries their "Purchase Complete" / "Sale Complete" copy. A
+    // swap (`swappedTo`) passes a sentinel like 'Ark' or 'coinos' as `to`
+    // rather than a real address, so it must not be rendered as "Paid to Ark",
+    // and it has its own success view already.
+    const isLightningSend =
+        type !== 'BUY' &&
+        type !== 'SELL' &&
+        !swappedTo &&
+        !!to &&
+        (startsWithLn(to) || String(to).includes('@'));
+
+    if (isLightningSend && response) {
+        return (
+            <ScreenLayout disableScroll showToolbar title={""} isBackButton={false}>
+                <LightningSendSuccess
+                    sats={amountSat}
+                    fiat={String(amountUSD)}
+                    fiatSymbol={getStrikeCurrency(currency)}
+                    // An ln-address is short and worth reading in full; a
+                    // BOLT11 invoice is not, so it is shortened.
+                    paidTo={
+                        String(to).includes('@')
+                            ? String(to)
+                            : `${String(to).slice(0, 12)}…${String(to).slice(-8)}`
+                    }
+                    // No `fromLabel`: this screen is reached from several
+                    // Strike and CoinOS paths and none of them pass which
+                    // wallet paid. Naming the wrong wallet on a payment
+                    // receipt is worse than naming none, so it is left off
+                    // until the callers carry it. Bark sends do show it.
+                    onHome={onPressClickHandler}
+                />
+            </ScreenLayout>
+        );
+    }
+
     return (
         <ScreenLayout disableScroll showToolbar title={""} isBackButton={false}>
             <View style={styles.main}>

--- a/src/services/ark/backgroundNotifications.ts
+++ b/src/services/ark/backgroundNotifications.ts
@@ -124,7 +124,7 @@ function fire(
 export function notifyConsecutiveFailures(): void {
     fire(
         'Auto-refresh trouble',
-        "Couldn't auto-refresh — tap to refresh manually.",
+        "Couldn't auto-refresh. Tap to refresh manually.",
         'low',
     );
 }
@@ -593,7 +593,7 @@ export function notifyDustUneconomic(
 ): void {
     fire(
         'Tiny capsules at risk',
-        `${vtxoCount} capsule${vtxoCount === 1 ? '' : 's'} totalling ${totalSats} sats will expire — refresh fee (${feeSats} sats) exceeds their value.`,
+        `${vtxoCount} capsule${vtxoCount === 1 ? '' : 's'} totalling ${totalSats} sats will expire. The refresh fee (${feeSats} sats) exceeds their value.`,
         'low',
         { feeSats, totalSats, vtxoCount },
     );

--- a/src/services/ark/backgroundNotifications.ts
+++ b/src/services/ark/backgroundNotifications.ts
@@ -238,7 +238,8 @@ export function isArkCapsuleTapSource(s: unknown): boolean {
         isArkExpiryWarningSource(s) ||
         isArkExitReadySource(s) ||
         s === 'ark-received' ||
-        s === 'ark-refresh-complete'
+        s === 'ark-refresh-complete' ||
+        s === ARK_REFRESH_REMINDER_SOURCE
     );
 }
 
@@ -648,6 +649,85 @@ export function notifyArkRefreshComplete(capsuleCount?: number): void {
         'low',
         { source: 'ark-refresh-complete', capsuleCount },
     );
+}
+
+export const ARK_REFRESH_REMINDER_SOURCE = 'ark-refresh-reminder';
+
+/**
+ * One fixed id: only one round can be in flight per wallet at a time
+ * (refreshSubmissionInFlight and sweepInFlight both enforce that), so a
+ * per-round key would buy nothing and a stale one could never be cancelled.
+ * Scheduling again simply replaces the pending alarm.
+ */
+const REFRESH_REMINDER_ID = fnv1aNotificationId('ark-refresh-reminder');
+
+/** Rounds are documented as taking up to about an hour on mainnet. */
+const REFRESH_REMINDER_DELAY_MS = 60 * 60 * 1000;
+
+/**
+ * Backstop reminder for a refresh round, scheduled when the round is submitted.
+ *
+ * WHY THIS EXISTS ALONGSIDE notifyArkRefreshComplete. That one is better in
+ * every way except availability: it fires on the real completion event, with
+ * the real capsule count, and says the round is done because it saw it happen.
+ * But it runs inside movementWatcher, which only observes anything while the
+ * app process is alive. Once iOS suspends or kills the app, nothing is watching
+ * and no completion notification is ever produced. Observed on device
+ * 2026-09-10: a round finalised while the app was closed and the user learned
+ * about it by opening the app and looking.
+ *
+ * A scheduled local notification is handed to the OS at submit time, so it
+ * fires whether or not the app is still running. That is the entire point, and
+ * the only reason to accept a timer over an event.
+ *
+ * It is therefore deliberately CAUTIOUS about what it claims. It does not say
+ * the refresh finished, because it does not know: an hour is the documented
+ * upper bound, not a guarantee, and the round may have failed. It says the
+ * round should be done and invites the user to look.
+ *
+ * Cancelled by {@link cancelArkRefreshReminder} the moment a completion is
+ * actually observed, so a user whose app stayed alive gets the accurate
+ * "Refresh complete" and never sees this one.
+ */
+export function scheduleArkRefreshReminder(capsuleCount?: number): void {
+    // Same toggle that gates every other Ark alarm.
+    if (!useAuthStore.getState().arkBgRefreshEnabled) return;
+    ensureInit();
+    const subject =
+        typeof capsuleCount === 'number' && capsuleCount > 0
+            ? `${capsuleCount} capsule${capsuleCount === 1 ? '' : 's'}`
+            : 'Your capsules';
+    try {
+        // Cast as the permission check above does: this library's types are
+        // stale and omit the scheduling methods it ships. Casting only the new
+        // call sites, so the repo's error baseline does not move.
+        (PushNotification as any).localNotificationSchedule({
+            id: REFRESH_REMINDER_ID,
+            channelId: CHANNEL_ID,
+            title: 'Refresh should be done',
+            // Deliberately not "is done". See the docstring: this alarm was set
+            // an hour ago and has observed nothing since.
+            message: `${subject} were refreshing. Tap to check they went through.`,
+            date: new Date(Date.now() + REFRESH_REMINDER_DELAY_MS),
+            priority: 'low',
+            importance: 'low',
+            playSound: false,
+            userInfo: { source: ARK_REFRESH_REMINDER_SOURCE, capsuleCount },
+            allowWhileIdle: true,
+        });
+    } catch (err) {
+        // Never let a reminder break a submission that already succeeded.
+        console.warn('[Ark notifications] scheduleArkRefreshReminder:', err);
+    }
+}
+
+/** Drop the backstop, called as soon as a completion is actually observed. */
+export function cancelArkRefreshReminder(): void {
+    try {
+        (PushNotification as any).cancelLocalNotification(REFRESH_REMINDER_ID);
+    } catch (err) {
+        console.warn('[Ark notifications] cancelArkRefreshReminder:', err);
+    }
 }
 
 /**

--- a/src/services/ark/backgroundRefresh.ts
+++ b/src/services/ark/backgroundRefresh.ts
@@ -11,6 +11,7 @@ import {
 } from './backgroundKeychain';
 import { getArkWalletHandle, getCachedArkMnemonic, openArkWallet } from './walletHandle';
 import { hasActiveArkExitRecords } from './exit';
+import { maybeSweepDustArkVtxos } from './foregroundSweep';
 import { maintenanceArkDelegated } from './refresh';
 import { syncArkWallet } from './sync';
 import { AVG_BLOCK_MINUTES, fetchChainTipHeight } from './chainTip';
@@ -237,6 +238,23 @@ export async function runArkBackgroundMaintenance(
             }
         } catch (regErr: any) {
             console.warn('[Ark bg-refresh] expiry re-registration failed (non-fatal):', regErr?.message ?? regErr);
+        }
+
+        // Dust sweep on the same wake. `maintenanceDelegated` picks its own
+        // capsules inside bark and there is no evidence it picks sub floor ones,
+        // so a wallet whose only problem is dust would wake, do nothing, and go
+        // back to sleep. This is the one rescue that shape has, and it needs no
+        // user present: the ASP accepts the delegation in seconds and finishes
+        // the round alone. Skipped by its own guards if maintenance above just
+        // submitted a round (one submission per wallet at a time).
+        try {
+            const vtxos = await fetchArkVtxos();
+            const tipHeight = await fetchChainTipHeight();
+            if (vtxos && typeof tipHeight === 'number') {
+                await maybeSweepDustArkVtxos(vtxos.spendable, tipHeight);
+            }
+        } catch (dustErr: any) {
+            console.warn('[Ark bg-refresh] dust sweep failed (non-fatal):', dustErr?.message ?? dustErr);
         }
     } catch (err: any) {
         const s = useAuthStore.getState();

--- a/src/services/ark/chainTipFreshness.ts
+++ b/src/services/ark/chainTipFreshness.ts
@@ -1,0 +1,228 @@
+/**
+ * Nominal minutes per block, mirroring `AVG_BLOCK_MINUTES` in ./chainTip.
+ *
+ * Deliberately re-declared rather than imported: chainTip.ts imports
+ * ./config, which imports the bark SDK, and config.ts cannot be loaded under
+ * jest. Keeping this module free of that edge is what lets the rules below be
+ * unit-tested. Same reasoning (and same trade) as ./esploraProviders.
+ *
+ * If AVG_BLOCK_MINUTES ever changes, change this with it. The unit suite
+ * pins the value so the drift is at least loud.
+ */
+export const NOMINAL_BLOCK_MINUTES = 10;
+
+/**
+ * How old the cached chain tip is allowed to get before the vault's expiry
+ * numbers stop being presented as verified.
+ *
+ * Background (the bug this module exists to close): `arkChainTipHeight` is
+ * only written when `fetchChainTipHeight()` succeeds. On an esplora outage
+ * the previous value is deliberately left in place, so every consumer that
+ * computes `expiryHeight - tip` freezes at whatever it read last. The
+ * VTXO countdown then stops ticking down and holds a value that is too
+ * generous, and it holds it silently: a frozen "25 days left" renders
+ * identically to a true one. The whole store is persisted (there is no
+ * `partialize`), so the stale tip also survives a force-quit, and the
+ * usual user remedy of relaunching reconfirms the wrong number instead of
+ * clearing it. Issue #204 was the same defect reached by a different route
+ * (the exit path returned before refreshing the tip) and its fix notes call
+ * the result "stale and over-optimistic".
+ *
+ * Two thresholds, both deliberately generous relative to the sync cadence
+ * (30s on iOS, 60s on Android) so a single missed tick never alarms:
+ *
+ *   - FRESH   (<= 3 min)  roughly 3-6 ticks of slack. Normal operation.
+ *   - DEGRADED(<= 20 min) esplora is flaking or the device is offline.
+ *                         Numbers are still shown but marked estimated.
+ *   - STALE   (> 20 min)  two block intervals with no contact. Nothing read
+ *                         from the chain can be asserted, including whether
+ *                         a VTXO is dead.
+ *
+ * Intentionally STRICTER than `MAX_TIP_AGE_FOR_TRIAGE_MS` (1 hour, in
+ * ./exitFunding), and the difference is not an oversight. That threshold
+ * decides whether to REFUSE to compute an exit plan, so it is set where the
+ * drift would actually change the answer. These thresholds decide how to
+ * LABEL a number we are showing either way, so they sit where the number
+ * stops being current. Do not collapse them into one value.
+ */
+export const TIP_FRESH_MS = 3 * 60 * 1000;
+export const TIP_DEGRADED_MS = 20 * 60 * 1000;
+
+export type TipFreshnessLevel = 'fresh' | 'degraded' | 'stale' | 'unknown';
+
+export interface TipFreshness {
+    level: TipFreshnessLevel;
+    /** Age of the cached tip in ms, or null when we have never fetched one. */
+    ageMs: number | null;
+    /**
+     * Whether a chain-derived assertion may be treated as authoritative.
+     * False for 'stale' and 'unknown'. Callers use this to avoid asserting
+     * the UNSAFE-if-wrong direction of a claim: specifically, "this VTXO is
+     * expired" must not be shown off a tip we cannot vouch for, because that
+     * tells the user their funds are gone when they may still be refreshable
+     * inside the ASP's post-expiry grace window.
+     */
+    trusted: boolean;
+}
+
+/**
+ * Classify how much we can rely on the cached chain tip.
+ *
+ * `fetchedAtMs` is the wall-clock time the tip was last successfully read,
+ * null when the app has never reached esplora.
+ */
+export function deriveTipFreshness(args: {
+    fetchedAtMs: number | null;
+    nowMs: number;
+}): TipFreshness {
+    const { fetchedAtMs, nowMs } = args;
+    if (fetchedAtMs === null || !Number.isFinite(fetchedAtMs)) {
+        return { level: 'unknown', ageMs: null, trusted: false };
+    }
+    // A clock that moved backwards (timezone change, NTP correction, user
+    // edit) would otherwise read as a negative age and pass every threshold
+    // as "fresh". Clamp: we cannot prove freshness, so do not claim it.
+    const ageMs = Math.max(0, nowMs - fetchedAtMs);
+    if (ageMs <= TIP_FRESH_MS) return { level: 'fresh', ageMs, trusted: true };
+    if (ageMs <= TIP_DEGRADED_MS) return { level: 'degraded', ageMs, trusted: true };
+    return { level: 'stale', ageMs, trusted: false };
+}
+
+/**
+ * The chain tip to actually compute expiry against: the last fetched height
+ * advanced by however many blocks are likely to have been mined since.
+ *
+ * Freezing the tip is the failure we are fixing, so doing nothing is not an
+ * option. Extrapolating at the nominal block interval is an estimate, but it
+ * errs in the SAFE direction and freezing errs in the unsafe one:
+ *
+ *   - Extrapolating too fast  -> we understate remaining life -> the user
+ *     refreshes earlier than strictly needed. Costs a few sats of round fee.
+ *   - Freezing                -> we overstate remaining life -> the user
+ *     does nothing and the VTXO expires. Costs the VTXO.
+ *
+ * Real inter-block time runs slightly under the nominal 10 minutes whenever
+ * hashrate is growing, so this estimate is, if anything, mildly conservative
+ * too, which is the direction we want.
+ *
+ * Deliberately uncapped. The cold-launch case is exactly why: an app reopened
+ * after three weeks offline reads its persisted tip from disk, and adding the
+ * elapsed blocks is what correctly renders those VTXOs as long gone rather
+ * than showing the 25-days-left number they had when the app was last closed.
+ *
+ * Returns null when there is no tip at all, which callers already handle as
+ * "expiry unknown".
+ */
+export function effectiveChainTip(args: {
+    tip: number | null;
+    fetchedAtMs: number | null;
+    nowMs: number;
+}): number | null {
+    const { tip, fetchedAtMs, nowMs } = args;
+    if (tip === null || !Number.isFinite(tip)) return null;
+    if (fetchedAtMs === null || !Number.isFinite(fetchedAtMs)) return tip;
+    const ageMs = Math.max(0, nowMs - fetchedAtMs);
+    const blockMs = NOMINAL_BLOCK_MINUTES * 60 * 1000;
+    return tip + Math.floor(ageMs / blockMs);
+}
+
+/**
+ * Traffic-light summary of whether the vault can currently see the chain.
+ *
+ * The vault UI previously looked identical whether esplora was answering or
+ * had been unreachable for a day, which is what let a frozen countdown pass
+ * for a live one. This is the signal that makes the difference visible.
+ *
+ * Two inputs, because they fail independently:
+ *   - the chain tip (esplora), which is what every expiry number is computed
+ *     against, and
+ *   - the sync loop's own completion stamp, which goes stale when the wallet
+ *     handle is wedged or the ASP is unreachable even while esplora is fine.
+ *
+ * The worse of the two wins. A vault that can read the chain but cannot
+ * complete a sync is not healthy, and neither is the reverse.
+ */
+export type VaultConnectivityLevel = 'green' | 'yellow' | 'red';
+
+export interface VaultConnectivity {
+    level: VaultConnectivityLevel;
+    tip: TipFreshness;
+    /** Age of the last completed sync cycle in ms, null if never completed. */
+    syncAgeMs: number | null;
+}
+
+export function deriveVaultConnectivity(args: {
+    tipFetchedAtMs: number | null;
+    lastSyncedAtMs: number | null;
+    nowMs: number;
+}): VaultConnectivity {
+    const { tipFetchedAtMs, lastSyncedAtMs, nowMs } = args;
+    const tip = deriveTipFreshness({ fetchedAtMs: tipFetchedAtMs, nowMs });
+
+    const syncAgeMs =
+        lastSyncedAtMs === null || !Number.isFinite(lastSyncedAtMs)
+            ? null
+            : Math.max(0, nowMs - lastSyncedAtMs);
+
+    const tipLevel: VaultConnectivityLevel =
+        tip.level === 'fresh' ? 'green' : tip.level === 'degraded' ? 'yellow' : 'red';
+
+    const syncLevel: VaultConnectivityLevel =
+        syncAgeMs === null
+            ? 'red'
+            : syncAgeMs <= TIP_FRESH_MS
+                ? 'green'
+                : syncAgeMs <= TIP_DEGRADED_MS
+                    ? 'yellow'
+                    : 'red';
+
+    const rank: Record<VaultConnectivityLevel, number> = { green: 0, yellow: 1, red: 2 };
+    const level = rank[syncLevel] > rank[tipLevel] ? syncLevel : tipLevel;
+
+    return { level, tip, syncAgeMs };
+}
+
+/**
+ * Maximum drift tolerated between a queued expiry alarm and the current best
+ * estimate of when the VTXO actually expires, before the alarm is re-queued.
+ *
+ * Two hours: the tightest warnings in the schedule are at 12h and 6h before
+ * expiry, so drift beyond a couple of hours is what starts moving those
+ * across the deadline they exist to precede.
+ */
+export const EXPIRY_ALARM_MAX_DRIFT_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Whether a VTXO's queued OS expiry alarms should be re-scheduled.
+ *
+ * The bug this closes: the alarms are computed ONCE, at the first sync that
+ * sees the VTXO, as `now + blocksLeft * 10 minutes`, and the scheduling call
+ * is then guarded on "have we scheduled this id before". Every later tick
+ * recomputes the estimate against a fresh tip and stores it, but never
+ * re-queues, so the stored estimate silently converges on the truth while the
+ * OS alarms stay pinned to the original guess. Nothing compared the two.
+ *
+ * The 10-minute nominal block interval is the source of the drift: real
+ * inter-block time runs under 10 minutes whenever hashrate is growing, so
+ * real expiry arrives EARLIER than the original projection and every alarm
+ * fires late. Over a full 28-day life that can be enough to push the last
+ * warnings past the expiry they were meant to precede.
+ *
+ * Re-scheduling is safe and cheap: the OS replaces an entry with the same id
+ * (see scheduleVtxoExpiryWarnings), so this is an update, not a duplicate.
+ * Gated on a threshold rather than run every tick because re-queueing five
+ * alarms per VTXO every 30 seconds would be wasteful and races the OS
+ * scheduler for no gain.
+ *
+ * `previousAtMs` is null when this VTXO has never been scheduled, which is
+ * always a yes.
+ */
+export function shouldRescheduleExpiryWarning(args: {
+    previousAtMs: number | null;
+    currentAtMs: number;
+    maxDriftMs?: number;
+}): boolean {
+    const { previousAtMs, currentAtMs, maxDriftMs = EXPIRY_ALARM_MAX_DRIFT_MS } = args;
+    if (previousAtMs === null || !Number.isFinite(previousAtMs)) return true;
+    return Math.abs(currentAtMs - previousAtMs) > maxDriftMs;
+}

--- a/src/services/ark/chainTipFreshness.ts
+++ b/src/services/ark/chainTipFreshness.ts
@@ -151,12 +151,37 @@ export interface VaultConnectivity {
     syncAgeMs: number | null;
 }
 
+/**
+ * Consecutive failed sync ticks at which the vault is called offline.
+ *
+ * Two, so roughly a minute at the 30s tick. One is enough to stop claiming
+ * everything is fine, but not enough to shout: a single failed tick is a
+ * common blip and flashing red on every one of them would train the user to
+ * ignore the colour that matters most.
+ */
+export const SYNC_FAIL_STREAK_FOR_RED = 2;
+
 export function deriveVaultConnectivity(args: {
     tipFetchedAtMs: number | null;
     lastSyncedAtMs: number | null;
     nowMs: number;
+    /**
+     * Consecutive failed sync ticks, 0 when the last tick succeeded.
+     *
+     * Without this the derivation is age-only, and both timestamps above are
+     * written ONLY on success, so a vault failing every single tick is
+     * indistinguishable from an idle one. Reaching red then took
+     * TIP_DEGRADED_MS, 20 minutes, and a device with its network switched off
+     * reported "connection slow" for the whole of it while the app had known
+     * on the first failed tick. Observed on device 2026-09-08.
+     *
+     * A failure is direct evidence. Age is only a proxy for it, so when both
+     * are available the evidence wins.
+     */
+    syncFailStreak?: number;
 }): VaultConnectivity {
     const { tipFetchedAtMs, lastSyncedAtMs, nowMs } = args;
+    const failStreak = Math.max(0, Math.trunc(args.syncFailStreak ?? 0));
     const tip = deriveTipFreshness({ fetchedAtMs: tipFetchedAtMs, nowMs });
 
     const syncAgeMs =
@@ -176,8 +201,16 @@ export function deriveVaultConnectivity(args: {
                     ? 'yellow'
                     : 'red';
 
+    // Failed ticks escalate on their own, independently of age. One says stop
+    // claiming green when we have just been told otherwise; two says offline.
+    const failLevel: VaultConnectivityLevel =
+        failStreak >= SYNC_FAIL_STREAK_FOR_RED ? 'red' : failStreak > 0 ? 'yellow' : 'green';
+
     const rank: Record<VaultConnectivityLevel, number> = { green: 0, yellow: 1, red: 2 };
-    const level = rank[syncLevel] > rank[tipLevel] ? syncLevel : tipLevel;
+    // Worst of the three wins, same rule as before with one more input.
+    const level = [tipLevel, syncLevel, failLevel].reduce((worst, l) =>
+        rank[l] > rank[worst] ? l : worst,
+    );
 
     return { level, tip, syncAgeMs };
 }

--- a/src/services/ark/datadir.ts
+++ b/src/services/ark/datadir.ts
@@ -20,12 +20,38 @@ export async function ensureArkDatadir(): Promise<string> {
  * Delete the Ark datadir (VTXO state, SQLite, exit txs).
  *
  * DESTRUCTIVE: any funds in VTXOs not backed up externally are unrecoverable
- * after this. Intended for dev-only resets. The `ensured` latch is flipped
- * back so a subsequent `ensureArkDatadir()` recreates the folder cleanly.
+ * after this.
+ *
+ * NOT dev-only, despite what this said until 2026-09-08. Every caller is a
+ * shipping path: the orphan-datadir auto-clean in CreateArkScreen, "Delete
+ * vault" in Ark settings, and the re-key in ArkSeedPhraseScreen. This is the
+ * function that destroys funds, and it has form: the old
+ * `pendingExitsTotalSats == 0` auto-delete wiped a wallet mid-exit twice.
+ *
+ * THROWS IF THE DIRECTORY SURVIVES. `RNFS.unlink` does not only fail on a
+ * missing path; it also fails on open file descriptors, iOS file protection,
+ * and partial directory deletes, and in those cases the datadir is still there
+ * afterwards. Callers use the throw to decide whether it is safe to delete the
+ * seed, so "did it actually go" has to be answered rather than assumed.
+ *
+ * The `ensured` latch is reset in a `finally`. It used to sit after the awaited
+ * unlink, so a throw left it `true` and the next `ensureArkDatadir()` returned
+ * the path without checking the directory was there.
  */
 export async function deleteArkDatadir(): Promise<void> {
-    if (await RNFS.exists(ARK_DATADIR)) {
-        await RNFS.unlink(ARK_DATADIR);
+    try {
+        if (await RNFS.exists(ARK_DATADIR)) {
+            await RNFS.unlink(ARK_DATADIR);
+        }
+        // Verify rather than trust. A resolved unlink is not proof on every
+        // platform and failure mode, and the caller is about to decide whether
+        // to destroy the only key to whatever is still on disk.
+        if (await RNFS.exists(ARK_DATADIR)) {
+            throw new Error(
+                `Ark datadir still present after delete: ${ARK_DATADIR}`,
+            );
+        }
+    } finally {
+        ensured = false;
     }
-    ensured = false;
 }

--- a/src/services/ark/dustSweep.ts
+++ b/src/services/ark/dustSweep.ts
@@ -1,0 +1,227 @@
+/**
+ * When should the wallet fold its dust capsules into one, by itself?
+ *
+ * WHY THIS EXISTS
+ *
+ * A Lightning receive is paid out of the ASP's VTXO pool, and the ASP bundles
+ * pool VTXOs the way an on-chain wallet bundles inputs. So a single 700 sat
+ * receive can land as a 300 and a 400 (observed live, reported to Second.tech
+ * 2026-09; Peter confirmed the bundling is by design). Each piece is below
+ * ARK_REFRESH_MIN_SATS, so:
+ *
+ *   - useArkoorReceivePrompt refuses to auto-refresh either one (its estimate
+ *     says the post-fee output would fall below the floor) and shows a notice
+ *     telling the user to spend them,
+ *   - foregroundSweep counts them as stranded dust and skips them,
+ *   - changeRefresh refuses them for the same reason,
+ *
+ * and the only thing that can actually save them is the user finding the "Dust
+ * refresh" button on the Capsules tab. Nobody does that. The pieces then expire
+ * even though the wallet holds enough dust to rescue them.
+ *
+ * The rescue itself is not new and not theoretical: a DELEGATED round over a
+ * batch of sub-floor inputs is accepted as long as the batch clears the dust
+ * limit, confirmed live on mainnet 2026-08-20 (two 400 sat capsules swept into
+ * one, bark 0.6.1, which is the core inside SDK 0.16.1 today). This module is
+ * that same rescue expressed as a rule, so the wallet can run it on its own.
+ *
+ * WHY A TOTAL, NOT A PER INPUT FLOOR
+ *
+ * The per input floor (ARK_REFRESH_MIN_SATS) is what makes a lone dust capsule
+ * unrefreshable, and it is why dust must never ride along in a MIXED batch of
+ * dust and healthy capsules (one sub floor input has made the ASP reject the
+ * whole round, so the healthy inputs lose their refresh too). Neither of those
+ * facts is changed here. A dust ONLY batch is the one shape that is known to
+ * work, so that is the only shape this module ever produces.
+ *
+ * WHY THE TOTAL IS NOT THE DUST LIMIT
+ *
+ * The ASP accepts the round as soon as the batch clears the on chain dust limit
+ * (ARK_VTXO_DUST_SATS, 330), and the manual button uses exactly that gate,
+ * because a user who taps a button has decided for themselves. An AUTOMATIC
+ * sweep should clear a higher bar: a 350 sat batch produces a ~349 sat capsule,
+ * which is still below the refresh floor, so the wallet would have spent a fee
+ * to arrive back at a capsule that cannot refresh itself, and nothing would have
+ * changed. The batch has to be able to produce an output that clears
+ * ARK_REFRESH_MIN_SATS, so the swept capsule rejoins normal maintenance.
+ *
+ * This rule applies that as a cheap size pre-filter only. The AUTHORITATIVE gate
+ * is the SDK's own fee estimate at submit time (see maybeSweepDustArkVtxos),
+ * because the fee is what decides whether the output clears the floor, and only
+ * bark can price a round. Keeping the pre-filter close to the floor rather than
+ * at a comfortable round number matters: a 550 sat Lightning receive that splits
+ * into two dust pieces is rescuable (output ~549, above the floor), and a gate of
+ * 600 would have refused it for no reason.
+ *
+ * WHY THE EXIT RUNWAY FLOOR DOES NOT APPLY
+ *
+ * Every other automatic refresh path refuses to act inside ARK_EXIT_RUNWAY_HOURS
+ * of expiry, because a delegated round that hangs would eat the window the user
+ * needs for a unilateral exit. That trade only exists when the exit is worth
+ * something. It is not, for dust: a 400 sat capsule at depth 17 costs 5,645 vB
+ * of exit tree fees to rescue 400 sats (measured 2026-08-22), which is why the
+ * exit triage discards dust rather than funding it. So a near expiry dust
+ * capsule loses nothing by joining a round, and doing nothing loses all of it.
+ *
+ * What we DO refuse is an input that could expire while the round runs. An
+ * expired input poisons the whole round, mainnet rounds fire hourly, so an input
+ * inside ARK_DUST_SWEEP_MIN_BLOCKS_LEFT of expiry is left out rather than
+ * allowed to sink the rescue of the others.
+ *
+ * Pure and import free, matching changeRefresh.ts and refreshBatch.ts, so the
+ * rule can be tested without standing up a wallet.
+ */
+
+/**
+ * Size pre-filter: the total the dust must reach before the wallet even asks
+ * bark to price a sweep.
+ *
+ * ARK_REFRESH_MIN_SATS (500) plus a 20 sat fee allowance. Below this the output
+ * cannot clear the refresh floor whatever the fee comes back as, so there is
+ * nothing to price. Above it, the SDK's estimate decides: the caller requires
+ * total minus fee to clear the floor before it submits anything. The fee was
+ * measured at ~1 sat on device (2026-08-20), so 20 is generous headroom rather
+ * than a real constraint.
+ *
+ * The manual Capsules button keeps its lower ARK_VTXO_DUST_SATS gate. A user who
+ * taps a button has decided for themselves.
+ */
+export const ARK_DUST_SWEEP_MIN_TOTAL_SATS = 520;
+
+/**
+ * Minimum blocks of life an input needs before it may join a sweep. Mainnet
+ * rounds run hourly and an expired input makes the ASP reject the whole round,
+ * so anything inside ~2 hours of expiry is excluded to protect the batch it
+ * would otherwise be riding in.
+ */
+export const ARK_DUST_SWEEP_MIN_BLOCKS_LEFT = 12;
+
+export type DustSweepVtxoInput = {
+    id: string;
+    sats: number;
+    /**
+     * Blocks until expiry, or null when the wallet cannot know. Arkoor capsules
+     * report expiryHeight 0 (the SDK does not surface the ASP trust window), and
+     * they are precisely the capsules a Lightning receive produces, so null must
+     * mean "include", not "skip". Their real deadline (~3 days) is far outside
+     * the mid round window this field guards.
+     */
+    blocksUntilExpiry: number | null;
+    /** bark state tag, flattened to its variant string. */
+    stateTag: string;
+    /** Already submitted to a round by another caller. */
+    alreadyRefreshing: boolean;
+};
+
+export type BuildDustSweepInputs = {
+    vtxos: readonly DustSweepVtxoInput[];
+    /** A unilateral exit is active on this wallet. */
+    exitInProgress: boolean;
+    /** Per input round minimum (ARK_REFRESH_MIN_SATS). Below it is dust. */
+    minRefreshSats: number;
+    /** Batch total the sweep needs; defaults to ARK_DUST_SWEEP_MIN_TOTAL_SATS. */
+    minTotalSats?: number;
+    /** Life an input needs to survive the round; defaults to ARK_DUST_SWEEP_MIN_BLOCKS_LEFT. */
+    minBlocksLeft?: number;
+};
+
+export type DustSweepPlan = {
+    sweep: boolean;
+    /**
+     * Ids to hand to refreshVtxosDelegated. Deliberately EMPTY unless `sweep`,
+     * so a caller that forgets to read `sweep` submits nothing rather than an
+     * unacceptable batch. Read `candidateCount` / `candidateSats` for what was
+     * considered.
+     */
+    ids: string[];
+    /** Aggregate sats of `ids`. */
+    totalSats: number;
+    /** Dust that passed every per input check, whether or not the batch fired. */
+    candidateCount: number;
+    /** Aggregate sats of that dust. Non zero on a refusal, which is the log line. */
+    candidateSats: number;
+    reason:
+        | 'sweep'
+        | 'exit-in-progress'
+        | 'no-dust'
+        | 'single-capsule'
+        | 'below-min-total';
+    /** Dust left out (not spendable, mid round, expiring inside the window). */
+    excludedCount: number;
+    /** Aggregate sats of the excluded dust, for the log line and any notice. */
+    excludedSats: number;
+};
+
+/**
+ * Decide whether the wallet's dust is worth sweeping, and which capsules go in.
+ */
+export function buildDustSweepPlan(input: BuildDustSweepInputs): DustSweepPlan {
+    const minTotalSats = input.minTotalSats ?? ARK_DUST_SWEEP_MIN_TOTAL_SATS;
+    const minBlocksLeft = input.minBlocksLeft ?? ARK_DUST_SWEEP_MIN_BLOCKS_LEFT;
+
+    const ids: string[] = [];
+    let totalSats = 0;
+    let excludedCount = 0;
+    let excludedSats = 0;
+
+    const refuse = (reason: DustSweepPlan['reason']): DustSweepPlan => ({
+        sweep: false,
+        ids: [],
+        totalSats: 0,
+        candidateCount: ids.length,
+        candidateSats: totalSats,
+        reason,
+        excludedCount,
+        excludedSats,
+    });
+
+    // A cooperative round spends a coin the exit has already committed on chain.
+    // Same refusal as every other refresh path.
+    if (input.exitInProgress) return refuse('exit-in-progress');
+
+    for (const v of input.vtxos) {
+        // Dust is defined by the per input refresh floor: these are exactly the
+        // capsules no other path can refresh.
+        if (v.sats >= input.minRefreshSats) continue;
+        if (v.stateTag.toLowerCase() !== 'spendable') {
+            excludedCount += 1;
+            excludedSats += v.sats;
+            continue;
+        }
+        if (v.alreadyRefreshing) {
+            excludedCount += 1;
+            excludedSats += v.sats;
+            continue;
+        }
+        // null is arkoor (expiry unknown, ~3 days out) and is included on
+        // purpose. A KNOWN expiry inside the round window is not: an input that
+        // expires mid round makes the ASP reject the batch it is riding in.
+        if (v.blocksUntilExpiry != null) {
+            if (!Number.isFinite(v.blocksUntilExpiry) || v.blocksUntilExpiry < minBlocksLeft) {
+                excludedCount += 1;
+                excludedSats += v.sats;
+                continue;
+            }
+        }
+        ids.push(v.id);
+        totalSats += v.sats;
+    }
+
+    if (ids.length === 0) return refuse('no-dust');
+    // A lone sub floor capsule cannot join a round on its own whatever its size:
+    // its round output would fall below the dust limit and the ASP rejects it.
+    // Only a batch has ever been accepted, so never submit a single id.
+    if (ids.length === 1) return refuse('single-capsule');
+    if (totalSats < minTotalSats) return refuse('below-min-total');
+
+    return {
+        sweep: true,
+        ids,
+        totalSats,
+        candidateCount: ids.length,
+        candidateSats: totalSats,
+        reason: 'sweep',
+        excludedCount,
+        excludedSats,
+    };
+}

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -241,7 +241,9 @@ export async function maybeSweepDustArkVtxos(
             return;
         }
 
-        sweepInFlight = true;
+        // Latch already claimed above, before the awaits. Only the pacing
+        // clock is stamped here, so a tick that bailed out earlier does not
+        // consume the next window.
         lastDustSweepAt = now;
         console.log(
             '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -7,8 +7,10 @@ import {
     ARK_REFRESH_MIN_SATS,
     ARK_SWEEP_MAX_RUNWAY_HOURS,
 } from './config';
+import { buildDustSweepPlan } from './dustSweep';
 import {
     ArkRefreshInFlightError,
+    estimateArkRefreshFee,
     fetchArkPendingRoundStates,
     refreshArkVtxosDelegatedAndSync,
 } from './refresh';
@@ -28,8 +30,10 @@ import type { ArkVtxoView } from './vtxos';
  *    we must NOT refresh — a delegated round that hangs would eat the exit
  *    window; the user should spend/exit instead (expiry warnings + escalation
  *    own that zone). Above a week there is no reason to spend the fee yet.
- *  - Dust: sub-ARK_REFRESH_MIN_SATS inputs are STRANDED, never ridden along
- *    (one sub-floor input makes bark reject the whole round). User spends them.
+ *  - Dust: sub-ARK_REFRESH_MIN_SATS inputs never ride along in this batch (one
+ *    sub-floor input makes bark reject the whole round). They are handled by
+ *    maybeSweepDustArkVtxos below, which folds them into ONE capsule in a dust
+ *    only round, the single shape the ASP is known to accept.
  *  - Covers regular + arkoor VTXOs uniformly (any kind, real expiry).
  *
  * Why this is safe now (it deadlocked in July on the self-signed path): the
@@ -51,6 +55,11 @@ import type { ArkVtxoView } from './vtxos';
 let sweepInFlight = false;
 let lastSweepAt = 0;
 let consecutiveFailures = 0;
+// Same pacing, kept separately so a dust sweep and a band sweep do not consume
+// each other's gap. `sweepInFlight` is deliberately SHARED: one submission at a
+// time per wallet, whichever kind it is.
+let lastDustSweepAt = 0;
+let dustFailures = 0;
 
 // Base pacing between sweep submissions. Only actual submissions consume it;
 // empty ticks (nothing in-band) re-run the cheap in-memory selection freely.
@@ -61,6 +70,171 @@ const FG_SWEEP_MAX_GAP_MS = 60 * 60 * 1000;
 
 function blocksForHours(hours: number): number {
     return Math.round((hours * 60) / AVG_BLOCK_MINUTES);
+}
+
+/**
+ * Fold the wallet's dust capsules into one, unprompted.
+ *
+ * WHY THIS IS SEPARATE FROM THE BAND SWEEP ABOVE
+ *
+ * The band sweep is driven by EXPIRY: it acts on capsules in their last week
+ * and skips everything else, dust included. That leaves a hole exactly where
+ * users get hurt. A Lightning receive is paid out of the ASP's VTXO pool and can
+ * arrive as several sub floor pieces (a 700 sat receive landed as a 300 and a
+ * 400, reported to Second.tech 2026-09), and those pieces are arkoor, so they
+ * report expiryHeight 0 and the band never even sees them. Nothing automatic
+ * could rescue them: the receive prompt refuses them as too small to refresh
+ * alone, this sweep counted them as stranded, and only the manual "Dust refresh"
+ * button on the Capsules tab could act. Users do not find that button.
+ *
+ * The trigger here is SIZE, not expiry: as soon as the wallet holds enough dust
+ * to make a batch the ASP will take, fold it into one capsule that is large
+ * enough to look after itself from then on.
+ *
+ * The batch is dust only, always. That is the shape confirmed live on mainnet
+ * (2026-08-20, two 400s into one, on the same bark core we ship today). Dust is
+ * still never mixed into a batch of healthy capsules: one sub floor input has
+ * made the ASP reject an entire round, and taking healthy capsules down with the
+ * dust is a strictly worse failure than leaving the dust alone.
+ *
+ * Shares `sweepInFlight` and the pending round check with the band sweep, so the
+ * wallet never has two submissions racing, and gets its own pacing so a wallet
+ * that sits just under the total does not re-submit on every tick.
+ */
+export async function maybeSweepDustArkVtxos(
+    spendable: ArkVtxoView[],
+    tip: number,
+    strandedInBand = 0,
+): Promise<void> {
+    if (sweepInFlight) return;
+    // Callable on its own from the background wake, so it repeats the two
+    // preconditions the band sweep checks before delegating to it.
+    if (getArkWalletHandle() == null) return;
+    const store = useAuthStore.getState();
+    if (store.arkRefreshStuck) return;
+    const refreshing = new Set(store.arkRefreshingVtxoIds);
+
+    const plan = buildDustSweepPlan({
+        vtxos: spendable.map((v) => ({
+            id: v.id,
+            sats: v.sats,
+            // expiryHeight 0 is arkoor: bark does not surface the ASP's trust
+            // window, so the height is unknown rather than imminent. null tells
+            // the rule to include it, which is the whole point here.
+            blocksUntilExpiry: v.expiryHeight > 0 ? v.expiryHeight - tip : null,
+            // A capsule mid unilateral exit is committed on chain already.
+            stateTag: v.exiting ? 'exiting' : v.state,
+            alreadyRefreshing: refreshing.has(v.id),
+        })),
+        exitInProgress: store.arkExitInProgress,
+        minRefreshSats: ARK_REFRESH_MIN_SATS,
+    });
+
+    if (!plan.sweep) {
+        // Only a wallet that HOLDS dust it cannot sweep is worth a feed entry.
+        // "Not enough dust yet" is the normal resting state of most wallets and
+        // would just be noise; report the genuinely stuck shapes.
+        const stuck = plan.reason === 'single-capsule' || plan.reason === 'below-min-total';
+        if (stuck || strandedInBand > 0) {
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'dust_stranded',
+                elapsedMs: 0,
+                vtxoCount: stuck ? plan.candidateCount : strandedInBand,
+            });
+        }
+        return;
+    }
+
+    const now = Date.now();
+    const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (dustFailures + 1), FG_SWEEP_MAX_GAP_MS);
+    if (now - lastDustSweepAt < gap) return;
+
+    const pending = await fetchArkPendingRoundStates();
+    if (pending.some((r) => r.ongoing)) {
+        console.log('[Ark dust sweep] skip: a round is already ongoing');
+        return;
+    }
+
+    // The real gate. The size rule above is a pre-filter; only bark can price the
+    // round, and the fee is what decides whether the swept capsule lands above
+    // the refresh floor or straight back in dust. Same shape as the receive
+    // prompt's single capsule decision, for the same reason.
+    let feeSats: number;
+    let spendsOnlyOurDust: boolean;
+    try {
+        const est = await estimateArkRefreshFee(plan.ids);
+        feeSats = est.feeSats;
+        const ours = new Set(plan.ids);
+        spendsOnlyOurDust = est.vtxosSpent.every((id) => ours.has(id));
+    } catch (estErr: any) {
+        // Wallet not ready or a transient network fault. Leave the dust alone and
+        // let a later tick price it again; do not count this as a failure, it
+        // never reached the ASP.
+        console.warn('[Ark dust sweep] fee estimate failed, will retry:', estErr?.message ?? estErr);
+        return;
+    }
+
+    if (!spendsOnlyOurDust) {
+        // The round would drag capsules in that we did not choose, which is the
+        // mixed batch we refuse to build. Never seen in QA; refusing costs
+        // nothing and the alternative risks healthy capsules.
+        console.warn('[Ark dust sweep] skip: the estimate would spend capsules outside the dust batch');
+        return;
+    }
+
+    const outputSats = plan.totalSats - feeSats;
+    if (outputSats < ARK_REFRESH_MIN_SATS) {
+        console.log(
+            '[Ark dust sweep] skip: output', outputSats,
+            'sats would still be below the', ARK_REFRESH_MIN_SATS, 'sat refresh floor',
+        );
+        recordEvent({
+            kind: 'ark-bg-refresh',
+            trigger: 'foreground',
+            outcome: 'dust_stranded',
+            elapsedMs: 0,
+            vtxoCount: plan.ids.length,
+        });
+        return;
+    }
+
+    sweepInFlight = true;
+    lastDustSweepAt = now;
+    console.log(
+        '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',
+        plan.totalSats, 'sats, fee', feeSats, 'sats, output', outputSats,
+        'sats; excluded=', plan.excludedCount,
+    );
+    try {
+        await refreshArkVtxosDelegatedAndSync(plan.ids, plan.totalSats);
+        dustFailures = 0;
+        recordEvent({
+            kind: 'ark-bg-refresh',
+            trigger: 'foreground',
+            outcome: 'success',
+            elapsedMs: Date.now() - now,
+            vtxoCount: plan.ids.length,
+        });
+    } catch (err: any) {
+        if (err instanceof ArkRefreshInFlightError) {
+            console.log('[Ark dust sweep] skipped: refresh already in flight');
+        } else {
+            dustFailures += 1;
+            console.warn('[Ark dust sweep] failed:', err?.message ?? err);
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'error',
+                elapsedMs: Date.now() - now,
+                vtxoCount: plan.ids.length,
+                errorMsg: String(err?.message ?? err).slice(0, 200),
+            });
+        }
+    } finally {
+        sweepInFlight = false;
+    }
 }
 
 /**
@@ -104,18 +278,13 @@ export async function maybeSweepDueArkVtxos(
     }
 
     if (refreshable.length === 0) {
-        // Surface stranded in-band dust so the user knows to spend it (rare;
-        // most dust sits above the floor's runway). Cheap outcomes like an
-        // empty sweep are intentionally NOT recorded to keep the feed sparse.
-        if (strandedDust > 0) {
-            recordEvent({
-                kind: 'ark-bg-refresh',
-                trigger: 'foreground',
-                outcome: 'dust_stranded',
-                elapsedMs: 0,
-                vtxoCount: strandedDust,
-            });
-        }
+        // Nothing in band. Dust is not simply "stranded" any more: a dust ONLY
+        // batch that clears the sweep total is the one shape the ASP accepts,
+        // so try that before reporting a problem. Runs on the whole spendable
+        // set, not the in-band selection above: the dust a Lightning receive
+        // leaves is arkoor, which reports no expiry height at all and is
+        // therefore invisible to the band. See dustSweep.ts.
+        await maybeSweepDustArkVtxos(spendable, tip, strandedDust);
         return;
     }
 

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -12,6 +12,8 @@ import {
     fetchArkPendingRoundStates,
     refreshArkVtxosDelegatedAndSync,
 } from './refresh';
+import { classifyArkNetworkFault } from './networkFault';
+import { ARK_SERVER_URL, ESPLORA_URLS } from './config';
 import { getArkWalletHandle } from './walletHandle';
 import type { ArkVtxoView } from './vtxos';
 
@@ -51,6 +53,16 @@ import type { ArkVtxoView } from './vtxos';
 let sweepInFlight = false;
 let lastSweepAt = 0;
 let consecutiveFailures = 0;
+/**
+ * Wall clock before which the sweep must not submit again, set when the chain
+ * source refuses us on quota.
+ *
+ * Separate from `consecutiveFailures` because a quota rejection is not the
+ * same kind of failure. An ordinary error might succeed on the next attempt;
+ * a 429 says the provider is working fine and is refusing THIS IP until its
+ * window rolls. Retrying into that spends the very quota needed to recover.
+ */
+let rateLimitedUntil = 0;
 
 // Base pacing between sweep submissions. Only actual submissions consume it;
 // empty ticks (nothing in-band) re-run the cheap in-memory selection freely.
@@ -58,6 +70,18 @@ const FG_SWEEP_MIN_GAP_MS = 5 * 60 * 1000;
 // S2: cap the backed-off gap so the sweep still retries a few times an hour
 // during a long outage (the fail-streak escalation is the user-facing signal).
 const FG_SWEEP_MAX_GAP_MS = 60 * 60 * 1000;
+/**
+ * How long to stand down after a quota rejection.
+ *
+ * An hour, because Blockstream's unauthenticated cap is stated per hour (700
+ * requests/hour per IP), so the window we are waiting on is an hour wide.
+ * Anything shorter is a guess that spends quota to discover it was too short.
+ *
+ * Safe against the deadline this sweep exists to meet: it fires on capsules
+ * inside ARK_SWEEP_MAX_RUNWAY_HOURS (a week) of expiry, so an hour of silence
+ * costs at most one attempt out of dozens still available.
+ */
+const FG_SWEEP_RATE_LIMIT_BACKOFF_MS = 60 * 60 * 1000;
 
 function blocksForHours(hours: number): number {
     return Math.round((hours * 60) / AVG_BLOCK_MINUTES);
@@ -121,27 +145,47 @@ export async function maybeSweepDueArkVtxos(
 
     // S2 backoff: only now (we have work) enforce pacing between submissions.
     const now = Date.now();
+    if (now < rateLimitedUntil) return;
     const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (consecutiveFailures + 1), FG_SWEEP_MAX_GAP_MS);
     if (now - lastSweepAt < gap) return;
 
-    // Belt-and-suspenders on top of refresh.ts's own guard: skip if a round is
-    // genuinely ongoing so we don't waste a submit + log noise.
-    const pending = await fetchArkPendingRoundStates();
-    if (pending.some((r) => r.ongoing)) {
-        console.log('[Ark sweep] skip: a round is already ongoing');
-        return;
-    }
-
-    sweepInFlight = true;
-    lastSweepAt = now;
+    // CLAIM THE SLOT BEFORE ANY await.
+    //
+    // The latch used to be set after the pending-rounds fetch below, which put
+    // a network round trip between reading `sweepInFlight` and writing it.
+    // Every caller that arrived during that fetch read false, waited, and then
+    // submitted. Worse, the window is widest exactly when it must not be: when
+    // the chain source is slow, the fetch takes longer, so more callers get in,
+    // and every extra submission spends more of the quota that made it slow.
+    //
+    // Measured on device 2026-09-09: 174 submissions in 12 minutes, about one
+    // every two seconds while each one took 18 seconds to fail, all of them on
+    // Blockstream's 429. A restart cleared it only because it emptied the pile
+    // of in-flight calls.
+    //
+    // Everything from here to the finally must therefore be inside the try, so
+    // no early return can leave the latch stuck on.
     const ids = refreshable.map((v) => v.id);
     const totalSats = refreshable.reduce((sum, v) => sum + v.sats, 0);
-    console.log(
-        '[Ark sweep] firing for', ids.length, 'vtxo(s), total', totalSats,
-        'sats; strandedDust=', strandedDust,
-    );
+
+    sweepInFlight = true;
     const startedAt = now;
     try {
+        // Belt-and-suspenders on top of refresh.ts's own guard: skip if a round
+        // is genuinely ongoing so we don't waste a submit + log noise.
+        const pending = await fetchArkPendingRoundStates();
+        if (pending.some((r) => r.ongoing)) {
+            console.log('[Ark sweep] skip: a round is already ongoing');
+            return;
+        }
+
+        // Only stamp the pacing clock once we are actually going to submit.
+        // Stamping it above would let a skipped tick eat the next window.
+        lastSweepAt = Date.now();
+        console.log(
+            '[Ark sweep] firing for', ids.length, 'vtxo(s), total', totalSats,
+            'sats; strandedDust=', strandedDust,
+        );
         await refreshArkVtxosDelegatedAndSync(ids, totalSats);
         consecutiveFailures = 0;
         recordEvent({
@@ -165,6 +209,32 @@ export async function maybeSweepDueArkVtxos(
             // A round started between our check and the submit. Not a failure;
             // don't inflate the backoff. Next eligible tick retries.
             console.log('[Ark sweep] skipped: refresh already in flight');
+        } else if (
+            classifyArkNetworkFault(err, { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }) ===
+            'chain-source-rate-limited'
+        ) {
+            // A quota rejection is a REFUSAL, not a transient failure. The
+            // provider is up and is refusing this IP until its window rolls,
+            // so every retry inside that window spends the quota needed to
+            // recover and pushes the recovery further out.
+            //
+            // Stand down for the width of the window rather than inflating
+            // consecutiveFailures, which tops out at FG_SWEEP_MAX_GAP_MS only
+            // after several failures and would let the next few attempts land
+            // inside the same exhausted hour.
+            rateLimitedUntil = Date.now() + FG_SWEEP_RATE_LIMIT_BACKOFF_MS;
+            console.warn(
+                '[Ark sweep] chain source is rate limiting this connection; standing down for',
+                Math.round(FG_SWEEP_RATE_LIMIT_BACKOFF_MS / 60000), 'min',
+            );
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'error',
+                elapsedMs: Date.now() - startedAt,
+                vtxoCount: ids.length,
+                errorMsg: 'rate-limited by chain source; backing off',
+            });
         } else {
             consecutiveFailures += 1;
             console.warn('[Ark sweep] failed:', err?.message ?? err);

--- a/src/services/ark/foregroundSweep.ts
+++ b/src/services/ark/foregroundSweep.ts
@@ -6,6 +6,8 @@ import {
     ARK_EXIT_RUNWAY_HOURS,
     ARK_REFRESH_MIN_SATS,
     ARK_SWEEP_MAX_RUNWAY_HOURS,
+    ARK_SERVER_URL,
+    ESPLORA_URLS,
 } from './config';
 import { buildDustSweepPlan } from './dustSweep';
 import {
@@ -14,6 +16,7 @@ import {
     fetchArkPendingRoundStates,
     refreshArkVtxosDelegatedAndSync,
 } from './refresh';
+import { classifyArkNetworkFault } from './networkFault';
 import { getArkWalletHandle } from './walletHandle';
 import type { ArkVtxoView } from './vtxos';
 
@@ -60,6 +63,25 @@ let consecutiveFailures = 0;
 // time per wallet, whichever kind it is.
 let lastDustSweepAt = 0;
 let dustFailures = 0;
+/**
+ * Wall clock before which NEITHER sweep may submit, set when the chain source
+ * refuses us on quota. Shared for the same reason `sweepInFlight` is: the quota
+ * belongs to the connection, not to one sweep, so a rejection earned by either
+ * has to silence both.
+ *
+ * Separate from the failure counters because a quota rejection is a different
+ * kind of failure. An ordinary error might succeed next tick; a 429 says the
+ * provider is fine and is refusing THIS IP until its window rolls, and retrying
+ * into that spends the quota needed to recover.
+ */
+let rateLimitedUntil = 0;
+/**
+ * How long to stand down after a quota rejection. An hour, because Blockstream
+ * states its unauthenticated cap per hour (700 requests/hour per IP), so that is
+ * the width of the window being waited on. Guessing shorter spends quota to find
+ * out it was too short.
+ */
+const FG_SWEEP_RATE_LIMIT_BACKOFF_MS = 60 * 60 * 1000;
 
 // Base pacing between sweep submissions. Only actual submissions consume it;
 // empty ticks (nothing in-band) re-run the cheap in-memory selection freely.
@@ -148,89 +170,121 @@ export async function maybeSweepDustArkVtxos(
     }
 
     const now = Date.now();
+    if (now < rateLimitedUntil) return;
     const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (dustFailures + 1), FG_SWEEP_MAX_GAP_MS);
     if (now - lastDustSweepAt < gap) return;
 
-    const pending = await fetchArkPendingRoundStates();
-    if (pending.some((r) => r.ongoing)) {
-        console.log('[Ark dust sweep] skip: a round is already ongoing');
-        return;
-    }
-
-    // The real gate. The size rule above is a pre-filter; only bark can price the
-    // round, and the fee is what decides whether the swept capsule lands above
-    // the refresh floor or straight back in dust. Same shape as the receive
-    // prompt's single capsule decision, for the same reason.
-    let feeSats: number;
-    let spendsOnlyOurDust: boolean;
-    try {
-        const est = await estimateArkRefreshFee(plan.ids);
-        feeSats = est.feeSats;
-        const ours = new Set(plan.ids);
-        spendsOnlyOurDust = est.vtxosSpent.every((id) => ours.has(id));
-    } catch (estErr: any) {
-        // Wallet not ready or a transient network fault. Leave the dust alone and
-        // let a later tick price it again; do not count this as a failure, it
-        // never reached the ASP.
-        console.warn('[Ark dust sweep] fee estimate failed, will retry:', estErr?.message ?? estErr);
-        return;
-    }
-
-    if (!spendsOnlyOurDust) {
-        // The round would drag capsules in that we did not choose, which is the
-        // mixed batch we refuse to build. Never seen in QA; refusing costs
-        // nothing and the alternative risks healthy capsules.
-        console.warn('[Ark dust sweep] skip: the estimate would spend capsules outside the dust batch');
-        return;
-    }
-
-    const outputSats = plan.totalSats - feeSats;
-    if (outputSats < ARK_REFRESH_MIN_SATS) {
-        console.log(
-            '[Ark dust sweep] skip: output', outputSats,
-            'sats would still be below the', ARK_REFRESH_MIN_SATS, 'sat refresh floor',
-        );
-        recordEvent({
-            kind: 'ark-bg-refresh',
-            trigger: 'foreground',
-            outcome: 'dust_stranded',
-            elapsedMs: 0,
-            vtxoCount: plan.ids.length,
-        });
-        return;
-    }
-
+    // CLAIM THE SLOT BEFORE ANY await.
+    //
+    // Same defect the band sweep below carried, and worse here: the latch
+    // used to be set after the pending-round fetch AND the fee estimate, so
+    // two network round trips sat between reading `sweepInFlight` and
+    // writing it. Every caller arriving in that window read false and went
+    // on to submit, and the window is widest exactly when it must not be,
+    // because a slow chain source lengthens both calls.
+    //
+    // Measured on the band sweep on device 2026-09-09: 174 submissions in
+    // 12 minutes, every one refused by a rate-limited chain source. This
+    // path has two awaits rather than one, so it is wider still.
+    //
+    // Everything below sits inside the try so none of the early returns can
+    // leave the latch stuck on.
     sweepInFlight = true;
-    lastDustSweepAt = now;
-    console.log(
-        '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',
-        plan.totalSats, 'sats, fee', feeSats, 'sats, output', outputSats,
-        'sats; excluded=', plan.excludedCount,
-    );
     try {
-        await refreshArkVtxosDelegatedAndSync(plan.ids, plan.totalSats);
-        dustFailures = 0;
-        recordEvent({
-            kind: 'ark-bg-refresh',
-            trigger: 'foreground',
-            outcome: 'success',
-            elapsedMs: Date.now() - now,
-            vtxoCount: plan.ids.length,
-        });
-    } catch (err: any) {
-        if (err instanceof ArkRefreshInFlightError) {
-            console.log('[Ark dust sweep] skipped: refresh already in flight');
-        } else {
-            dustFailures += 1;
-            console.warn('[Ark dust sweep] failed:', err?.message ?? err);
+
+        const pending = await fetchArkPendingRoundStates();
+        if (pending.some((r) => r.ongoing)) {
+            console.log('[Ark dust sweep] skip: a round is already ongoing');
+            return;
+        }
+
+        // The real gate. The size rule above is a pre-filter; only bark can price the
+        // round, and the fee is what decides whether the swept capsule lands above
+        // the refresh floor or straight back in dust. Same shape as the receive
+        // prompt's single capsule decision, for the same reason.
+        let feeSats: number;
+        let spendsOnlyOurDust: boolean;
+        try {
+            const est = await estimateArkRefreshFee(plan.ids);
+            feeSats = est.feeSats;
+            const ours = new Set(plan.ids);
+            spendsOnlyOurDust = est.vtxosSpent.every((id) => ours.has(id));
+        } catch (estErr: any) {
+            // Wallet not ready or a transient network fault. Leave the dust alone and
+            // let a later tick price it again; do not count this as a failure, it
+            // never reached the ASP.
+            console.warn('[Ark dust sweep] fee estimate failed, will retry:', estErr?.message ?? estErr);
+            return;
+        }
+
+        if (!spendsOnlyOurDust) {
+            // The round would drag capsules in that we did not choose, which is the
+            // mixed batch we refuse to build. Never seen in QA; refusing costs
+            // nothing and the alternative risks healthy capsules.
+            console.warn('[Ark dust sweep] skip: the estimate would spend capsules outside the dust batch');
+            return;
+        }
+
+        const outputSats = plan.totalSats - feeSats;
+        if (outputSats < ARK_REFRESH_MIN_SATS) {
+            console.log(
+                '[Ark dust sweep] skip: output', outputSats,
+                'sats would still be below the', ARK_REFRESH_MIN_SATS, 'sat refresh floor',
+            );
             recordEvent({
                 kind: 'ark-bg-refresh',
                 trigger: 'foreground',
-                outcome: 'error',
+                outcome: 'dust_stranded',
+                elapsedMs: 0,
+                vtxoCount: plan.ids.length,
+            });
+            return;
+        }
+
+        sweepInFlight = true;
+        lastDustSweepAt = now;
+        console.log(
+            '[Ark dust sweep] firing for', plan.ids.length, 'capsule(s), total',
+            plan.totalSats, 'sats, fee', feeSats, 'sats, output', outputSats,
+            'sats; excluded=', plan.excludedCount,
+        );
+        try {
+            await refreshArkVtxosDelegatedAndSync(plan.ids, plan.totalSats);
+            dustFailures = 0;
+            recordEvent({
+                kind: 'ark-bg-refresh',
+                trigger: 'foreground',
+                outcome: 'success',
                 elapsedMs: Date.now() - now,
                 vtxoCount: plan.ids.length,
-                errorMsg: String(err?.message ?? err).slice(0, 200),
             });
+        } catch (err: any) {
+            if (err instanceof ArkRefreshInFlightError) {
+                console.log('[Ark dust sweep] skipped: refresh already in flight');
+            } else if (
+                classifyArkNetworkFault(err, { chainUrls: ESPLORA_URLS, arkUrl: ARK_SERVER_URL }) ===
+                'chain-source-rate-limited'
+            ) {
+                // A quota rejection is a REFUSAL, not a transient failure. The
+                // provider is up and refusing this IP until its window rolls, so
+                // retrying inside it spends the quota needed to recover.
+                rateLimitedUntil = Date.now() + FG_SWEEP_RATE_LIMIT_BACKOFF_MS;
+                console.warn(
+                    '[Ark dust sweep] chain source is rate limiting this connection; standing down for',
+                    Math.round(FG_SWEEP_RATE_LIMIT_BACKOFF_MS / 60000), 'min',
+                );
+            } else {
+                dustFailures += 1;
+                console.warn('[Ark dust sweep] failed:', err?.message ?? err);
+                recordEvent({
+                    kind: 'ark-bg-refresh',
+                    trigger: 'foreground',
+                    outcome: 'error',
+                    elapsedMs: Date.now() - now,
+                    vtxoCount: plan.ids.length,
+                    errorMsg: String(err?.message ?? err).slice(0, 200),
+                });
+            }
         }
     } finally {
         sweepInFlight = false;
@@ -290,6 +344,7 @@ export async function maybeSweepDueArkVtxos(
 
     // S2 backoff: only now (we have work) enforce pacing between submissions.
     const now = Date.now();
+    if (now < rateLimitedUntil) return;
     const gap = Math.min(FG_SWEEP_MIN_GAP_MS * (consecutiveFailures + 1), FG_SWEEP_MAX_GAP_MS);
     if (now - lastSweepAt < gap) return;
 

--- a/src/services/ark/history.ts
+++ b/src/services/ark/history.ts
@@ -173,9 +173,9 @@ function describe(
                 : direction;
 
     switch (status) {
-        case 'pending':   return `Pending — ${body.toLowerCase()}`;
-        case 'failed':    return `Failed — ${body.toLowerCase()}`;
-        case 'canceled':  return `Canceled — ${body.toLowerCase()}`;
+        case 'pending':   return `Pending: ${body.toLowerCase()}`;
+        case 'failed':    return `Failed: ${body.toLowerCase()}`;
+        case 'canceled':  return `Canceled: ${body.toLowerCase()}`;
         default:          return body;
     }
 }

--- a/src/services/ark/indeterminate.ts
+++ b/src/services/ark/indeterminate.ts
@@ -18,6 +18,27 @@
  * `exit.claimArkExitsToAddress`, and `recoverOnchainBoard`. Fixing a path
  * rather than a capability leaves the next call site to reintroduce it.
  *
+ * CALL SITES. Keep this list current; an audit found the Lightning ones missing
+ * from it, and the list being wrong is part of why they stayed unguarded. Six
+ * sites were enumerated here, all of them arkoor, on-chain or exit paths, so
+ * "the Lightning branch is not on the list" never looked like an omission.
+ *
+ *   exit.ts                 claimArkExitsToAddress
+ *   exitFunding.ts          convertToExitFees
+ *   recoverOnchainBoard.ts  recoverArkOnchainBoard
+ *   offboard.ts             offboardArkVtxos
+ *   send.ts                 sendArkoorPayment
+ *   send.ts                 sendOnchain
+ *   send.ts                 dispatchLnSend          <- added 2026-09-08
+ *
+ * `lightning.ts#cancelArkLightningReceive` uses `looksLikeConnectionLoss`
+ * directly rather than this wrapper, because it returns a discriminated result
+ * instead of throwing. Same rule, different shape.
+ *
+ * The test to apply when adding a call: does it hand something to the ASP or
+ * the chain that could still land after the connection dies? If yes, it belongs
+ * here, and it belongs on this list.
+ *
  * It imports nothing from the SDK on purpose, so any module can wrap a call
  * without dragging the native binding into a unit test.
  */

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -200,7 +200,14 @@ export type { ArkRefreshFeeView, ArkRefreshResult, ArkDelegatedRefreshResult } f
 
 export { setArkBackgroundRefreshEnabled } from './backgroundRefresh';
 
-export { maybeSweepDueArkVtxos } from './foregroundSweep';
+export { maybeSweepDueArkVtxos, maybeSweepDustArkVtxos } from './foregroundSweep';
+
+export {
+    ARK_DUST_SWEEP_MIN_BLOCKS_LEFT,
+    ARK_DUST_SWEEP_MIN_TOTAL_SATS,
+    buildDustSweepPlan,
+} from './dustSweep';
+export type { BuildDustSweepInputs, DustSweepPlan, DustSweepVtxoInput } from './dustSweep';
 
 export { barkStateTag, isActiveExit } from './barkState';
 

--- a/src/services/ark/lightning.ts
+++ b/src/services/ark/lightning.ts
@@ -60,6 +60,33 @@ export async function tryClaimArkLightningReceives(): Promise<ArkLightningReceiv
         // (e.g. stuck mid-round), which deadlocks the whole 30s sync via
         // its inFlight guard. Observed live: one stuck wait=true call
         // silenced every subsequent cycle until app restart.
+        // DEV only. The claim reports "All N lightning receive claim(s) failed"
+        // with no cause attached (BarkError carries only message/tag/stack, the
+        // per-receive reason is discarded at the FFI boundary), and the receive
+        // is gone by the time anything can be probed after the fact.
+        //
+        // `state` is the field that settles what actually happened, and it cost
+        // most of a night's debugging to learn that: "awaiting-payment" means
+        // nothing ever arrived and the claim failure is noise, while
+        // "htlcs-ready" or later means the money is there and the claim is
+        // genuinely broken. Those two look identical in the error.
+        //
+        // Costs an extra SDK call per sync tick, hence __DEV__ only.
+        if (__DEV__) try {
+            const pendingBefore = await handle.pendingLightningReceives();
+            console.log(
+                '[Ark claim] PRE-CLAIM pending receives:',
+                pendingBefore.length,
+                JSON.stringify(pendingBefore.map((r: { paymentHash: string; amountSats: bigint; state: string }) => ({
+                    hash: r.paymentHash.slice(0, 12),
+                    sats: Number(r.amountSats),
+                    state: r.state,
+                }))),
+            );
+        } catch (probeErr: any) {
+            console.warn('[Ark claim] PRE-CLAIM probe failed:', probeErr?.message ?? probeErr);
+        }
+
         const raw = await handle.tryClaimAllLightningReceives(false);
         console.log(
             '[Ark claim] returned',
@@ -89,6 +116,23 @@ export async function tryClaimArkLightningReceives(): Promise<ArkLightningReceiv
             '| message=', e?.message ?? String(err),
             '| inner=', e?.inner?.errorMessage ?? e?.inner?.message ?? 'n/a',
         );
+        // DEV only. The line above reports `inner= n/a` for claim failures,
+        // because BarkError puts nothing where that destructure reaches. Own
+        // properties are exactly ["message","tag","stack"] and the message is
+        // only the aggregate sentence, so the per-receive reason never crosses
+        // the binding at all. Keep the dump so the next person can confirm that
+        // for themselves rather than re-deriving it, and so it surfaces
+        // immediately if a future SDK starts attaching a cause.
+        if (__DEV__) try {
+            const own = Object.getOwnPropertyNames(err as object);
+            console.warn(
+                '[Ark claim] RAW ERROR keys=', JSON.stringify(own),
+                '| full=', JSON.stringify(err, own),
+                '| proto=', Object.prototype.toString.call(err),
+            );
+        } catch (dumpErr) {
+            console.warn('[Ark claim] RAW ERROR could not be serialised:', String(dumpErr));
+        }
         return [];
     }
 }

--- a/src/services/ark/lightning.ts
+++ b/src/services/ark/lightning.ts
@@ -1,6 +1,7 @@
 import bolt11 from 'bolt11';
 
 import { getArkWalletHandle } from './walletHandle';
+import { looksLikeConnectionLoss } from './networkFault';
 
 /**
  * Plain-JS view of a pending Lightning receive.
@@ -233,21 +234,41 @@ export async function cancelArkLightningReceive(
             return {
                 ok: false,
                 kind: 'preimage-revealed',
-                reason: 'Payment is already in flight — can\'t cancel.',
+                reason: 'Payment is already in flight, so it can\'t be cancelled.',
             };
         }
         if (/already finished/i.test(msg)) {
             return {
                 ok: false,
                 kind: 'already-finished',
-                reason: 'Receive already settled — nothing to cancel.',
+                reason: 'Receive already settled, so there is nothing to cancel.',
+            };
+        }
+        // A dropped connection is not a refusal. Without this branch anything
+        // the two guards above do not match fell through to `kind: 'unknown'`
+        // with the raw text as its reason, which reads to the user as a
+        // definite "it did not happen" for an outcome we cannot know: the ASP
+        // may have accepted the cancellation before the line died.
+        //
+        // Bounded, unlike the send paths: the UI leaves the row in place on
+        // failure, so the next 30s sync corrects the display either way. The
+        // fix is about not asserting something we cannot know.
+        if (looksLikeConnectionLoss(err)) {
+            return {
+                ok: false,
+                kind: 'unknown',
+                reason: 'The connection dropped, so this may or may not have been cancelled. Check again in a moment.',
             };
         }
         console.warn('[Ark cancel-ln-recv] failed:', err);
         return {
             ok: false,
             kind: 'unknown',
-            reason: msg || 'Cancel failed; try again or wait for the next sync.',
+            // Prefer the written sentence over bark's internal text. `msg ||`
+            // had it backwards: it showed the SDK's own vocabulary, unbounded
+            // in length and written for developers, and the human fallback only
+            // appeared when the SDK gave us nothing at all.
+            reason: 'Cancel failed; try again or wait for the next sync.',
         };
     }
 }

--- a/src/services/ark/movementWatcher.ts
+++ b/src/services/ark/movementWatcher.ts
@@ -6,7 +6,11 @@ import {
 } from '@secondts/bark-react-native';
 
 import useAuthStore from '@Cypher/stores/authStore';
-import { notifyArkReceived, notifyArkRefreshComplete } from './backgroundNotifications';
+import {
+    cancelArkRefreshReminder,
+    notifyArkReceived,
+    notifyArkRefreshComplete,
+} from './backgroundNotifications';
 import { getArkWalletHandle } from './walletHandle';
 
 /**
@@ -217,6 +221,12 @@ function handleNotification(notif: { tag: string; inner?: any }): void {
     // completed round, ever, for this process. Backgrounded only: with
     // the app open the Capsules UI is the completion signal.
     if (subsystem === 'refresh' && status === 'successful') {
+        // Drop the backstop first, and OUTSIDE the dedupe guard. This runs on
+        // every re-emission of the movement, which is what we want: the alarm
+        // must die even if the notification itself was already handled, or
+        // suppressed because the app was in the foreground. Cancelling an id
+        // that is not queued is a no-op.
+        cancelArkRefreshReminder();
         if (!notifiedRefreshMovementIds.has(movement.id)) {
             notifiedRefreshMovementIds.add(movement.id);
             if (AppState.currentState !== 'active') {

--- a/src/services/ark/networkFault.ts
+++ b/src/services/ark/networkFault.ts
@@ -32,23 +32,47 @@ export type ArkNetworkFault =
     | 'ark-server'
     | 'unknown';
 
-/** Flatten a thrown value into searchable text. BarkError hides detail in `inner`. */
+/**
+ * Flatten a thrown value into searchable text. BarkError hides detail in `inner`.
+ *
+ * Follows `cause` as well, because an error wrapped once loses nothing but an
+ * error wrapped twice used to lose the signal entirely before any matcher saw
+ * it. Depth-limited and cycle-guarded: this runs on the error path, where
+ * throwing again would replace a useful message with a useless one.
+ *
+ * Measured on device 2026-09-08 (bark 0.6.1): a dropped ASP connection arrives
+ * as a BarkError whose own properties are exactly ["message","tag","stack"],
+ * with no `inner` and no `cause`, and the whole detail sits in `message`. The
+ * traversal below is therefore defensive rather than load-bearing today.
+ */
 export function arkErrorText(err: unknown): string {
-    if (err == null) return '';
-    if (typeof err === 'string') return err;
-    const e = err as {
-        tag?: unknown;
-        message?: unknown;
-        inner?: { errorMessage?: unknown; message?: unknown };
+    const parts: string[] = [];
+    const seen = new Set<unknown>();
+
+    const walk = (v: unknown, depth: number): void => {
+        if (v == null || depth > 4) return;
+        if (typeof v === 'string') {
+            parts.push(v);
+            return;
+        }
+        if (typeof v !== 'object' || seen.has(v)) return;
+        seen.add(v);
+        const e = v as {
+            tag?: unknown;
+            message?: unknown;
+            errorMessage?: unknown;
+            inner?: unknown;
+            cause?: unknown;
+        };
+        for (const p of [e.tag, e.message, e.errorMessage]) {
+            if (typeof p === 'string') parts.push(p);
+        }
+        walk(e.inner, depth + 1);
+        walk(e.cause, depth + 1);
     };
-    return [
-        e.tag,
-        e.message,
-        e.inner?.errorMessage,
-        e.inner?.message,
-    ]
-        .filter((p) => typeof p === 'string')
-        .join(' ');
+
+    walk(err, 0);
+    return parts.join(' ');
 }
 
 function hostOf(url: string): string | null {
@@ -190,11 +214,39 @@ export function describeArkFailure(
  * Deliberately biased toward returning true. A false "may have gone through"
  * costs a user one balance check. A false "your funds were not moved" costs
  * them their trust that the wallet knows where their money is.
+ *
+ * POLARITY: refusals are enumerated, everything else is unknown.
+ *
+ * This used to match transport failures positively and return false for
+ * anything it did not recognise, which put the unknown case on the dangerous
+ * side: an unmatched error was reported as a definite refusal, and the caller
+ * re-armed its send control on the strength of it. For an ln-address or
+ * ln-offer a retry mints a fresh invoice with a new payment hash, so it settles
+ * alongside the first and the recipient is paid twice.
+ *
+ * Refusals are a closed set we own: not enough funds, below dust, a bad
+ * address, a quota rejection. Transport failures are open ended, and the set
+ * grew every time the SDK reworded something. Enumerating the closed side puts
+ * the unknown case on the safe side, which is the same "fail closed" convention
+ * reset.ts documents.
+ *
+ * Measured on device 2026-09-08, bark 0.6.1, ~3 minutes fully offline: 79
+ * captured ASP failures, two distinct shapes, and BOTH would have matched the
+ * old positive regex (on "dns" and on "transport"). So this is not a live bug
+ * today. It is latent, and the reason is worth stating: they matched on words
+ * from tonic's verbose `source:` chain, not on the gRPC status. The status text
+ * alone, "The service is currently unavailable", matched nothing, because the
+ * old pattern carried `unreachable` and not `unavailable`. Any upstream change
+ * that trims that source chain would have flipped both shapes to "definite
+ * refusal" silently.
  */
+const DEFINITE_REFUSAL =
+    /insufficient|not enough|below dust|dust limit|too small|minimum|invalid address|bad user input|malformed|unparse|could not parse|\b429\b|too many requests|rate limit|exceeds the current limit|already spent|already finished|not found/i;
+
 export function looksLikeConnectionLoss(err: unknown): boolean {
     const tag = (err as { tag?: string })?.tag ?? '';
     const text = `${tag} ${arkErrorText(err)}`;
-    return /ServerConnection|connect|timed? ?out|network|unreachable|dns|socket|transport|aborted|reset by peer|broken pipe/i.test(
-        text,
-    );
+    // Nothing to read is not evidence of a refusal. Treat it as unknown.
+    if (!text.trim()) return true;
+    return !DEFINITE_REFUSAL.test(text);
 }

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -4,6 +4,7 @@ import { assertNoActiveArkExitAsync } from './exit';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
 import { writeArkAutoBackup } from './backup';
+import { scheduleArkRefreshReminder } from './backgroundNotifications';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import useAuthStore from '@Cypher/stores/authStore';
 import type { FeeEstimate, RoundState } from '@secondts/bark-react-native';
@@ -369,6 +370,17 @@ export async function refreshArkVtxosDelegatedAndSync(
 ): Promise<ArkDelegatedRefreshResult> {
     const handle = await requireHandle();
     const result = await refreshArkVtxosDelegated(vtxoIds, totalSats);
+    // Backstop reminder, armed only once the ASP has accepted the round. Handed
+    // to the OS now so it survives the app being suspended or killed, which is
+    // the case movementWatcher's completion notification cannot cover: it only
+    // observes anything while the process is alive. Cancelled the moment a real
+    // completion is seen, so a user whose app stays up never sees it.
+    try {
+        scheduleArkRefreshReminder(vtxoIds.length);
+    } catch (err) {
+        // A reminder must never take down a submission that already succeeded.
+        console.warn('[Ark refresh] reminder schedule failed:', err);
+    }
     await handle.sync();
     await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
     // G2: eager backup so the just-refreshed state is captured now, not on

--- a/src/services/ark/reset.ts
+++ b/src/services/ark/reset.ts
@@ -20,10 +20,16 @@ export interface ResetArkWalletOptions {
      * biometric (Face/Touch ID) fast path so the user doesn't have to
      * re-type 12 words on the same device.
      *
-     * Defaults to false — i.e. the historic "nuke everything" behavior
-     * for reset paths that explicitly want a clean slate (DEV-only reset
-     * in CreateArkScreen, the auto-reset triggered after a successful
-     * unilateral exit in `useArkSync`).
+     * Defaults to false, i.e. the historic "nuke everything" behavior for
+     * reset paths that explicitly want a clean slate.
+     *
+     * This used to name "the auto-reset triggered after a successful unilateral
+     * exit in useArkSync" as a caller. There is no such caller, and grep finds
+     * no reference to one anywhere in the tree. Every caller is user-initiated:
+     * "Reset & wipe" and the orphan auto-clean in CreateArkScreen, the re-key in
+     * ArkSeedPhraseScreen, and "Delete vault" in Ark settings. Worth stating,
+     * because that phantom caller is what made this function look like it sat
+     * under the exit-fix freeze.
      */
     keepSeedInKeychain?: boolean;
 
@@ -81,11 +87,33 @@ export async function resetArkWalletState(
     // Scrub the in-memory PBKDF2 key so it doesn't carry over to a new wallet.
     clearArkKeyCache();
 
+    // DO NOT SWALLOW THIS.
+    //
+    // The old catch here reasoned "a missing datadir is the success state
+    // anyway", which is true for exactly one failure mode. `RNFS.unlink` also
+    // fails on open file descriptors, iOS file protection and partial directory
+    // deletes, and in those cases the datadir is still on disk. Reset then
+    // carried on and deleted the Keychain mnemonic and the background seed copy
+    // below, and `resetArkWalletState` resolved normally as though it had
+    // worked.
+    //
+    // End state: the wallet's data still on disk with the only key to it
+    // destroyed, and nobody told. That is the one outcome this function must
+    // never produce.
+    //
+    // So: bail before anything else is deleted. Nothing after this point runs,
+    // which also leaves the backup files alone, since they are the recovery
+    // path if the datadir really is stuck. The seed survives, so the wallet is
+    // still recoverable, and the caller gets a real error instead of silence.
     try {
         await deleteArkDatadir();
-    } catch (err) {
-        console.warn('[Ark] deleteArkDatadir failed:', err);
-        // Swallow — a missing datadir is the success state anyway.
+    } catch (err: any) {
+        console.warn('[Ark] deleteArkDatadir failed, aborting reset:', err);
+        throw new Error(
+            'Could not delete the Ark wallet data, so the seed was kept to avoid ' +
+            'leaving wallet data on this device with no way to open it. ' +
+            'Nothing was deleted. Close the app and try again.',
+        );
     }
 
     // Wallet-scoped backup deletion. Best-effort, swallow per-channel

--- a/src/services/ark/safFolderBackup.ts
+++ b/src/services/ark/safFolderBackup.ts
@@ -168,10 +168,10 @@ export function messageForSafError(cls: SafErrorClass): string {
         case 'folder-unreachable':
             return "The backup folder is no longer reachable (it may have been deleted, moved, or the storage was removed). Tap 'Pick folder' to choose a new one.";
         case 'create-failed':
-            return "Couldn't create the backup file in the chosen folder. The folder may be read-only — pick a different one.";
+            return "Couldn't create the backup file in the chosen folder. The folder may be read-only, so pick a different one.";
         case 'open-failed':
         case 'write-failed':
-            return "Couldn't write the backup to the chosen folder. The storage may be full or read-only — pick a different folder.";
+            return "Couldn't write the backup to the chosen folder. The storage may be full or read-only, so pick a different folder.";
         case 'native-not-loaded':
             return 'Local-folder backup is not available on this build.';
         case 'unknown':

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -536,52 +536,39 @@ export async function executeArkSend(
 
     console.log('[Ark send]', dest.kind, 'resolved id=', id.slice(0, 16) + '…');
 
-    // Slow-broadcast hint for `onchain` direction. The ASP sets the round's
-    // on-chain fee rate at construction; empirically it picks at-or-below
-    // mempool's economyFee floor to maximise its margin (the user paid Y
-    // sats but only ~45% of that hit miners; rest is server margin). This
-    // routinely lands withdrawals at ~2 sat/vb, meaning hours of mempool
-    // wait. Fire off a non-blocking mempool fee-rate fetch + warn-log if
-    // the resulting tx is well below current `fastestFee`. Pre-broadcast
-    // disclosure already exists on ArkWithdrawReviewScreen; this log is
-    // the breadcrumb a downstream auto-CPFP-prompt feature would key on.
+    // REMOVED 2026-09-08: a fire-and-forget slow-broadcast breadcrumb that
+    // fetched `https://mempool.space/api/tx/<txid>` after every on-chain
+    // withdrawal.
     //
-    // Fire-and-forget so we don't add latency to the send return path.
-    // 2-second budget on the mempool fetch; bail silently on error or
-    // timeout. Only runs for 'onchain' direction since LN sends route off
-    // chain and the rate concept doesn't apply.
-    if (dest.kind === 'onchain') {
-        const onchainTxid = id;
-        void (async () => {
-            try {
-                const controller = new AbortController();
-                const t = setTimeout(() => controller.abort(), 2000);
-                const [txRes, feeRes] = await Promise.all([
-                    fetch(`https://mempool.space/api/tx/${onchainTxid}`, { signal: controller.signal }),
-                    fetch('https://mempool.space/api/v1/fees/recommended', { signal: controller.signal }),
-                ]);
-                clearTimeout(t);
-                if (!txRes.ok || !feeRes.ok) return;
-                const tx = await txRes.json();
-                const feeRecs = await feeRes.json();
-                const vsize = (tx?.weight ?? 0) / 4;
-                const fee = tx?.fee ?? 0;
-                if (!vsize || !fee) return;
-                const broadcastRate = fee / vsize;
-                const fastest = Number(feeRecs?.fastestFee ?? 1);
-                if (broadcastRate < fastest / 2) {
-                    console.warn(
-                        '[Ark send] onchain broadcast at ' + broadcastRate.toFixed(1) +
-                        ' sat/vb (current fastestFee=' + fastest + ' sat/vb). ' +
-                        'Tx ' + onchainTxid.slice(0, 12) + '… may take hours to confirm. ' +
-                        'User can speed up via CPFP on the receiving wallet (see Hot Vault → tap pending → "Accelerate transaction").',
-                    );
-                }
-            } catch {
-                /* swallow — best-effort breadcrumb only */
-            }
-        })();
-    }
+    // It bound this device's IP to a specific withdrawal txid at a host the
+    // wallet otherwise never contacts. On a default install the chain source is
+    // blockstream.info, and esploraProviders states the invariant it broke: "A
+    // healthy wallet talks to exactly one provider." It was ungated: no setting,
+    // no consent, not even __DEV__.
+    //
+    // What it bought was a console.warn, and often not even that. There is no
+    // retry and no delay, so the lookup regularly ran before the tx had
+    // propagated, 404'd, and returned early. The disclosure was paid on every
+    // withdrawal; the breadcrumb was not always produced.
+    //
+    // NOT REPLACED, and the reason is worth recording. The plan was to keep the
+    // warning and derive it from the fee endpoint plus a local transaction size.
+    // There is no local transaction size. In a cooperative offboard the ASP
+    // builds and broadcasts the round transaction; this device never broadcasts
+    // anything, and that transaction's weight and fee are shared across everyone
+    // in the round, so `fee / vsize` was never a measure of this user's payment
+    // to begin with. `ArkSendFeeView` carries feeSats but no weight, and the SDK
+    // hands back only a txid.
+    //
+    // Nothing user-facing is lost. Pre-broadcast fee disclosure already exists
+    // on ArkWithdrawReviewScreen, and the remedy the warning pointed at (CPFP
+    // via Hot Vault, tap the pending row, Accelerate transaction) is a shipped
+    // flow the user reaches without it. The only consumer was a downstream
+    // auto-CPFP prompt that was never built.
+    //
+    // The fee-rate endpoint itself is fine and stays in use elsewhere
+    // (exitFunding.ts): it carries no user data. Only the per-txid lookup was
+    // the problem.
 
     // Re-read local state so the UI reflects the send before the 30s poll.
     //

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -451,7 +451,27 @@ export async function executeArkSend(
         // throws so the user checks Activity instead of being silently re-sent.
         let settled = false;
         for (let attempt = 1; attempt <= MAX_LN_SEND_ATTEMPTS; attempt++) {
-            const status = await dispatchLnSend(handle, dest, amount, comment);
+            // Wrapped, so a connection that dies mid-dispatch is reported as
+            // UNKNOWN rather than as a failure. This is the one send path that
+            // was not: runBroadcastCall guards sendArkoorPayment and sendOnchain
+            // below, and the four other ASP-facing calls across exit.ts,
+            // offboard.ts, exitFunding.ts and recoverOnchainBoard.ts, but the
+            // Lightning branch went straight to the SDK.
+            //
+            // It is also the path where being wrong costs the most. On a
+            // transport failure the ASP may already have begun the HTLC. If the
+            // caller is told "failed" it re-arms the send control, and for an
+            // ln-address or ln-offer a retry mints a FRESH invoice with a new
+            // payment hash, so it settles alongside the first one. The recipient
+            // is paid twice and the retry loop below cannot see it, because it
+            // only ever retries on a movement confirmed refunded.
+            //
+            // Throwing here leaves the loop entirely, which is correct: an
+            // indeterminate outcome must never be retried.
+            const status = await runBroadcastCall(
+                () => dispatchLnSend(handle, dest, amount, comment),
+                'payment',
+            );
 
             // Fast path: bark settled at dispatch and handed us the preimage.
             if (status.tag === LightningSendStatus_Tags.Paid) {

--- a/src/services/lightningSwap/providers/strike.ts
+++ b/src/services/lightningSwap/providers/strike.ts
@@ -194,7 +194,7 @@ const strikeProvider: LightningSwapProvider = {
                 throw new PaymentPendingError(
                     'strike',
                     `Strike payment ${pidShort} is still settling on Lightning. ` +
-                    `Do NOT retry — open the Strike app to check. It will complete or refund automatically within a few hours.`,
+                    `Do NOT retry. Open the Strike app to check. It will complete or refund automatically within a few hours.`,
                     String(paymentId ?? ''),
                 );
             }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -410,6 +410,21 @@ export type AuthStateType = {
      */
     arkRefreshFailStreak: number;
     /**
+     * Consecutive failed sync ticks, reset to 0 by any success.
+     *
+     * Exists because every other connectivity signal is written only on
+     * SUCCESS, so a vault that is failing every tick looks identical to one
+     * that is simply idle, and the UI could only infer trouble from staleness.
+     * That took 20 minutes (TIP_DEGRADED_MS) to reach "offline" while the app
+     * already knew on the first failed tick. A failure is direct evidence;
+     * age is a proxy for it.
+     *
+     * Deliberately NOT persisted: it describes right now, and a streak
+     * restored from a previous run would claim knowledge of a network the app
+     * has not touched since launching.
+     */
+    arkSyncFailStreak: number;
+    /**
      * Epoch ms when the refresh-failing-near-expiry Alert was last shown.
      * Gates re-showing so the escalation fires once per re-show window
      * instead of on every sync tick while the streak persists.
@@ -525,6 +540,7 @@ export type AuthStateType = {
     ) => void;
     setArkBgRefreshConsecutiveFailures: (state: number) => void;
     setArkRefreshFailStreak: (state: number) => void;
+    setArkSyncFailStreak: (state: number) => void;
     setArkRefreshFailAlertAt: (state: number | null) => void;
     setArkBgRefreshDeferredBackup: (state: boolean) => void;
     setArkBgRefreshLastWarn24hAt: (state: number | null) => void;
@@ -621,6 +637,7 @@ const createAuthStore = (
     arkBgRefreshLastAttempt: null,
     arkBgRefreshConsecutiveFailures: 0,
     arkRefreshFailStreak: 0,
+    arkSyncFailStreak: 0,
     arkRefreshFailAlertAt: null,
     arkBgRefreshDeferredBackup: false,
     arkBgRefreshLastWarn24hAt: null,
@@ -710,6 +727,7 @@ const createAuthStore = (
     setArkBgRefreshLastAttempt: (state) => set({ arkBgRefreshLastAttempt: state }),
     setArkBgRefreshConsecutiveFailures: (state: number) => set({ arkBgRefreshConsecutiveFailures: state }),
     setArkRefreshFailStreak: (state: number) => set({ arkRefreshFailStreak: state }),
+    setArkSyncFailStreak: (state: number) => set({ arkSyncFailStreak: state }),
     setArkRefreshFailAlertAt: (state: number | null) => set({ arkRefreshFailAlertAt: state }),
     setArkBgRefreshDeferredBackup: (state: boolean) => set({ arkBgRefreshDeferredBackup: state }),
     setArkBgRefreshLastWarn24hAt: (state: number | null) => set({ arkBgRefreshLastWarn24hAt: state }),
@@ -792,6 +810,7 @@ const createAuthStore = (
             arkBgRefreshLastAttempt: null,
             arkBgRefreshConsecutiveFailures: 0,
             arkRefreshFailStreak: 0,
+            arkSyncFailStreak: 0,
             arkRefreshFailAlertAt: null,
             arkBgRefreshDeferredBackup: false,
             arkBgRefreshLastWarn24hAt: null,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -435,6 +435,18 @@ export type AuthStateType = {
      * next mount, which is the safer failure mode.
      */
     arkPendingTapRefresh: boolean;
+    /**
+     * One-shot: sweep the dust as soon as the Capsules tab is next mounted.
+     *
+     * Set when the user takes the "top up from CoinOS" way out of a dust set
+     * too small to sweep. The swap runs on another screen, so the intent has to
+     * outlive this one, and the sweep can only run once the topped-up sats have
+     * actually landed as a capsule.
+     *
+     * Not persisted. It describes an intent inside one session; restoring it
+     * from a previous run would fire a round the user never asked for.
+     */
+    arkPendingDustSweep: boolean;
 
     /**
      * One-shot flag: set when the homepage "stuck on-chain funds" banner is
@@ -532,6 +544,7 @@ export type AuthStateType = {
     setArkBgRefreshLastStuckWarnAt: (state: number | null) => void;
     setArkBgRefreshMaxFeeSats: (state: number) => void;
     setArkPendingTapRefresh: (state: boolean) => void;
+    setArkPendingDustSweep: (state: boolean) => void;
     setArkPendingOnchainRecoverOpen: (state: boolean) => void;
     setArkIosBackupReminderActive: (state: boolean) => void;
     setArkArkoorPromptState: (
@@ -628,6 +641,7 @@ const createAuthStore = (
     arkBgRefreshLastStuckWarnAt: null,
     arkBgRefreshMaxFeeSats: 5000,
     arkPendingTapRefresh: false,
+    arkPendingDustSweep: false,
     arkPendingOnchainRecoverOpen: false,
     arkIosBackupReminderActive: false,
     arkArkoorPromptState: {},
@@ -717,6 +731,7 @@ const createAuthStore = (
     setArkBgRefreshLastStuckWarnAt: (state: number | null) => set({ arkBgRefreshLastStuckWarnAt: state }),
     setArkBgRefreshMaxFeeSats: (state: number) => set({ arkBgRefreshMaxFeeSats: state }),
     setArkPendingTapRefresh: (state: boolean) => set({ arkPendingTapRefresh: state }),
+    setArkPendingDustSweep: (state: boolean) => set({ arkPendingDustSweep: state }),
     setArkPendingOnchainRecoverOpen: (state: boolean) => set({ arkPendingOnchainRecoverOpen: state }),
     setArkIosBackupReminderActive: (state: boolean) => set({ arkIosBackupReminderActive: state }),
     setArkArkoorPromptState: (state) => set({ arkArkoorPromptState: state }),

--- a/tests/unit/arkNetworkFault.test.ts
+++ b/tests/unit/arkNetworkFault.test.ts
@@ -313,7 +313,47 @@ describe('telling a refusal apart from a dropped connection', () => {
         expect(loss(new Error('insufficient funds'))).toBe(false);
         expect(loss(new Error('bad user input: invalid address'))).toBe(false);
         expect(loss(new Error('amount below dust limit'))).toBe(false);
-        expect(loss({ tag: 'Internal', message: 'BarkError.Internal' })).toBe(false);
+        expect(loss(new Error('amount is below the minimum'))).toBe(false);
+    });
+
+    it('treats an unrecognised error as ambiguous, not as a refusal', () => {
+        // CHANGED DELIBERATELY. This case previously asserted `false`, back when
+        // the rule matched transport failures positively and returned false for
+        // everything it did not recognise.
+        //
+        // A bare "internal error" carries no evidence either way: the ASP may
+        // have signed and broadcast before whatever went wrong. Reporting it as
+        // a definite refusal re-arms the send control, and for an ln-address or
+        // ln-offer a retry mints a fresh invoice with a new payment hash, so it
+        // settles alongside the first and the recipient is paid twice.
+        //
+        // The unknown case now sits on the safe side. The cost is a balance
+        // check the user did not need; the cost of the old default was a
+        // double payment.
+        expect(loss({ tag: 'Internal', message: 'BarkError.Internal' })).toBe(true);
+        expect(loss(new Error('something nobody has seen before'))).toBe(true);
+    });
+
+    it('is not fooled by a gRPC status with the source chain trimmed', () => {
+        // Observed on device 2026-09-08 (bark 0.6.1): a dropped ASP connection
+        // arrives as tonic's verbose Display output, which happens to contain
+        // "dns" and "transport". The old positive regex matched on those, not on
+        // the gRPC status, and the status text on its own carries neither. It
+        // says "unavailable"; the old pattern knew "unreachable".
+        //
+        // So the old rule was correct only for as long as bark kept printing the
+        // source chain. These are the shapes that would have broken it.
+        expect(loss({ tag: 'Inner', message: "code: 'The service is currently unavailable'" })).toBe(true);
+        expect(loss({ tag: 'Inner', message: "code: 'DEADLINE_EXCEEDED'" })).toBe(true);
+        expect(loss({ tag: 'Inner', message: 'h2 protocol error' })).toBe(true);
+    });
+
+    it('reads a doubly wrapped error through its cause chain', () => {
+        // arkErrorText used to read tag/message/inner only, so a refusal wrapped
+        // twice lost its signal before any matcher saw it and fell to the
+        // default. Cheap to support and it fails in the right direction.
+        expect(loss({ message: 'send failed', cause: { message: 'insufficient funds' } })).toBe(false);
+        expect(loss({ message: 'outer', cause: { cause: { message: 'below dust limit' } } })).toBe(false);
     });
 
     it('does not throw on null, undefined or a non-error', () => {

--- a/tests/unit/chainTipFreshness.test.ts
+++ b/tests/unit/chainTipFreshness.test.ts
@@ -1,0 +1,242 @@
+import {
+    deriveTipFreshness,
+    deriveVaultConnectivity,
+    effectiveChainTip,
+    EXPIRY_ALARM_MAX_DRIFT_MS,
+    NOMINAL_BLOCK_MINUTES,
+    shouldRescheduleExpiryWarning,
+    TIP_DEGRADED_MS,
+    TIP_FRESH_MS,
+} from '../../src/services/ark/chainTipFreshness';
+
+const MIN = 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+describe('NOMINAL_BLOCK_MINUTES', () => {
+    // Pinned because the constant is re-declared rather than imported from
+    // chainTip.ts (which pulls config.ts and the bark SDK, unloadable under
+    // jest). If AVG_BLOCK_MINUTES moves, this fails and points at the drift.
+    it('mirrors AVG_BLOCK_MINUTES', () => {
+        expect(NOMINAL_BLOCK_MINUTES).toBe(10);
+    });
+});
+
+describe('deriveTipFreshness', () => {
+    it('reports unknown when the tip has never been fetched', () => {
+        const r = deriveTipFreshness({ fetchedAtMs: null, nowMs: NOW });
+        expect(r.level).toBe('unknown');
+        expect(r.ageMs).toBeNull();
+        expect(r.trusted).toBe(false);
+    });
+
+    it('reports fresh inside the fresh window', () => {
+        expect(deriveTipFreshness({ fetchedAtMs: NOW, nowMs: NOW }).level).toBe('fresh');
+        expect(
+            deriveTipFreshness({ fetchedAtMs: NOW - TIP_FRESH_MS, nowMs: NOW }).level,
+        ).toBe('fresh');
+    });
+
+    it('reports degraded past the fresh window but inside the degraded one', () => {
+        const r = deriveTipFreshness({ fetchedAtMs: NOW - TIP_FRESH_MS - 1, nowMs: NOW });
+        expect(r.level).toBe('degraded');
+        // Still trusted: the numbers are usable, just no longer pristine.
+        expect(r.trusted).toBe(true);
+        expect(
+            deriveTipFreshness({ fetchedAtMs: NOW - TIP_DEGRADED_MS, nowMs: NOW }).level,
+        ).toBe('degraded');
+    });
+
+    it('reports stale and untrusted past the degraded window', () => {
+        const r = deriveTipFreshness({ fetchedAtMs: NOW - TIP_DEGRADED_MS - 1, nowMs: NOW });
+        expect(r.level).toBe('stale');
+        expect(r.trusted).toBe(false);
+    });
+
+    it('never claims freshness from a backwards clock', () => {
+        // Clock jumped forward then corrected back, so fetchedAt is "future".
+        const r = deriveTipFreshness({ fetchedAtMs: NOW + 60 * MIN, nowMs: NOW });
+        expect(r.ageMs).toBe(0);
+        expect(r.level).toBe('fresh');
+    });
+
+    it('surfaces the age so callers can render it', () => {
+        expect(deriveTipFreshness({ fetchedAtMs: NOW - 7 * MIN, nowMs: NOW }).ageMs).toBe(
+            7 * MIN,
+        );
+    });
+});
+
+describe('effectiveChainTip', () => {
+    it('returns null when there is no tip at all', () => {
+        expect(effectiveChainTip({ tip: null, fetchedAtMs: NOW, nowMs: NOW })).toBeNull();
+    });
+
+    it('returns the raw tip when it has no fetch stamp', () => {
+        // Pre-upgrade persisted state: a tip exists but was written before the
+        // timestamp field was added. Do not invent an age for it.
+        expect(effectiveChainTip({ tip: 900_000, fetchedAtMs: null, nowMs: NOW })).toBe(900_000);
+    });
+
+    it('does not advance the tip within one block interval', () => {
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - 9 * MIN, nowMs: NOW }),
+        ).toBe(900_000);
+    });
+
+    it('advances one block per nominal block interval', () => {
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - 10 * MIN, nowMs: NOW }),
+        ).toBe(900_001);
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - 60 * MIN, nowMs: NOW }),
+        ).toBe(900_006);
+    });
+
+    it('is uncapped, so a long offline gap expires what should be expired', () => {
+        // The regression this exists for: app closed 21 days, reopened offline.
+        // Freezing would render a VTXO with 25 days of nominal life as still
+        // having 25 days left. Extrapolating burns the 3024 blocks that
+        // actually elapsed.
+        const threeWeeksMs = 21 * 24 * 60 * MIN;
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW - threeWeeksMs, nowMs: NOW }),
+        ).toBe(900_000 + 3024);
+    });
+
+    it('never runs the tip backwards on a backwards clock', () => {
+        expect(
+            effectiveChainTip({ tip: 900_000, fetchedAtMs: NOW + 60 * MIN, nowMs: NOW }),
+        ).toBe(900_000);
+    });
+});
+
+describe('deriveVaultConnectivity', () => {
+    it('is green when both the tip and the sync loop are current', () => {
+        const r = deriveVaultConnectivity({
+            tipFetchedAtMs: NOW,
+            lastSyncedAtMs: NOW,
+            nowMs: NOW,
+        });
+        expect(r.level).toBe('green');
+        expect(r.syncAgeMs).toBe(0);
+    });
+
+    it('is yellow when the tip is merely degraded', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 10 * MIN,
+                lastSyncedAtMs: NOW,
+                nowMs: NOW,
+            }).level,
+        ).toBe('yellow');
+    });
+
+    it('is red once the tip is stale', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 45 * MIN,
+                lastSyncedAtMs: NOW,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('takes the worse of the two signals, sync side', () => {
+        // esplora answering fine, but the wallet handle is wedged so no cycle
+        // has completed. Not a healthy vault.
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW,
+                lastSyncedAtMs: NOW - 45 * MIN,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('takes the worse of the two signals, tip side', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 45 * MIN,
+                lastSyncedAtMs: NOW - 10 * MIN,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('is red when no sync has ever completed', () => {
+        expect(
+            deriveVaultConnectivity({
+                tipFetchedAtMs: NOW,
+                lastSyncedAtMs: null,
+                nowMs: NOW,
+            }).level,
+        ).toBe('red');
+    });
+
+    it('carries the tip detail through for rendering', () => {
+        const r = deriveVaultConnectivity({
+            tipFetchedAtMs: NOW - 45 * MIN,
+            lastSyncedAtMs: NOW,
+            nowMs: NOW,
+        });
+        expect(r.tip.level).toBe('stale');
+        expect(r.tip.trusted).toBe(false);
+    });
+});
+
+describe('shouldRescheduleExpiryWarning', () => {
+    it('schedules a VTXO that has never been scheduled', () => {
+        expect(
+            shouldRescheduleExpiryWarning({ previousAtMs: null, currentAtMs: NOW }),
+        ).toBe(true);
+    });
+
+    it('leaves an alarm alone while the estimate has barely moved', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + 30 * MIN,
+            }),
+        ).toBe(false);
+    });
+
+    it('does not re-queue exactly at the threshold', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + EXPIRY_ALARM_MAX_DRIFT_MS,
+            }),
+        ).toBe(false);
+    });
+
+    it('re-queues once the estimate has drifted past the threshold', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + EXPIRY_ALARM_MAX_DRIFT_MS + 1,
+            }),
+        ).toBe(true);
+    });
+
+    it('re-queues when expiry turns out to be EARLIER than projected', () => {
+        // The direction that actually bites: nominal 10-minute blocks
+        // overestimate remaining life, so the corrected deadline moves
+        // backwards and the queued warnings would otherwise fire late.
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW - (EXPIRY_ALARM_MAX_DRIFT_MS + 1),
+            }),
+        ).toBe(true);
+    });
+
+    it('honours a caller-supplied threshold', () => {
+        expect(
+            shouldRescheduleExpiryWarning({
+                previousAtMs: NOW,
+                currentAtMs: NOW + 5 * MIN,
+                maxDriftMs: 1 * MIN,
+            }),
+        ).toBe(true);
+    });
+});

--- a/tests/unit/chainTipFreshness.test.ts
+++ b/tests/unit/chainTipFreshness.test.ts
@@ -1,6 +1,7 @@
 import {
     deriveTipFreshness,
     deriveVaultConnectivity,
+    SYNC_FAIL_STREAK_FOR_RED,
     effectiveChainTip,
     EXPIRY_ALARM_MAX_DRIFT_MS,
     NOMINAL_BLOCK_MINUTES,
@@ -9,6 +10,7 @@ import {
     TIP_FRESH_MS,
 } from '../../src/services/ark/chainTipFreshness';
 
+const SEC = 1000;
 const MIN = 60 * 1000;
 const NOW = 1_800_000_000_000;
 
@@ -119,6 +121,84 @@ describe('deriveVaultConnectivity', () => {
         });
         expect(r.level).toBe('green');
         expect(r.syncAgeMs).toBe(0);
+    });
+
+    describe('failed sync ticks, not just staleness', () => {
+        // Observed on device 2026-09-08: a phone with airplane mode on AND
+        // Wi-Fi off reported "connection slow" while completely unreachable,
+        // and would have kept saying so for 20 minutes. Both timestamps this
+        // derivation reads are written only on SUCCESS, so a vault failing
+        // every tick looked exactly like an idle one and the only route to red
+        // was TIP_DEGRADED_MS ageing out. The app knew on the first failed
+        // tick; nothing recorded it.
+
+        it('does not stay green once a tick has actually failed', () => {
+            // Everything still fresh by age. Age alone would say green.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW,
+                    lastSyncedAtMs: NOW,
+                    nowMs: NOW,
+                    syncFailStreak: 1,
+                }).level,
+            ).toBe('yellow');
+        });
+
+        it('is red on a sustained streak, without waiting out the 20 minute staleness', () => {
+            const r = deriveVaultConnectivity({
+                tipFetchedAtMs: NOW - 30 * SEC,
+                lastSyncedAtMs: NOW - 30 * SEC,
+                nowMs: NOW,
+                syncFailStreak: SYNC_FAIL_STREAK_FOR_RED,
+            });
+            expect(r.level).toBe('red');
+            // The point of the fix: by age this is unambiguously green.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW - 30 * SEC,
+                    lastSyncedAtMs: NOW - 30 * SEC,
+                    nowMs: NOW,
+                }).level,
+            ).toBe('green');
+        });
+
+        it('recovers to green as soon as a tick succeeds', () => {
+            // The streak is cleared by success, so the dot must not need the
+            // staleness window to age out before it can say healthy again.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW,
+                    lastSyncedAtMs: NOW,
+                    nowMs: NOW,
+                    syncFailStreak: 0,
+                }).level,
+            ).toBe('green');
+        });
+
+        it('never improves on what age already says', () => {
+            // A zero streak must not argue a stale vault is healthy.
+            expect(
+                deriveVaultConnectivity({
+                    tipFetchedAtMs: NOW - 60 * MIN,
+                    lastSyncedAtMs: NOW - 60 * MIN,
+                    nowMs: NOW,
+                    syncFailStreak: 0,
+                }).level,
+            ).toBe('red');
+        });
+
+        it('treats a missing or nonsense streak as no evidence', () => {
+            for (const bad of [undefined, -1, 0.4, NaN]) {
+                expect(
+                    deriveVaultConnectivity({
+                        tipFetchedAtMs: NOW,
+                        lastSyncedAtMs: NOW,
+                        nowMs: NOW,
+                        syncFailStreak: bad as number,
+                    }).level,
+                ).toBe('green');
+            }
+        });
     });
 
     it('is yellow when the tip is merely degraded', () => {

--- a/tests/unit/dustSweep.test.ts
+++ b/tests/unit/dustSweep.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Folding dust capsules into one, without being asked.
+ *
+ * The case that drove this: a 700 sat Lightning receive landed as a 300 and a
+ * 400 (the ASP pays out of a pool of VTXOs and bundles them, confirmed by
+ * Second.tech 2026-09). Both pieces are below the per input refresh floor, so
+ * every automatic path refused them and only the manual Capsules button could
+ * rescue them.
+ *
+ * The shape the ASP accepts is a dust ONLY batch clearing the dust limit,
+ * confirmed live on mainnet 2026-08-20 (two 400s swept into one, bark 0.6.1).
+ * These tests pin that shape: never a lone capsule, never mixed with healthy
+ * ones, never an input that could expire mid round.
+ */
+
+import {
+    ARK_DUST_SWEEP_MIN_BLOCKS_LEFT,
+    ARK_DUST_SWEEP_MIN_TOTAL_SATS,
+    buildDustSweepPlan,
+    type BuildDustSweepInputs,
+    type DustSweepVtxoInput,
+} from '../../src/services/ark/dustSweep';
+
+const MIN_SATS = 500; // ARK_REFRESH_MIN_SATS
+
+const dust = (over: Partial<DustSweepVtxoInput> = {}): DustSweepVtxoInput => ({
+    id: `v${Math.random().toString(36).slice(2, 8)}`,
+    sats: 400,
+    blocksUntilExpiry: null, // arkoor, the Lightning receive case
+    stateTag: 'Spendable',
+    alreadyRefreshing: false,
+    ...over,
+});
+
+const plan = (vtxos: DustSweepVtxoInput[], over: Partial<BuildDustSweepInputs> = {}) =>
+    buildDustSweepPlan({
+        vtxos,
+        exitInProgress: false,
+        minRefreshSats: MIN_SATS,
+        ...over,
+    });
+
+describe('the reported case', () => {
+    it('sweeps a 700 sat receive that landed as a 300 and a 400', () => {
+        const a = dust({ id: 'a', sats: 300 });
+        const b = dust({ id: 'b', sats: 400 });
+        expect(plan([a, b])).toEqual({
+            sweep: true,
+            ids: ['a', 'b'],
+            totalSats: 700,
+            candidateCount: 2,
+            candidateSats: 700,
+            reason: 'sweep',
+            excludedCount: 0,
+            excludedSats: 0,
+        });
+    });
+
+    it('leaves the healthy capsules in the wallet out of the batch', () => {
+        // A mixed batch has made the ASP reject the whole round, taking the
+        // healthy inputs down with the dust. Dust only, always.
+        const result = plan([
+            dust({ id: 'dust1', sats: 300 }),
+            dust({ id: 'dust2', sats: 400 }),
+            dust({ id: 'healthy', sats: 5_000 }),
+            dust({ id: 'at-the-floor', sats: MIN_SATS }),
+        ]);
+        expect(result.ids).toEqual(['dust1', 'dust2']);
+        expect(result.totalSats).toBe(700);
+    });
+});
+
+describe('the total gate', () => {
+    it('does not sweep below the total, the output would be dust again', () => {
+        const result = plan([dust({ sats: 200 }), dust({ sats: 150 })]);
+        expect(result).toMatchObject({ sweep: false, reason: 'below-min-total', ids: [] });
+        // The refusal still reports what it looked at, so the caller can say
+        // how far short the wallet is instead of going quiet.
+        expect(result).toMatchObject({ candidateCount: 2, candidateSats: 350 });
+    });
+
+    it('sweeps at the total, not only above it', () => {
+        const half = ARK_DUST_SWEEP_MIN_TOTAL_SATS / 2;
+        expect(plan([dust({ sats: half }), dust({ sats: half })]).sweep).toBe(true);
+    });
+
+    it('clears the refresh floor after the round fee, which is the point of the gate', () => {
+        const result = plan([dust({ sats: 300 }), dust({ sats: 300 })]);
+        expect(result.sweep).toBe(true);
+        // Fee measured at ~1 sat on device; even the 20 sat allowance in the
+        // pre-filter leaves the output above the floor, so the swept capsule can
+        // refresh itself from then on. The caller re-checks this against bark's
+        // real estimate before submitting.
+        expect(result.totalSats - 20).toBeGreaterThanOrEqual(MIN_SATS);
+    });
+
+    it('lets through a 550 sat receive that split into two dust pieces', () => {
+        // The concrete case a round 600 gate would have refused: output ~549,
+        // comfortably above the floor, so the rescue is worth making.
+        const result = plan([dust({ id: 'a', sats: 250 }), dust({ id: 'b', sats: 300 })]);
+        expect(result).toMatchObject({ sweep: true, ids: ['a', 'b'], totalSats: 550 });
+    });
+
+    it('honours a caller supplied total', () => {
+        expect(plan([dust({ sats: 200 }), dust({ sats: 200 })], { minTotalSats: 331 }).sweep).toBe(
+            true,
+        );
+    });
+});
+
+describe('what never goes into a sweep', () => {
+    it('refuses a single capsule however large, a lone sub floor input is rejected', () => {
+        expect(plan([dust({ sats: 499 })])).toMatchObject({
+            sweep: false,
+            reason: 'single-capsule',
+        });
+    });
+
+    it('refuses everything while a unilateral exit is in flight', () => {
+        expect(
+            plan([dust({ sats: 400 }), dust({ sats: 400 })], { exitInProgress: true }),
+        ).toMatchObject({ sweep: false, reason: 'exit-in-progress' });
+    });
+
+    it('leaves out capsules that are not spendable', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400 }),
+            dust({ id: 'ok2', sats: 400 }),
+            dust({ id: 'locked', sats: 400, stateTag: 'Locked' }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result).toMatchObject({ excludedCount: 1, excludedSats: 400 });
+    });
+
+    it('leaves out capsules another caller already submitted to a round', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400 }),
+            dust({ id: 'ok2', sats: 400 }),
+            dust({ id: 'mid-round', sats: 400, alreadyRefreshing: true }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result.excludedCount).toBe(1);
+    });
+
+    it('leaves out an input that could expire while the round runs', () => {
+        // Rounds fire hourly on mainnet and an expired input poisons the batch.
+        const result = plan([
+            dust({ id: 'ok1', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'ok2', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'expiring', sats: 400, blocksUntilExpiry: ARK_DUST_SWEEP_MIN_BLOCKS_LEFT - 1 }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result).toMatchObject({ sweep: true, excludedCount: 1, excludedSats: 400 });
+    });
+
+    it('leaves out an already expired input', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'ok2', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'expired', sats: 400, blocksUntilExpiry: -10 }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+    });
+
+    it('reports no dust rather than sweeping a healthy wallet', () => {
+        expect(plan([dust({ sats: 5_000 }), dust({ sats: 900 })])).toMatchObject({
+            sweep: false,
+            reason: 'no-dust',
+            ids: [],
+        });
+    });
+});
+
+describe('near expiry dust, where this rule departs from the other refresh paths', () => {
+    it('sweeps dust that is inside the exit runway floor', () => {
+        // Every other automatic path refuses inside 28h of expiry, to protect
+        // the unilateral exit window. Dust cannot be economically exited (a 400
+        // at depth 17 costs 5,645 vB to rescue 400 sats), so refusing here just
+        // loses the funds. 28h is ~168 blocks; these two sit well inside it.
+        const result = plan([
+            dust({ id: 'a', sats: 400, blocksUntilExpiry: 40 }),
+            dust({ id: 'b', sats: 400, blocksUntilExpiry: 40 }),
+        ]);
+        expect(result).toMatchObject({ sweep: true, ids: ['a', 'b'], totalSats: 800 });
+    });
+
+    it('includes arkoor capsules, whose expiry the SDK does not report', () => {
+        // expiryHeight 0 reaches this rule as null. These are exactly the
+        // capsules a Lightning receive produces, so null must not mean skip.
+        const result = plan([
+            dust({ id: 'a', sats: 350, blocksUntilExpiry: null }),
+            dust({ id: 'b', sats: 350, blocksUntilExpiry: null }),
+        ]);
+        expect(result.sweep).toBe(true);
+    });
+
+    it('treats an unreadable expiry as unsafe rather than guessing', () => {
+        const result = plan([
+            dust({ id: 'ok1', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'ok2', sats: 400, blocksUntilExpiry: 4032 }),
+            dust({ id: 'nan', sats: 400, blocksUntilExpiry: Number.NaN }),
+        ]);
+        expect(result.ids).toEqual(['ok1', 'ok2']);
+        expect(result.excludedCount).toBe(1);
+    });
+});

--- a/tests/unit/noEmDashInUserCopy.test.ts
+++ b/tests/unit/noEmDashInUserCopy.test.ts
@@ -1,0 +1,122 @@
+/**
+ * No em-dash in text a user can read.
+ *
+ * A house rule that was audited by hand and kept losing. An audit in September
+ * 2026 found six violations in `src/services` and concluded the directory had
+ * rotted because it was missing from the list of places to grep. A full scan
+ * said otherwise: `src/screens` had been on that list the whole time and held
+ * forty. Being listed is not what keeps a directory clean; something failing is.
+ *
+ * SCOPE. Text a user can read, which is narrower than every em-dash in the
+ * tree:
+ *
+ *   comments        skipped. Not user-facing, and the codebase uses em-dashes
+ *                   in prose comments deliberately.
+ *   console.*       skipped. Developer output, most of it behind __DEV__.
+ *   `return '—'`    skipped. An em-dash standing in for "no value" in a table
+ *                   cell is a typographic convention, not prose, and replacing
+ *                   it with a hyphen would just look wrong.
+ *   loc/*.json      not scanned. Those are inherited BlueWallet translations in
+ *                   other languages; the rule is about English copy.
+ *
+ * The scanner is deliberately line-based and slightly blunt. A false positive
+ * costs someone one punctuation change; a false negative is how forty of these
+ * accumulated in a directory that was already being audited.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ROOTS = ['src'];
+const EM_DASH = '—';
+
+/**
+ * Files whose user-facing em-dashes are fixed on branches that have not merged
+ * yet (the Ark L1 audit copy pass, and the money-safety change that rewrites
+ * the Lightning cancel block).
+ *
+ * DELETE THIS LIST once those land. It exists so this test can start guarding
+ * everything else today instead of waiting, and every entry is a known debt
+ * rather than an accepted one.
+ */
+const PENDING_ON_OTHER_BRANCHES = new Set([
+    'src/services/ark/history.ts',
+    'src/services/ark/backgroundNotifications.ts',
+    'src/services/ark/safFolderBackup.ts',
+    'src/services/ark/lightning.ts',
+    'src/services/lightningSwap/providers/strike.ts',
+]);
+
+function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+            walk(full, out);
+        } else if (/\.tsx?$/.test(entry.name)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+function offendingLines(body: string): { line: number; text: string }[] {
+    const out: { line: number; text: string }[] = [];
+    const lines = body.split('\n');
+    let inBlockComment = false;
+
+    lines.forEach((raw, idx) => {
+        const trimmed = raw.trim();
+        let seg = raw;
+
+        if (inBlockComment) {
+            if (!raw.includes('*/')) return;
+            inBlockComment = false;
+            seg = raw.split('*/', 2)[1] ?? '';
+        }
+        // Remove block comments that open AND close on this line first. Without
+        // this, every single-line `/** ... */` doc comment reads as live code:
+        // that was 22 false positives on the first run, all of them comments.
+        seg = seg.replace(/\/\*[\s\S]*?\*\//g, '');
+
+        const open = seg.indexOf('/*');
+        if (open >= 0) {
+            inBlockComment = true;
+            seg = seg.slice(0, open);
+        }
+        if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+
+        // Trailing line comment. The lookbehind keeps "https://" intact.
+        seg = seg.replace(/(?<![:"'`])\/\/.*$/, '');
+        if (!seg.includes(EM_DASH)) return;
+
+        // "no value" placeholder, see the scope note above.
+        if (/return\s*['"`]—['"`]/.test(seg)) return;
+
+        // Developer output. Checked across a small window because these calls
+        // are routinely wrapped over several lines.
+        const window = lines.slice(Math.max(0, idx - 3), idx + 1).join('\n');
+        if (/console\.(log|warn|error|info|debug)\s*\(/.test(window)) return;
+
+        out.push({ line: idx + 1, text: trimmed.slice(0, 120) });
+    });
+    return out;
+}
+
+describe('no em-dash in user-facing copy', () => {
+    it('finds none, anywhere under src', () => {
+        const offenders: string[] = [];
+        for (const root of ROOTS) {
+            for (const abs of walk(path.join(REPO_ROOT, root))) {
+                const rel = path.relative(REPO_ROOT, abs);
+                if (PENDING_ON_OTHER_BRANCHES.has(rel)) continue;
+                if (rel.endsWith('noEmDashInUserCopy.test.ts')) continue;
+                for (const hit of offendingLines(fs.readFileSync(abs, 'utf8'))) {
+                    offenders.push(`${rel}:${hit.line}  ${hit.text}`);
+                }
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+});


### PR DESCRIPTION
Integration branch for the 0.1.10 archive. Merges #254 through #268 into main and bumps the shipped identifiers.

## Why one PR instead of fifteen

The `main` ruleset sets `dismiss_stale_reviews_on_push`, and three of the fifteen conflict with each other (#257, #263, #268). Merging them one at a time means resolving those three in the GitHub UI and re-approving after each push, for 18+ approval round-trips. This branch resolves them once, locally, against a tree that has already been exercised on device.

Each PR's head commit is contained here, so merging this marks all fifteen as merged.

## The verification that matters

The whole point of this branch is that it is **not new code**. It is the exact tree that was tested on device, re-derived from `main`:

```
integration tree: 660cbd8c209214c7bda30568077c55371f3667dc
tested tree:      660cbd8c209214c7bda30568077c55371f3667dc
```

Byte-for-byte identical before the version bump. After it, the only difference is the four files below.

## Conflicts and how they were resolved

| PR | File | Resolution |
|---|---|---|
| #257 | `HomeScreen/WalletsView/index.tsx` | tested version |
| #263 | `services/ark/foregroundSweep.ts` | tested version (#263's structure supersedes #255's) |
| #268 | `ArkCapsules.tsx`, `SwapAmount/index.tsx` | tested version (keeps #261's strict `<` **and** #268's `!isDustTopup`) |

The #255/#263 pair is the one worth a second look. Both touch `foregroundSweep.ts`, and #255's branch predates the TOCTOU latch fix and the rate-limit backoff. Merged in this order, #263's version wins, which is the one that ran on device. Merged the other way round, the broken latch ordering comes back.

## Version

`v0.1.9-vc37` is already published, so the identifiers cannot be reused.

| | was | now |
|---|---|---|
| marketing | 0.1.9 | **0.1.10** |
| Android versionCode | 37 | **38** |
| iOS build | 20 | **21** |

**No dependency changes.** The lockfile diff is two lines, both the root version field. `node_modules/slip39` is independently at 0.1.9 and untouched.

## What is in it

Ark L1 security audit fixes (#258 money-safety, #259 privacy, #260 copy), vault connectivity and stale-expiry correctness (#254), the sweep rate-limit backoff (#263), dust handling (#255, #268), Lightning send animation (#262), the em-dash CI guard (#265), and UI fixes (#257, #261, #264, #266, #267, #256).

## Not done here

Signing and the archive itself. Those happen in the release user.
